### PR TITLE
generators: add support for nested lists

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -634,6 +634,8 @@ func (g openAPITypeWriter) generateSliceProperty(t *types.Type) error {
 		return fmt.Errorf("please add type %v to getOpenAPITypeFormat function", elemType)
 	case types.Struct:
 		g.generateReferenceProperty(elemType)
+	case types.Slice, types.Array:
+		g.generateSliceProperty(elemType)
 	default:
 		return fmt.Errorf("slice Element kind %v is not supported in %v", elemType.Kind, t)
 	}

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -424,3 +424,59 @@ Dependencies: []string{
 },
 `, buffer.String())
 }
+
+func TestNestedLists(t *testing.T) {
+	err, assert, buffer := testOpenAPITypeWritter(t, `
+package foo
+
+// Blah is a test.
+// +k8s:openapi-gen=true
+// +k8s:openapi-gen=x-kubernetes-type-tag:type_test
+type Blah struct {
+	// Nested list
+	NestedList [][]int64
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(`"base/foo.Blah": {
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Blah is a test.",
+Properties: map[string]spec.Schema{
+"NestedList": {
+SchemaProps: spec.SchemaProps{
+Description: "Nested list",
+Type: []string{"array"},
+Items: &spec.SchemaOrArray{
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"array"},
+Items: &spec.SchemaOrArray{
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"integer"},
+Format: "int64",
+},
+},
+},
+},
+},
+},
+},
+},
+},
+Required: []string{"NestedList"},
+},
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"x-kubernetes-type-tag": "type_test",
+},
+},
+},
+Dependencies: []string{
+},
+},
+`, buffer.String())
+}


### PR DESCRIPTION
This change makes it possible to generate OpenAPI models when a field is a list-of-lists. 

Consider the following type:

```golang
// GeoJSON
// +k8s:openapi-gen=true
type GeoJSON struct {
    Name        string    `json:"name"`
    Coordinates [][]int64 `json:"coordinates"`
}
```

When the openapi codegen is run against it, it currently results in the following error:
```
ERROR: logging before flag.Parse: E0128 23:09:41.045732   55143 openapi.go:338] Error when generating: coordinates, Coordinates [][]int64
ERROR: logging before flag.Parse: F0128 23:09:41.045761   55143 main.go:44] Error: Failed executing generator: some packages had errors:
slice Element kind Slice is not supported in [][]int64
```

Nested lists has been supported since Swagger 2.0. See:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#itemsObject

![image](https://user-images.githubusercontent.com/12677113/35505140-03e6ba6e-049a-11e8-8965-dc7f4e067115.png)
