### PR TITLE
Fix generator to work without pre-existing Go files in target package

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -118,35 +118,13 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 `)...)
 
-	outputPath := arguments.OutputPackagePath
-
-	if err := context.AddDir(outputPath); err != nil {
-		glog.Fatalf("Failed to load output package: %v", err)
-	}
-
-	// Compute the canonical output path to allow retrieval of the
-	// package for a vendored output path.
-	const vendorPath = "/vendor/"
-	canonicalOutputPath := outputPath
-	if strings.Contains(outputPath, vendorPath) {
-		canonicalOutputPath = outputPath[strings.Index(outputPath, vendorPath)+len(vendorPath):]
-	}
-
-	// The package for outputPath is mapped to the canonical path
-	pkg := context.Universe[canonicalOutputPath]
-	if pkg == nil {
-		glog.Fatalf("Got nil output package: %v", err)
-	}
 	return generator.Packages{
 		&generator.DefaultPackage{
-			PackageName: strings.Split(filepath.Base(pkg.Path), ".")[0],
-			// Use the supplied output path rather than the canonical
-			// one to allow generation into the path of a
-			// vendored package.
-			PackagePath: outputPath,
+			PackageName: filepath.Base(arguments.OutputPackagePath),
+			PackagePath: arguments.OutputPackagePath,
 			HeaderText:  header,
 			GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
-				return []generator.Generator{NewOpenAPIGen(arguments.OutputFileBaseName, pkg, context)}
+				return []generator.Generator{NewOpenAPIGen(arguments.OutputFileBaseName, arguments.OutputPackagePath, context)}
 			},
 			FilterFunc: func(c *generator.Context, t *types.Type) bool {
 				// There is a conflict between this codegen and codecgen, we should avoid types generated for codecgen
@@ -175,12 +153,12 @@ const (
 type openAPIGen struct {
 	generator.DefaultGen
 	// TargetPackage is the package that will get GetOpenAPIDefinitions function returns all open API definitions.
-	targetPackage *types.Package
+	targetPackage string
 	imports       namer.ImportTracker
 	context       *generator.Context
 }
 
-func NewOpenAPIGen(sanitizedName string, targetPackage *types.Package, context *generator.Context) generator.Generator {
+func NewOpenAPIGen(sanitizedName string, targetPackage string, context *generator.Context) generator.Generator {
 	return &openAPIGen{
 		DefaultGen: generator.DefaultGen{
 			OptionalName: sanitizedName,
@@ -194,7 +172,7 @@ func NewOpenAPIGen(sanitizedName string, targetPackage *types.Package, context *
 func (g *openAPIGen) Namers(c *generator.Context) namer.NameSystems {
 	// Have the raw namer for this file track what it imports.
 	return namer.NameSystems{
-		"raw": namer.NewRawNamer(g.targetPackage.Path, g.imports),
+		"raw": namer.NewRawNamer(g.targetPackage, g.imports),
 	}
 }
 
@@ -207,10 +185,10 @@ func (g *openAPIGen) Filter(c *generator.Context, t *types.Type) bool {
 }
 
 func (g *openAPIGen) isOtherPackage(pkg string) bool {
-	if pkg == g.targetPackage.Path {
+	if pkg == g.targetPackage {
 		return false
 	}
-	if strings.HasSuffix(pkg, "\""+g.targetPackage.Path+"\"") {
+	if strings.HasSuffix(pkg, "\""+g.targetPackage+"\"") {
 		return false
 	}
 	return true


### PR DESCRIPTION
This is needed to create openapi specs in 3rdparty project via k8s.io/code-generator/generate-{,internal}-groups.sh.