### PR TITLE
More descriptive error messages for extensions

### DIFF
--- a/pkg/generators/extension_test.go
+++ b/pkg/generators/extension_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package generators
 
 import (
-	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -27,33 +27,45 @@ func TestSingleTagExtension(t *testing.T) {
 	// Comments only contain one tag extension and one value.
 	var tests = []struct {
 		comments        []string
+		extensionTag    string
 		extensionName   string
 		extensionValues []string
 	}{
 		{
 			comments:        []string{"+patchMergeKey=name"},
+			extensionTag:    "patchMergeKey",
 			extensionName:   "x-kubernetes-patch-merge-key",
 			extensionValues: []string{"name"},
 		},
 		{
 			comments:        []string{"+patchStrategy=merge"},
+			extensionTag:    "patchStrategy",
 			extensionName:   "x-kubernetes-patch-strategy",
 			extensionValues: []string{"merge"},
 		},
 		{
 			comments:        []string{"+listType=atomic"},
+			extensionTag:    "listType",
 			extensionName:   "x-kubernetes-list-type",
 			extensionValues: []string{"atomic"},
 		},
 		{
 			comments:        []string{"+listMapKey=port"},
+			extensionTag:    "listMapKey",
 			extensionName:   "x-kubernetes-list-map-keys",
 			extensionValues: []string{"port"},
 		},
 		{
 			comments:        []string{"+k8s:openapi-gen=x-kubernetes-member-tag:member_test"},
+			extensionTag:    "k8s:openapi-gen",
 			extensionName:   "x-kubernetes-member-tag",
 			extensionValues: []string{"member_test"},
+		},
+		{
+			comments:        []string{"+k8s:openapi-gen=x-kubernetes-member-tag:member_test:member_test2"},
+			extensionTag:    "k8s:openapi-gen",
+			extensionName:   "x-kubernetes-member-tag",
+			extensionValues: []string{"member_test:member_test2"},
 		},
 		{
 			// Test that poorly formatted extensions aren't added.
@@ -62,12 +74,17 @@ func TestSingleTagExtension(t *testing.T) {
 				"+k8s:openapi-gen=x-kubernetes-member-success:success",
 				"+k8s:openapi-gen=x-kubernetes-wrong-separator;error",
 			},
+			extensionTag:    "k8s:openapi-gen",
 			extensionName:   "x-kubernetes-member-success",
 			extensionValues: []string{"success"},
 		},
 	}
 	for _, test := range tests {
-		actual := parseExtensions(test.comments)[0]
+		extensions, _ := parseExtensions(test.comments)
+		actual := extensions[0]
+		if actual.tag != test.extensionTag {
+			t.Errorf("Extension Tag: expected (%s), actual (%s)\n", test.extensionTag, actual.tag)
+		}
 		if actual.name != test.extensionName {
 			t.Errorf("Extension Name: expected (%s), actual (%s)\n", test.extensionName, actual.name)
 		}
@@ -85,6 +102,7 @@ func TestMultipleTagExtensions(t *testing.T) {
 
 	var tests = []struct {
 		comments        []string
+		extensionTag    string
 		extensionName   string
 		extensionValues []string
 	}{
@@ -93,17 +111,25 @@ func TestMultipleTagExtensions(t *testing.T) {
 				"+listMapKey=port",
 				"+listMapKey=protocol",
 			},
+			extensionTag:    "listMapKey",
 			extensionName:   "x-kubernetes-list-map-keys",
 			extensionValues: []string{"port", "protocol"},
 		},
 	}
 	for _, test := range tests {
-		actual := parseExtensions(test.comments)[0]
+		extensions, errors := parseExtensions(test.comments)
+		if len(errors) > 0 {
+			t.Errorf("Unexpected errors: %v\n", errors)
+		}
+		actual := extensions[0]
+		if actual.tag != test.extensionTag {
+			t.Errorf("Extension Tag: expected (%s), actual (%s)\n", test.extensionTag, actual.tag)
+		}
 		if actual.name != test.extensionName {
-			t.Errorf("Extension Name: expected (%s), actual (%s)\n", actual.name, test.extensionName)
+			t.Errorf("Extension Name: expected (%s), actual (%s)\n", test.extensionName, actual.name)
 		}
 		if !reflect.DeepEqual(actual.values, test.extensionValues) {
-			t.Errorf("Extension Values: expected (%s), actual (%s)\n", actual.values, test.extensionValues)
+			t.Errorf("Extension Values: expected (%s), actual (%s)\n", test.extensionValues, actual.values)
 		}
 		if !actual.hasMultipleValues() {
 			t.Errorf("%s: hasMultipleValues() should be true\n", actual.name)
@@ -112,68 +138,133 @@ func TestMultipleTagExtensions(t *testing.T) {
 
 }
 
-func TestExtensionAllowedValues(t *testing.T) {
+func TestExtensionErrors(t *testing.T) {
 
 	var tests = []struct {
-		e   extension
-		err error
+		comments     []string
+		errorMessage string
+	}{
+		{
+			// Missing extension value should be an error.
+			comments: []string{
+				"+k8s:openapi-gen=x-kubernetes-no-value",
+			},
+			errorMessage: "x-kubernetes-no-value",
+		},
+		{
+			// Wrong separator should be an error.
+			comments: []string{
+				"+k8s:openapi-gen=x-kubernetes-wrong-separator;error",
+			},
+			errorMessage: "x-kubernetes-wrong-separator;error",
+		},
+		{
+			// disallowed is not one of the allowed values for listType.
+			comments: []string{
+				"+listType=disallowed",
+			},
+			errorMessage: "listType",
+		},
+		{
+			// Missing list type value should be an error.
+			comments: []string{
+				"+listType",
+			},
+			errorMessage: "listType",
+		},
+		{
+			// badStrategy is not one of the allowed values for patchStrategy.
+			comments: []string{
+				"+patchStrategy=badStrategy",
+			},
+			errorMessage: "patchStrategy",
+		},
+	}
+
+	for _, test := range tests {
+		_, errors := parseExtensions(test.comments)
+		if len(errors) == 0 {
+			t.Errorf("Expected errors while parsing: %v\n", test.comments)
+		}
+		error := errors[0]
+		if !strings.Contains(error.Error(), test.errorMessage) {
+			t.Errorf("Error (%v) should contain substring (%s)\n", error, test.errorMessage)
+		}
+	}
+}
+
+func TestExtensionAllowedValues(t *testing.T) {
+
+	var successTests = []struct {
+		e extension
 	}{
 		{
 			e: extension{
+				tag:    "patchStrategy",
 				name:   "x-kubernetes-patch-strategy",
 				values: []string{"merge"},
 			},
-			err: nil,
 		},
 		{
 			// Validate multiple values.
 			e: extension{
+				tag:    "patchStrategy",
 				name:   "x-kubernetes-patch-strategy",
 				values: []string{"merge", "retainKeys"},
 			},
-			err: nil,
-		},
-		{
-			// Every value must be allowed.
-			e: extension{
-				name:   "x-kubernetes-patch-strategy",
-				values: []string{"disallowed", "merge"},
-			},
-			err: errors.New("x-kubernetes-patch-strategy: value(s) [disallowed merge] not allowed. Allowed values: [merge retainKeys]\n"),
 		},
 		{
 			e: extension{
-				name:   "x-kubernetes-patch-strategy",
-				values: []string{"foo"},
-			},
-			err: errors.New("x-kubernetes-patch-strategy: value(s) [foo] not allowed. Allowed values: [merge retainKeys]\n"),
-		},
-		{
-			e: extension{
+				tag:    "patchMergeKey",
 				name:   "x-kubernetes-patch-merge-key",
 				values: []string{"key1"},
 			},
-			err: nil,
 		},
 		{
 			e: extension{
+				tag:    "listType",
 				name:   "x-kubernetes-list-type",
 				values: []string{"atomic"},
 			},
-			err: nil,
+		},
+	}
+	for _, test := range successTests {
+		actualErr := test.e.validateAllowedValues()
+		if actualErr != nil {
+			t.Errorf("Expected no error for (%v), but received: %v\n", test.e, actualErr)
+		}
+	}
+
+	var failureTests = []struct {
+		e extension
+	}{
+		{
+			// Every value must be allowed.
+			e: extension{
+				tag:    "patchStrategy",
+				name:   "x-kubernetes-patch-strategy",
+				values: []string{"disallowed", "merge"},
+			},
 		},
 		{
 			e: extension{
+				tag:    "patchStrategy",
+				name:   "x-kubernetes-patch-strategy",
+				values: []string{"foo"},
+			},
+		},
+		{
+			e: extension{
+				tag:    "listType",
 				name:   "x-kubernetes-list-type",
 				values: []string{"not-allowed"},
 			},
-			err: errors.New("x-kubernetes-list-type: value(s) [not-allowed] not allowed. Allowed values: [atomic map set]\n"),
 		},
 	}
-	for _, test := range tests {
+	for _, test := range failureTests {
 		actualErr := test.e.validateAllowedValues()
-		if !reflect.DeepEqual(test.err, actualErr) {
-			t.Errorf("Expected: %v, Got: %v\n", test.err, actualErr)
+		if actualErr == nil {
+			t.Errorf("Expected error, but received none: %v\n", test.e)
 		}
 	}
 

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -403,7 +403,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			g.Do("Required: []string{\"$.$\"},\n", strings.Join(required, "\",\""))
 		}
 		g.Do("},\n", nil)
-		if err := g.generateExtensions(t.CommentLines); err != nil {
+		if err := g.generateStructExtensions(t); err != nil {
 			return err
 		}
 		g.Do("},\n", nil)
@@ -428,12 +428,40 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 	return nil
 }
 
-func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
-	extensions := parseExtensions(CommentLines)
-	if len(extensions) == 0 {
-		return nil
+func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
+	extensions, errors := parseExtensions(t.CommentLines)
+	// Initially, we will only log struct extension errors.
+	if len(errors) > 0 {
+		for e := range errors {
+			glog.V(2).Infof("[%s]: %s\n", t.String(), e)
+		}
 	}
+	// TODO(seans3): Validate struct extensions here.
+	g.emitExtensions(extensions)
+	return nil
+}
+
+func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *types.Type) error {
+	extensions, errors := parseExtensions(m.CommentLines)
+	// Initially, we will only log member extension errors.
+	if len(errors) > 0 {
+		errorPrefix := fmt.Sprintf("[%s] %s:", parent.String(), m.String())
+		for e := range errors {
+			glog.V(2).Infof("%s %s\n", errorPrefix, e)
+		}
+	}
+	// TODO(seans3): Validate member extensions here.
+	// Example: listType extension is only on a Slice.
+	// Example: cross-extension validation - listMapKey only makes sense with listType=map
+	g.emitExtensions(extensions)
+	return nil
+}
+
+func (g openAPITypeWriter) emitExtensions(extensions []extension) {
 	// If any extensions exist, then emit code to create them.
+	if len(extensions) == 0 {
+		return
+	}
 	g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
 	for _, extension := range extensions {
 		g.Do("\"$.$\": ", extension.name)
@@ -448,7 +476,6 @@ func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
 		}
 	}
 	g.Do("},\n},\n", nil)
-	return nil
 }
 
 // TODO(#44005): Move this validation outside of this generator (probably to policy verifier)
@@ -520,7 +547,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 		return err
 	}
 	g.Do("\"$.$\": {\n", name)
-	if err := g.generateExtensions(m.CommentLines); err != nil {
+	if err := g.generateMemberExtensions(m, parent); err != nil {
 		return err
 	}
 	g.Do("SchemaProps: spec.SchemaProps{\n", nil)


### PR DESCRIPTION
* generateExtensions() is bifurcated into generateStructExtensions() and generateMemberExtensions(). Cross-extension validation is now possible.
* parseExtensions() now returns a list of errors
* add "tag" to extension struct (e.g. +listType) for better error reporting
