### PR TITLE
generators: let types provide defs without importing kube-openapi

### DIFF
--- a/pkg/generators/README
+++ b/pkg/generators/README
@@ -11,5 +11,36 @@ escape or quote the value string. Extensions can be used to pass more informatio
 documentation generators. For example a type might have a friendly name to be displayed in documentation or
 being used in a client's fluent interface.
 
+# Custom OpenAPI type definitions
+
+Custom types which otherwise don't map directly to OpenAPI can override their
+OpenAPI definition by implementing a function named "OpenAPIDefinition" with
+the following signature:
+
+	import openapi "k8s.io/kube-openapi/pkg/common"
+
+	// ...
+
+	type Time struct {
+		time.Time
+	}
+
+	func (_ Time) OpenAPIDefinition() openapi.OpenAPIDefinition {
+		return openapi.OpenAPIDefinition{
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type:   []string{"string"},
+					Format: "date-time",
+				},
+			},
+		}
+	}
+
+Alternatively, the type can avoid the "openapi" import by defining the following
+methods. The following example produces the same OpenAPI definition as the
+example above:
+
+    func (_ Time) OpenAPISchemaType() []string { return []string{"string"} }
+    func (_ Time) OpenAPISchemaFormat() string { return "date-time" }
 
 TODO(mehdy): Make k8s:openapi-gen a parameter to the generator now that OpenAPI has its own repo.

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -300,21 +300,35 @@ func newOpenAPITypeWriter(sw *generator.SnippetWriter) openAPITypeWriter {
 	}
 }
 
+func methodReturnsValue(mt *types.Type, pkg, name string) bool {
+	if len(mt.Signature.Parameters) != 0 || len(mt.Signature.Results) != 1 {
+		return false
+	}
+	r := mt.Signature.Results[0]
+	return r.Name.Name == name && r.Name.Package == pkg
+}
+
 func hasOpenAPIDefinitionMethod(t *types.Type) bool {
 	for mn, mt := range t.Methods {
 		if mn != "OpenAPIDefinition" {
 			continue
 		}
-		if len(mt.Signature.Parameters) != 0 || len(mt.Signature.Results) != 1 {
-			return false
-		}
-		r := mt.Signature.Results[0]
-		if r.Name.Name != "OpenAPIDefinition" || r.Name.Package != openAPICommonPackagePath {
-			return false
-		}
-		return true
+		return methodReturnsValue(mt, openAPICommonPackagePath, "OpenAPIDefinition")
 	}
 	return false
+}
+
+func hasOpenAPIDefinitionMethods(t *types.Type) bool {
+	var hasSchemaTypeMethod, hasOpenAPISchemaFormat bool
+	for mn, mt := range t.Methods {
+		switch mn {
+		case "OpenAPISchemaType":
+			hasSchemaTypeMethod = methodReturnsValue(mt, "", "[]string")
+		case "OpenAPISchemaFormat":
+			hasOpenAPISchemaFormat = methodReturnsValue(mt, "", "string")
+		}
+	}
+	return hasSchemaTypeMethod && hasOpenAPISchemaFormat
 }
 
 // typeShortName returns short package name (e.g. the name x appears in package x definition) dot type name.
@@ -358,6 +372,17 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		g.Do("\"$.$\": ", t.Name)
 		if hasOpenAPIDefinitionMethod(t) {
 			g.Do("$.type|raw${}.OpenAPIDefinition(),\n", args)
+			return nil
+		}
+		if hasOpenAPIDefinitionMethods(t) {
+			g.Do("common.OpenAPIDefinition{\n"+
+				"Schema: spec.Schema{\n"+
+				"SchemaProps: spec.SchemaProps{\n"+
+				"Type:$.type|raw${}.OpenAPISchemaType(),\n"+
+				"Format:$.type|raw${}.OpenAPISchemaFormat(),\n"+
+				"},\n"+
+				"},\n"+
+				"},\n", args)
 			return nil
 		}
 		g.Do("{\nSchema: spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)


### PR DESCRIPTION
This change lets types override their generated spec definition
with methods that don't import kube-openapi. Doing this will let
client-go remove its openapi imports, eliminating ~10 transitive
dependencies for Kubernetes clients.

To override the generated spec definition, a type can now implement
the following two methods:

	func (_ MicroTime) OpenAPISchemaType() []string {
		return []string{"string"}
	}

	func (_ MicroTime) OpenAPISchemaFormat() string {
		return "date-time"
	}

POC can be found here: https://github.com/ericchiang/kubernetes/commit/b0282c59f05df721e769fb9d34ab52fe9a8db4a5

cc @sttts @mbohlool 