### PR TITLE
Allow specs to have empty Paths in aggregation

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -61,6 +61,10 @@ func (s *referenceWalker) walkRef(ref spec.Ref) spec.Ref {
 		k := refStr[len(definitionPrefix):]
 		def := s.root.Definitions[k]
 		s.walkSchema(&def)
+		// Make sure we don't assign to nil map
+		if s.root.Definitions == nil {
+			s.root.Definitions = spec.Definitions{}
+		}
 		s.root.Definitions[k] = def
 	}
 	return s.walkRefCallback(ref)
@@ -147,6 +151,9 @@ func (s *referenceWalker) walkOperation(op *spec.Operation) {
 }
 
 func (s *referenceWalker) Start() {
+	if s.root.Paths == nil {
+		return
+	}
 	for _, pathItem := range s.root.Paths.Paths {
 		s.walkParams(pathItem.Parameters)
 		s.walkOperation(pathItem.Delete)
@@ -220,6 +227,10 @@ func renameDefinition(s *spec.Swagger, old, new string) {
 		}
 		return ref
 	}, s)
+	// Make sure we don't assign to nil map
+	if s.Definitions == nil {
+		s.Definitions = spec.Definitions{}
+	}
 	s.Definitions[new] = s.Definitions[old]
 	delete(s.Definitions, old)
 }
@@ -244,6 +255,13 @@ func MergeSpecs(dest, source *spec.Swagger) error {
 
 func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConflicts bool) (err error) {
 	specCloned := false
+	// Paths may be empty, due to [ACL constraints](http://goo.gl/8us55a#securityFiltering).
+	if source.Paths == nil {
+		source.Paths = &spec.Paths{}
+	}
+	if dest.Paths == nil {
+		dest.Paths = &spec.Paths{}
+	}
 	if ignorePathConflicts {
 		keepPaths := []string{}
 		hasConflictingPath := false
@@ -345,6 +363,10 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 	for k, v := range source.Paths.Paths {
 		if _, found := dest.Paths.Paths[k]; found {
 			return fmt.Errorf("unable to merge: duplicated path %s", k)
+		}
+		// PathItem may be empty, due to [ACL constraints](http://goo.gl/8us55a#securityFiltering).
+		if dest.Paths.Paths == nil {
+			dest.Paths.Paths = map[string]spec.PathItem{}
 		}
 		dest.Paths.Paths[k] = v
 	}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -477,6 +477,105 @@ definitions:
 	}
 	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
 }
+
+func TestMergeSpecsEmptyPaths(t *testing.T) {
+	var spec1, spec2, expected *spec.Swagger
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+definitions:
+  Test:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      status:
+        type: "string"
+        description: "Status"
+  InvalidInput:
+    type: "string"
+    format: "string"
+`), &spec1)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest:
+    post:
+      tags:
+      - "test2"
+      summary: "Test2 API"
+      operationId: "addTest2"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "test2 object"
+        required: true
+        schema:
+          $ref: "#/definitions/Test2"
+definitions:
+  Test2:
+    type: "object"
+    properties:
+      other:
+        $ref: "#/definitions/Other"
+  Other:
+    type: "string"
+`), &spec2)
+
+	yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /othertest:
+    post:
+      tags:
+      - "test2"
+      summary: "Test2 API"
+      operationId: "addTest2"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "test2 object"
+        required: true
+        schema:
+          $ref: "#/definitions/Test2"
+definitions:
+  Test:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      status:
+        type: "string"
+        description: "Status"
+  InvalidInput:
+    type: "string"
+    format: "string"
+  Test2:
+    type: "object"
+    properties:
+      other:
+        $ref: "#/definitions/Other"
+  Other:
+    type: "string"
+`), &expected)
+
+	assert := assert.New(t)
+	if !assert.NoError(MergeSpecs(spec1, spec2)) {
+		return
+	}
+	assert.Equal(DebugSpec{expected}, DebugSpec{spec1})
+}
+
 func TestMergeSpecsReuseModel(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
 	yaml.Unmarshal([]byte(`


### PR DESCRIPTION
fixes https://github.com/kubernetes/kube-openapi/issues/66

Paths and PathItem may be empty, due to [ACL constraints](http://goo.gl/8us55a#securityFiltering).