### PR TITLE
Typo fix in swagger.json: mulitple->multiple

### DIFF
--- a/pkg/util/proto/testing/swagger.json
+++ b/pkg/util/proto/testing/swagger.json
@@ -1112,7 +1112,7 @@
           "type": "string"
         },
         "kind": {
-          "description": "Expected values Shared: mulitple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+          "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
           "type": "string"
         },
         "readOnly": {


### PR DESCRIPTION
mulitple->multiple