### PR TITLE
Typo fix "it's definition."->" to its definition."

### DIFF
--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -143,7 +143,7 @@ func (o *openAPI) buildDefinitionRecursively(name string) error {
 	return nil
 }
 
-// buildDefinitionForType build a definition for a given type and return a referable name to it's definition.
+// buildDefinitionForType build a definition for a given type and return a referable name to its definition.
 // This is the main function that keep track of definitions used in this spec and is depend on code generated
 // by k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen.
 func (o *openAPI) buildDefinitionForType(sample interface{}) (string, error) {


### PR DESCRIPTION
 in line 146: "...and return a referable name to it's definition." 
"it's" should be replaced with "its" .