### PR TITLE
Multi-value extensions

### DIFF
--- a/pkg/generators/extension.go
+++ b/pkg/generators/extension.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/gengo/examples/set-gen/sets"
+	"k8s.io/gengo/types"
+)
+
+const extensionTag = "x-kubernetes-"
+
+// Extension tag to openapi extension
+var tagToExtension = map[string]string{
+	"patchMergeKey": "x-kubernetes-patch-merge-key",
+	"patchStrategy": "x-kubernetes-patch-strategy",
+	"listType":      "x-kubernetes-list-type",
+	"listMapKey":    "x-kubernetes-list-map-keys",
+}
+
+// Enum values per extension
+var allowedExtensionValues = map[string]sets.String{
+	"x-kubernetes-patch-strategy": sets.NewString("merge", "retainKeys"),
+	"x-kubernetes-list-type":      sets.NewString("atomic", "set", "map"),
+}
+
+// Extension encapsulates information necessary to generate an OpenAPI extension.
+// TODO(seans3): Create interface for an extension validation function, and create
+// validation functions for different extensions.
+type extension struct {
+	name   string   // Example: x-kubernetes-list-type
+	values []string // Example: atomic
+}
+
+func (e extension) validateAllowedValues() error {
+	// allowedValues not set means no restrictions on values.
+	allowedValues, exists := allowedExtensionValues[e.name]
+	if !exists {
+		return nil
+	}
+	// For each extension value, validate that it is allowed.
+	if !allowedValues.HasAll(e.values...) {
+		return fmt.Errorf("%s: value(s) %v not allowed. Allowed values: %v\n",
+			e.name, e.values, allowedValues.List())
+	}
+	return nil
+}
+
+func (e extension) hasMultipleValues() bool {
+	return len(e.values) > 1
+}
+
+// Returns sorted list of map keys. Needed for deterministic testing.
+func sortedMapKeys(m map[string][]string) []string {
+	keys := make([]string, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Parses comments to return openapi extensions
+func parseExtensions(comments []string) []extension {
+	extensions := []extension{}
+	// First, generate extensions from "+k8s:openapi-gen=x-kubernetes-*" annotations.
+	values := getOpenAPITagValue(comments)
+	for _, val := range values {
+		// Example: x-kubernetes-member-tag:member_test
+		if strings.HasPrefix(val, extensionTag) {
+			parts := strings.SplitN(val, ":", 2)
+			if len(parts) != 2 {
+				// TODO(seans3): Spit out source file/line number with error.
+				glog.V(2).Info(fmt.Sprintf("Invalid extension value: %v", val))
+				continue
+			}
+			e := extension{
+				name:   parts[0],           // Example: x-kubernetes-member-tag
+				values: []string{parts[1]}, // Example: member_test
+			}
+			extensions = append(extensions, e)
+		}
+	}
+	// Next, generate extensions from "tags" (e.g. +listType)
+	tagValues := types.ExtractCommentTags("+", comments)
+	for _, tag := range sortedMapKeys(tagValues) {
+		extensionName, exists := tagToExtension[tag]
+		if !exists {
+			continue
+		}
+		extensionValues := tagValues[tag]
+		e := extension{
+			name:   extensionName,
+			values: extensionValues,
+		}
+		// TODO(seans3): Validate the number of allowed values
+		// TODO(seans3): Validate the field type for this extension.
+		// Example: +listType is only allowed on an array.
+		if err := e.validateAllowedValues(); err != nil {
+			// For now, only log the extension validation errors.
+			glog.V(2).Info(err)
+		}
+		extensions = append(extensions, e)
+	}
+	return extensions
+}

--- a/pkg/generators/extension_test.go
+++ b/pkg/generators/extension_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestSingleTagExtension(t *testing.T) {
+
+	// Comments only contain one tag extension and one value.
+	var tests = []struct {
+		comments        []string
+		extensionName   string
+		extensionValues []string
+	}{
+		{
+			comments:        []string{"+patchMergeKey=name"},
+			extensionName:   "x-kubernetes-patch-merge-key",
+			extensionValues: []string{"name"},
+		},
+		{
+			comments:        []string{"+patchStrategy=merge"},
+			extensionName:   "x-kubernetes-patch-strategy",
+			extensionValues: []string{"merge"},
+		},
+		{
+			comments:        []string{"+listType=atomic"},
+			extensionName:   "x-kubernetes-list-type",
+			extensionValues: []string{"atomic"},
+		},
+		{
+			comments:        []string{"+listMapKey=port"},
+			extensionName:   "x-kubernetes-list-map-keys",
+			extensionValues: []string{"port"},
+		},
+		{
+			comments:        []string{"+k8s:openapi-gen=x-kubernetes-member-tag:member_test"},
+			extensionName:   "x-kubernetes-member-tag",
+			extensionValues: []string{"member_test"},
+		},
+		{
+			// Test that poorly formatted extensions aren't added.
+			comments: []string{
+				"+k8s:openapi-gen=x-kubernetes-no-value",
+				"+k8s:openapi-gen=x-kubernetes-member-success:success",
+				"+k8s:openapi-gen=x-kubernetes-wrong-separator;error",
+			},
+			extensionName:   "x-kubernetes-member-success",
+			extensionValues: []string{"success"},
+		},
+	}
+	for _, test := range tests {
+		actual := parseExtensions(test.comments)[0]
+		if actual.name != test.extensionName {
+			t.Errorf("Extension Name: expected (%s), actual (%s)\n", test.extensionName, actual.name)
+		}
+		if !reflect.DeepEqual(actual.values, test.extensionValues) {
+			t.Errorf("Extension Values: expected (%s), actual (%s)\n", test.extensionValues, actual.values)
+		}
+		if actual.hasMultipleValues() {
+			t.Errorf("%s: hasMultipleValues() should be false\n", actual.name)
+		}
+	}
+
+}
+
+func TestMultipleTagExtensions(t *testing.T) {
+
+	var tests = []struct {
+		comments        []string
+		extensionName   string
+		extensionValues []string
+	}{
+		{
+			comments: []string{
+				"+listMapKey=port",
+				"+listMapKey=protocol",
+			},
+			extensionName:   "x-kubernetes-list-map-keys",
+			extensionValues: []string{"port", "protocol"},
+		},
+	}
+	for _, test := range tests {
+		actual := parseExtensions(test.comments)[0]
+		if actual.name != test.extensionName {
+			t.Errorf("Extension Name: expected (%s), actual (%s)\n", actual.name, test.extensionName)
+		}
+		if !reflect.DeepEqual(actual.values, test.extensionValues) {
+			t.Errorf("Extension Values: expected (%s), actual (%s)\n", actual.values, test.extensionValues)
+		}
+		if !actual.hasMultipleValues() {
+			t.Errorf("%s: hasMultipleValues() should be true\n", actual.name)
+		}
+	}
+
+}
+
+func TestExtensionAllowedValues(t *testing.T) {
+
+	var tests = []struct {
+		e   extension
+		err error
+	}{
+		{
+			e: extension{
+				name:   "x-kubernetes-patch-strategy",
+				values: []string{"merge"},
+			},
+			err: nil,
+		},
+		{
+			// Validate multiple values.
+			e: extension{
+				name:   "x-kubernetes-patch-strategy",
+				values: []string{"merge", "retainKeys"},
+			},
+			err: nil,
+		},
+		{
+			// Every value must be allowed.
+			e: extension{
+				name:   "x-kubernetes-patch-strategy",
+				values: []string{"disallowed", "merge"},
+			},
+			err: errors.New("x-kubernetes-patch-strategy: value(s) [disallowed merge] not allowed. Allowed values: [merge retainKeys]\n"),
+		},
+		{
+			e: extension{
+				name:   "x-kubernetes-patch-strategy",
+				values: []string{"foo"},
+			},
+			err: errors.New("x-kubernetes-patch-strategy: value(s) [foo] not allowed. Allowed values: [merge retainKeys]\n"),
+		},
+		{
+			e: extension{
+				name:   "x-kubernetes-patch-merge-key",
+				values: []string{"key1"},
+			},
+			err: nil,
+		},
+		{
+			e: extension{
+				name:   "x-kubernetes-list-type",
+				values: []string{"atomic"},
+			},
+			err: nil,
+		},
+		{
+			e: extension{
+				name:   "x-kubernetes-list-type",
+				values: []string{"not-allowed"},
+			},
+			err: errors.New("x-kubernetes-list-type: value(s) [not-allowed] not allowed. Allowed values: [atomic map set]\n"),
+		},
+	}
+	for _, test := range tests {
+		actualErr := test.e.validateAllowedValues()
+		if !reflect.DeepEqual(test.err, actualErr) {
+			t.Errorf("Expected: %v, Got: %v\n", test.err, actualErr)
+		}
+	}
+
+}


### PR DESCRIPTION
* Multi-value OpenAPI extensions (e.g. x-kubernetes-list-type-keys: "port", "protocol")
* Validation of extension enum values (e.g. x-kubernetes-patch-strategy must be either "merge" or "retainKeys"). This validation only logs a warning now.
* Moved extension code into its own file.
* Unit tests for extension code.