### PR TITLE
Add the Pattern if it's specified

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -353,7 +353,18 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			return nil
 		}
 		if hasOpenAPIDefinitionMethods(t) {
-			g.Do("common.OpenAPIDefinition{\n"+
+			// Since this generated snippet is part of a map:
+			//
+			//		map[string]common.OpenAPIDefinition: {
+			//			"TYPE_NAME": {
+			//				Schema: spec.Schema{ ... },
+			//			},
+			//		}
+			//
+			// For compliance with gofmt -s it's important we elide the
+			// struct type. The type is implied by the map and will be
+			// removed otherwise.
+			g.Do("{\n"+
 				"Schema: spec.Schema{\n"+
 				"SchemaProps: spec.SchemaProps{\n"+
 				"Type:$.type|raw${}.OpenAPISchemaType(),\n"+

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -42,6 +42,7 @@ const tagOptional = "optional"
 const (
 	tagValueTrue               = "true"
 	tagValueFalse              = "false"
+	tagPattern                 = "pattern"
 	tagExtensionPrefix         = "x-kubernetes-"
 	tagPatchStrategy           = "patchStrategy"
 	tagPatchMergeKey           = "patchMergeKey"
@@ -542,6 +543,11 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 	typeString, format := openapi.GetOpenAPITypeFormat(t.String())
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)
+		if pattern, err := getSingleTagsValue(m.CommentLines, tagPattern); err == nil {
+			if pattern != "" {
+				g.Do("Pattern: \"$.$\",\n", pattern)
+			}
+		}
 		g.Do("},\n},\n", nil)
 		return nil
 	}

--- a/pkg/util/proto/validation/types.go
+++ b/pkg/util/proto/validation/types.go
@@ -166,11 +166,11 @@ func (item *arrayItem) VisitArray(schema *proto.Array) {
 }
 
 func (item *arrayItem) VisitMap(schema *proto.Map) {
-	item.AddValidationError(InvalidTypeError{Path: schema.GetPath().String(), Expected: "array", Actual: "map"})
+	item.AddValidationError(InvalidTypeError{Path: schema.GetPath().String(), Expected: "map", Actual: "array"})
 }
 
 func (item *arrayItem) VisitKind(schema *proto.Kind) {
-	item.AddValidationError(InvalidTypeError{Path: schema.GetPath().String(), Expected: "array", Actual: "map"})
+	item.AddValidationError(InvalidTypeError{Path: schema.GetPath().String(), Expected: "map", Actual: "array"})
 }
 
 func (item *arrayItem) VisitArbitrary(schema *proto.Arbitrary) {


### PR DESCRIPTION
This is related to #26 and demonstrates the easiest way to add `spec.SchemaProps.Pattern` support to an Schema but admittedly a crude attempt. I'd like to add Pattern and Enum support given pointers on what's the preferred way.