### PR TITLE
generators: elide struct type when generating maps

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -353,7 +353,18 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			return nil
 		}
 		if hasOpenAPIDefinitionMethods(t) {
-			g.Do("common.OpenAPIDefinition{\n"+
+			// Since this generated snippet is part of a map:
+			//
+			//		map[string]common.OpenAPIDefinition: {
+			//			"TYPE_NAME": {
+			//				Schema: spec.Schema{ ... },
+			//			},
+			//		}
+			//
+			// For compliance with gofmt -s it's important we elide the
+			// struct type. The type is implied by the map and will be
+			// removed otherwise.
+			g.Do("{\n"+
 				"Schema: spec.Schema{\n"+
 				"SchemaProps: spec.SchemaProps{\n"+
 				"Type:$.type|raw${}.OpenAPISchemaType(),\n"+


### PR DESCRIPTION
./hack/verify-gofmt.sh was not happy with the generated code, which
isn't compliant with "gofmt -s". Elide the struct type when
generating OpenAPI definitions for a map value.

Example failure from (https://github.com/kubernetes/kubernetes/pull/57059):
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/57059/pull-kubernetes-verify/70488/

Follow up to https://github.com/kubernetes/kube-openapi/pull/21

/cc @mbohlool 