### PR TITLE
remove VisitArbitrary from SchemaVisitor, make different interface

### DIFF
--- a/pkg/util/proto/openapi.go
+++ b/pkg/util/proto/openapi.go
@@ -55,8 +55,15 @@ type SchemaVisitor interface {
 	VisitMap(*Map)
 	VisitPrimitive(*Primitive)
 	VisitKind(*Kind)
-	VisitArbitrary(*Arbitrary)
 	VisitReference(Reference)
+}
+
+// SchemaVisitorArbitrary is an additional visitor interface which handles
+// arbitrary types. For backwards compatability, it's a separate interface
+// which is checked for at runtime.
+type SchemaVisitorArbitrary interface {
+	SchemaVisitor
+	VisitArbitrary(*Arbitrary)
 }
 
 // Schema is the base definition of an openapi type.
@@ -251,7 +258,9 @@ type Arbitrary struct {
 var _ Schema = &Arbitrary{}
 
 func (a *Arbitrary) Accept(v SchemaVisitor) {
-	v.VisitArbitrary(a)
+	if visitor, ok := v.(SchemaVisitorArbitrary); ok {
+		visitor.VisitArbitrary(a)
+	}
 }
 
 func (a *Arbitrary) GetName() string {


### PR DESCRIPTION
Lots of things in k8s.io/kubernetes implement SchemaVisitor, and
adding a new interface method breaks that.[1] Instead of adding
VisitArbitrary directly to that interface introduce a new
SchemaVisitorArbitrary that types can optionally implement to visit
an arbitrary type.

/assign @luksa
/assign @apelisse

Modifies change in https://github.com/kubernetes/kube-openapi/pull/25

Fixes https://github.com/kubernetes/kube-openapi/issues/27

[1] https://github.com/kubernetes/kubernetes/pull/57059#issuecomment-350896736