### PR TITLE
New OpenAPI endpoint

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -22,18 +22,19 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"mime"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/NYTimes/gziphandler"
-	"github.com/emicklei/go-restful"
+	restful "github.com/emicklei/go-restful"
 	"github.com/go-openapi/spec"
 	"github.com/golang/protobuf/proto"
-	"github.com/googleapis/gnostic/OpenAPIv2"
+	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
 	"github.com/googleapis/gnostic/compiler"
 
 	"k8s.io/kube-openapi/pkg/builder"
@@ -77,6 +78,10 @@ func computeETag(data []byte) string {
 	return fmt.Sprintf("\"%X\"", sha512.Sum512(data))
 }
 
+// NOTE: [DEPRECATION] We will announce deprecation for format-separated endpoints for OpenAPI spec,
+// and switch to a single /openapi/v2 endpoint in Kubernetes 1.9. The design doc and deprecation process
+// are tracked at: https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU.
+//
 // BuildAndRegisterOpenAPIService builds the spec and registers a handler to provides access to it.
 // Use this method if your OpenAPI spec is static. If you want to update the spec, use BuildOpenAPISpec then RegisterOpenAPIService.
 func BuildAndRegisterOpenAPIService(servePath string, webServices []*restful.WebService, config *common.Config, handler common.PathHandler) (*OpenAPIService, error) {
@@ -87,6 +92,10 @@ func BuildAndRegisterOpenAPIService(servePath string, webServices []*restful.Web
 	return RegisterOpenAPIService(spec, servePath, handler)
 }
 
+// NOTE: [DEPRECATION] We will announce deprecation for format-separated endpoints for OpenAPI spec,
+// and switch to a single /openapi/v2 endpoint in Kubernetes 1.9. The design doc and deprecation process
+// are tracked at: https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU.
+//
 // RegisterOpenAPIService registers a handler to provides access to provided swagger spec.
 // Note: servePath should end with ".json" as the RegisterOpenAPIService assume it is serving a
 // json file and will also serve .pb and .gz files.
@@ -201,4 +210,54 @@ func toGzip(data []byte) []byte {
 	zw.Write(data)
 	zw.Close()
 	return buf.Bytes()
+}
+
+// RegisterOpenAPIVersionedService registers a handler to provides access to provided swagger spec.
+func RegisterOpenAPIVersionedService(openapiSpec *spec.Swagger, servePath string, handler common.PathHandler) (*OpenAPIService, error) {
+	o := OpenAPIService{}
+	if err := o.UpdateSpec(openapiSpec); err != nil {
+		return nil, err
+	}
+
+	files := map[string]func() ([]byte, string, time.Time){
+		"application/json":                                           o.getSwaggerBytes,
+		"application/com.github.proto-openapi.spec.v2@v1.0+protobuf": o.getSwaggerPbBytes,
+	}
+
+	handler.Handle(servePath, gziphandler.GzipHandler(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var getDataAndETag func() ([]byte, string, time.Time)
+			// Get the first value associated with header "Accept"
+			decipherableFormat := r.Header.Get("Accept")
+			if decipherableFormat == "" || decipherableFormat == "*/*" {
+				// If "Accept" header is not set or "*/*", serve json file as default
+				decipherableFormat = "application/json"
+			}
+			w.Header().Add("Vary", "Accept")
+
+			getDataAndETag = files[decipherableFormat]
+			if getDataAndETag == nil {
+				// Return 406 for not acceptable format
+				w.WriteHeader(406)
+				return
+			}
+			data, etag, lastModified := getDataAndETag()
+			w.Header().Set("Etag", etag)
+
+			// ServeContent will take care of caching using eTag.
+			http.ServeContent(w, r, servePath, lastModified, bytes.NewReader(data))
+		}),
+	))
+
+	return &o, nil
+}
+
+// BuildAndRegisterOpenAPIVersionedService builds the spec and registers a handler to provides access to it.
+// Use this method if your OpenAPI spec is static. If you want to update the spec, use BuildOpenAPISpec then RegisterOpenAPIVersionedService.
+func BuildAndRegisterOpenAPIVersionedService(servePath string, webServices []*restful.WebService, config *common.Config, handler common.PathHandler) (*OpenAPIService, error) {
+	spec, err := builder.BuildOpenAPISpec(webServices, config)
+	if err != nil {
+		return nil, err
+	}
+	return RegisterOpenAPIVersionedService(spec, servePath, handler)
 }


### PR DESCRIPTION
OpenAPI endpoint that includes spec version in name, but hides all other details in the header of the request and response. 

The design doc and deprecation process are tracked at: https://docs.google.com/document/d/19lEqE9lc4yHJ3WJAJxS_G7TcORIJXGHyq3wpwcH28nU. 

The endpoints in [generic apiserver](https://github.com/kubernetes/kubernetes/blob/443908193d564736d02efdca4c9ba25caf1e96fb/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go#L35) and [aggregator](https://github.com/kubernetes/kubernetes/blob/443908193d564736d02efdca4c9ba25caf1e96fb/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator.go#L112-L113) will be deprecated. 