### PR TITLE
Aggregator now re-uses the model definition that it had renamed previously

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -308,7 +308,7 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 					i++
 					newName = fmt.Sprintf("%s_v%d", k, i)
 					v2, found = dest.Definitions[newName]
-					if reflect.DeepEqual(v, v2) {
+					if found && reflect.DeepEqual(v, v2) {
 						renames = append(renames, Rename{from: k, to: newName})
 						continue OUTERLOOP
 					}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -97,6 +97,7 @@ definitions:
   Other:
     type: "string"
 `), &spec1)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -131,6 +132,7 @@ definitions:
     type: "string"
     format: "string"
 `), &spec1_filtered)
+
 	assert := assert.New(t)
 	FilterSpecByPaths(spec1, []string{"/test"})
 	assert.Equal(DebugSpec{spec1_filtered}, DebugSpec{spec1})
@@ -198,6 +200,7 @@ definitions:
   Unused:
     type: "object"
 `), &spec1)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -234,6 +237,7 @@ definitions:
   Unused:
     type: "object"
 `), &spec1Filtered)
+
 	assert := assert.New(t)
 	FilterSpecByPaths(spec1, []string{"/test"})
 	assert.Equal(DebugSpec{spec1Filtered}, DebugSpec{spec1})
@@ -275,6 +279,7 @@ definitions:
     type: "string"
     format: "string"
 `), &spec1)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -304,6 +309,7 @@ definitions:
   Other:
     type: "string"
 `), &spec2)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -362,6 +368,7 @@ definitions:
   Other:
     type: "string"
 `), &expected)
+
 	assert := assert.New(t)
 	if !assert.NoError(MergeSpecs(spec1, spec2)) {
 		return
@@ -405,6 +412,7 @@ definitions:
     type: "string"
     format: "string"
 `), &spec1)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -439,6 +447,7 @@ definitions:
     type: "string"
     format: "string"
 `), &spec2)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -490,6 +499,7 @@ definitions:
     type: "string"
     format: "string"
 `), &expected)
+
 	assert := assert.New(t)
 	if !assert.NoError(MergeSpecs(spec1, spec2)) {
 		return
@@ -533,6 +543,7 @@ definitions:
     type: "string"
     format: "string"
 `), &spec1)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -565,6 +576,7 @@ definitions:
     type: "string"
     format: "string"
 `), &spec2)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -623,8 +635,345 @@ definitions:
     type: "string"
     format: "string"
 `), &expected)
+
 	assert := assert.New(t)
 	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
+}
+
+func TestMergeSpecsRenameModelWithExistingV2InDestination(t *testing.T) {
+	var spec1, spec2, expected *spec.Swagger
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /testv2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+definitions:
+  Test:
+    type: "object"
+  Test_v2:
+    description: "This is an existing Test_v2 in destination schema"
+    type: "object"
+`), &spec1)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    description: "This Test has a description"
+    type: "object"
+`), &spec2)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /testv2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+  /othertest:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v3"
+definitions:
+  Test:
+    type: "object"
+  Test_v2:
+    description: "This is an existing Test_v2 in destination schema"
+    type: "object"
+  Test_v3:
+    description: "This Test has a description"
+    type: "object"
+`), &expected)
+
+	assert := assert.New(t)
+	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
+}
+
+func TestMergeSpecsRenameModelWithExistingV2InSource(t *testing.T) {
+	var spec1, spec2, expected *spec.Swagger
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    type: "object"
+`), &spec1)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /testv2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+definitions:
+  Test:
+    description: "This Test has a description"
+    type: "object"
+  Test_v2:
+    description: "This is an existing Test_v2 in source schema"
+    type: "object"
+`), &spec2)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /testv2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+  /othertest:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v3"
+definitions:
+  Test:
+    type: "object"
+  Test_v2:
+    description: "This is an existing Test_v2 in source schema"
+    type: "object"
+  Test_v3:
+    description: "This Test has a description"
+    type: "object"
+`), &expected)
+
+	assert := assert.New(t)
+	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
+}
+
+// This tests if there are three specs, where the first two use the same object definition,
+// while the third one uses its own.
+// We expect the merged schema to contain two versions of the object, not three
+func TestTwoMergeSpecsFirstTwoSchemasHaveSameDefinition(t *testing.T) {
+	var spec1, spec2, spec3, expected *spec.Swagger
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    description: "spec1 and spec2 use the same object definition, while spec3 doesn't"
+    type: "object"
+`), &spec1)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    description: "spec1 and spec2 use the same object definition, while spec3 doesn't"
+    type: "object"
+`), &spec2)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test3:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    description: "spec3 has its own definition (the description doesn't match)"
+    type: "object"
+`), &spec3)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /test2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /test3:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+definitions:
+  Test:
+    description: "spec1 and spec2 use the same object definition, while spec3 doesn't"
+    type: "object"
+  Test_v2:
+    description: "spec3 has its own definition (the description doesn't match)"
+    type: "object"
+`), &expected)
+
+	assert := assert.New(t)
+	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	if !assert.NoError(MergeSpecs(spec1, spec3)) {
+		return
+	}
+	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
+}
+
+// This tests if there are three specs, where the last two use the same object definition,
+// while the first one uses its own.
+// We expect the merged schema to contain two versions of the object, not three
+func TestTwoMergeSpecsLastTwoSchemasHaveSameDefinition(t *testing.T) {
+	var spec1, spec2, spec3, expected *spec.Swagger
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    type: "object"
+`), &spec1)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    description: "spec2 and spec3 use the same object definition, while spec1 doesn't"
+    type: "object"
+`), &spec2)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+definitions:
+  Test:
+    description: "spec2 and spec3 use the same object definition, while spec1 doesn't"
+    type: "object"
+`), &spec3)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test"
+  /othertest:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+  /othertest2:
+    post:
+      parameters:
+      - name: "body"
+        schema:
+          $ref: "#/definitions/Test_v2"
+definitions:
+  Test:
+    type: "object"
+  Test_v2:
+    description: "spec2 and spec3 use the same object definition, while spec1 doesn't"
+    type: "object"
+`), &expected)
+
+	assert := assert.New(t)
+	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	if !assert.NoError(MergeSpecs(spec1, spec3)) {
 		return
 	}
 	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
@@ -657,6 +1006,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &fooSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -682,6 +1032,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &barSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -727,6 +1078,7 @@ definitions:
           type: "integer"
           format: "int64"
   `), &expected)
+
 	assert := assert.New(t)
 	actual, err := CloneSpec(fooSpec)
 	if !assert.NoError(err) {
@@ -765,6 +1117,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &fooSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -790,6 +1143,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &barSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -829,6 +1183,7 @@ definitions:
           type: "integer"
           format: "int64"
   `), &expected)
+
 	assert := assert.New(t)
 	actual, err := CloneSpec(fooSpec)
 	if !assert.NoError(err) {
@@ -867,6 +1222,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &fooSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -894,6 +1250,7 @@ definitions:
       new_field:
         type: "string"
 `), &barSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -933,6 +1290,7 @@ definitions:
           type: "integer"
           format: "int64"
   `), &expected)
+
 	assert := assert.New(t)
 	actual, err := CloneSpec(fooSpec)
 	if !assert.NoError(err) {
@@ -968,6 +1326,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &fooSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -996,6 +1355,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &barSpec)
+
 	yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
@@ -1041,6 +1401,7 @@ definitions:
           type: "integer"
           format: "int64"
   `), &expected)
+
 	assert := assert.New(t)
 	actual, err := CloneSpec(fooSpec)
 	if !assert.NoError(err) {
@@ -1086,6 +1447,7 @@ definitions:
         type: "integer"
         format: "int64"
 `), &fooSpec)
+
 	assert := assert.New(t)
 	foo2Spec, err := CloneSpec(fooSpec)
 	actual, err := CloneSpec(fooSpec)


### PR DESCRIPTION
Before this fix, the aggregator would create multiple identical
copies (but with a different name) of the same object type.

This fixes https://github.com/kubernetes/kubernetes/issues/55941