### PR TITLE
Properly initialize spec.Definitions when merging specs

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -335,6 +335,9 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 	}
 	for k, v := range source.Definitions {
 		if _, found := dest.Definitions[k]; !found {
+			if dest.Definitions == nil {
+				dest.Definitions = spec.Definitions{}
+			}
 			dest.Definitions[k] = v
 		}
 	}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -376,6 +376,107 @@ definitions:
 	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
 }
 
+func TestMergeSpecsEmptyDefinitions(t *testing.T) {
+	var spec1, spec2, expected *spec.Swagger
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      tags:
+      - "test"
+      summary: "Test API"
+      operationId: "addTest"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "test object"
+        required: true
+      responses:
+        405:
+          description: "Invalid input"
+`), &spec1)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest:
+    post:
+      tags:
+      - "test2"
+      summary: "Test2 API"
+      operationId: "addTest2"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "test2 object"
+        required: true
+        schema:
+          $ref: "#/definitions/Test2"
+definitions:
+  Test2:
+    type: "object"
+    properties:
+      other:
+        $ref: "#/definitions/Other"
+  Other:
+    type: "string"
+`), &spec2)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /test:
+    post:
+      tags:
+      - "test"
+      summary: "Test API"
+      operationId: "addTest"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "test object"
+        required: true
+      responses:
+        405:
+          description: "Invalid input"
+  /othertest:
+    post:
+      tags:
+      - "test2"
+      summary: "Test2 API"
+      operationId: "addTest2"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "test2 object"
+        required: true
+        schema:
+          $ref: "#/definitions/Test2"
+definitions:
+  Test2:
+    type: "object"
+    properties:
+      other:
+        $ref: "#/definitions/Other"
+  Other:
+    type: "string"
+`), &expected)
+
+	assert := assert.New(t)
+	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
+}
 func TestMergeSpecsReuseModel(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
 	yaml.Unmarshal([]byte(`


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/63218

When aggregating openapi specs, based on sort priority, a valid openapi spec with empty [`Definitions`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitions-object) may become the first [specToReturn](https://github.com/kubernetes/kubernetes/blob/d4ab47518836c750f9949b9e0d387f20fb92260b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator.go#L200-L214). Currently the aggregator panics on "assignment to entry in nil map". This PR initialize the map if it's nil. 