### PR TITLE
Remove unnecessarily stored spec

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -58,7 +58,6 @@ type OpenAPIService struct {
 	// rwMutex protects All members of this service.
 	rwMutex sync.RWMutex
 
-	orgSpec      *spec.Swagger
 	lastModified time.Time
 
 	specBytes []byte
@@ -161,7 +160,6 @@ func (o *OpenAPIService) getSwaggerPbGzBytes() ([]byte, string, time.Time) {
 }
 
 func (o *OpenAPIService) UpdateSpec(openapiSpec *spec.Swagger) (err error) {
-	orgSpec := openapiSpec
 	specBytes, err := json.MarshalIndent(openapiSpec, " ", " ")
 	if err != nil {
 		return err
@@ -181,7 +179,6 @@ func (o *OpenAPIService) UpdateSpec(openapiSpec *spec.Swagger) (err error) {
 	o.rwMutex.Lock()
 	defer o.rwMutex.Unlock()
 
-	o.orgSpec = orgSpec
 	o.specBytes = specBytes
 	o.specPb = specPb
 	o.specPbGz = specPbGz


### PR DESCRIPTION
We store a reference, orgSpec, to the spec.Swagger (go typed openapi spec), but we never serve it. once the specBytes we serve are generated from the orgSpec we don't need a reference to the original spec anymore

@mbohlool 