### PR TITLE
Refactor to make it easier to add extension tags

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -44,6 +44,13 @@ const (
 	tagValueFalse = "false"
 )
 
+// Used for temporary validation of patch struct tags.
+// TODO: Remove patch struct tag validation because they we are now consuming OpenAPI on server.
+var tempPatchTags = [...]string{
+	"patchMergeKey",
+	"patchStrategy",
+}
+
 // Extension tag to openapi extension string.
 var tagToExtension = map[string]string{
 	"patchMergeKey": "x-kubernetes-patch-merge-key",
@@ -457,8 +464,9 @@ func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
 }
 
 // TODO(#44005): Move this validation outside of this generator (probably to policy verifier)
-func (g openAPITypeWriter) validateTags(m *types.Member, parent *types.Type) error {
-	for tagKey := range tagToExtension {
+func (g openAPITypeWriter) validatePatchTags(m *types.Member, parent *types.Type) error {
+	// TODO: Remove patch struct tag validation because they we are now consuming OpenAPI on server.
+	for _, tagKey := range tempPatchTags {
 		structTagValue := reflect.StructTag(m.Tags).Get(tagKey)
 		commentTagValue, err := getSingleTagsValue(m.CommentLines, tagKey)
 		if err != nil {
@@ -520,7 +528,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 	if name == "" {
 		return nil
 	}
-	if err := g.validateTags(m, parent); err != nil {
+	if err := g.validatePatchTags(m, parent); err != nil {
 		return err
 	}
 	g.Do("\"$.$\": {\n", name)

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -44,16 +44,10 @@ const (
 	tagValueFalse = "false"
 )
 
-// First-class Kubernetes extension tags within comments.
-var tags = [...]string{
-	"patchMergeKey",
-	"patchStrategy",
-}
-
 // Extension tag to openapi extension string.
 var tagToExtension = map[string]string{
-	"patchStrategy": "x-kubernetes-patch-strategy",
 	"patchMergeKey": "x-kubernetes-patch-merge-key",
+	"patchStrategy": "x-kubernetes-patch-strategy",
 }
 
 func getOpenAPITagValue(comments []string) []string {
@@ -439,7 +433,7 @@ func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
 		}
 	}
 	// Next, generate extensions from "tags".
-	for _, tagKey := range tags {
+	for tagKey := range tagToExtension {
 		tagValue, err := getSingleTagsValue(CommentLines, tagKey)
 		if err != nil {
 			return err
@@ -464,7 +458,7 @@ func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
 
 // TODO(#44005): Move this validation outside of this generator (probably to policy verifier)
 func (g openAPITypeWriter) validateTags(m *types.Member, parent *types.Type) error {
-	for _, tagKey := range tags {
+	for tagKey := range tagToExtension {
 		structTagValue := reflect.StructTag(m.Tags).Get(tagKey)
 		commentTagValue, err := getSingleTagsValue(m.CommentLines, tagKey)
 		if err != nil {


### PR DESCRIPTION
Refactors openapi generator to make it easier to add extension tags within comments.
Refactored "patchMergeStrategy" and "patchMergeKey" extension tags.
No new functionality.
Current unit tests pass.
