### PR TITLE
Allow openapi definitions to be built for a single resource

### DIFF
--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -45,6 +45,16 @@ type openAPI struct {
 
 // BuildOpenAPISpec builds OpenAPI spec given a list of webservices (containing routes) and common.Config to customize it.
 func BuildOpenAPISpec(webServices []*restful.WebService, config *common.Config) (*spec.Swagger, error) {
+	o := newOpenAPI(config)
+	err := o.buildPaths(webServices)
+	if err != nil {
+		return nil, err
+	}
+	return o.finalizeSwagger()
+}
+
+// newOpenAPI sets up the openAPI object so we can build the spec.
+func newOpenAPI(config *common.Config) openAPI {
 	o := openAPI{
 		config: config,
 		swagger: &spec.Swagger{
@@ -56,16 +66,6 @@ func BuildOpenAPISpec(webServices []*restful.WebService, config *common.Config) 
 			},
 		},
 	}
-
-	err := o.init(webServices)
-	if err != nil {
-		return nil, err
-	}
-
-	return o.swagger, nil
-}
-
-func (o *openAPI) init(webServices []*restful.WebService) error {
 	if o.config.GetOperationIDAndTags == nil {
 		o.config.GetOperationIDAndTags = func(r *restful.Route) (string, []string, error) {
 			return r.Operation, nil, nil
@@ -83,22 +83,25 @@ func (o *openAPI) init(webServices []*restful.WebService) error {
 	if o.config.CommonResponses == nil {
 		o.config.CommonResponses = map[int]spec.Response{}
 	}
-	err := o.buildPaths(webServices)
-	if err != nil {
-		return err
-	}
+	return o
+}
+
+// finalizeSwagger is called after the spec is built and returns the final spec.
+// NOTE: finalizeSwagger also make changes to the final spec, as specified in the config.
+func (o *openAPI) finalizeSwagger() (*spec.Swagger, error) {
 	if o.config.SecurityDefinitions != nil {
 		o.swagger.SecurityDefinitions = *o.config.SecurityDefinitions
 		o.swagger.Security = o.config.DefaultSecurity
 	}
 	if o.config.PostProcessSpec != nil {
+		var err error
 		o.swagger, err = o.config.PostProcessSpec(o.swagger)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return o.swagger, nil
 }
 
 func getCanonicalizeTypeName(t reflect.Type) string {

--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -53,6 +53,22 @@ func BuildOpenAPISpec(webServices []*restful.WebService, config *common.Config) 
 	return o.finalizeSwagger()
 }
 
+// BuildOpenAPIDefinitionsForResource builds a partial OpenAPI spec given a sample object and common.Config to customize it.
+func BuildOpenAPIDefinitionsForResource(model interface{}, config *common.Config) (*spec.Definitions, error) {
+	o := newOpenAPI(config)
+	// We can discard the return value of toSchema because all we care about is the side effect of calling it.
+	// All the models created for this resource get added to o.swagger.Definitions
+	_, err := o.toSchema(model)
+	if err != nil {
+		return nil, err
+	}
+	swagger, err := o.finalizeSwagger()
+	if err != nil {
+		return nil, err
+	}
+	return &swagger.Definitions, nil
+}
+
 // newOpenAPI sets up the openAPI object so we can build the spec.
 func newOpenAPI(config *common.Config) openAPI {
 	o := openAPI{

--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -453,3 +453,23 @@ func TestBuildOpenAPISpec(t *testing.T) {
 	}
 	assert.Equal(string(expected_json), string(actual_json))
 }
+
+func TestBuildOpenAPIDefinitionsForResource(t *testing.T) {
+	config, _, assert := setUp(t, true)
+	expected := &spec.Definitions{
+		"builder.TestInput":  getTestInputDefinition(),
+	}
+	swagger, err := BuildOpenAPIDefinitionsForResource(TestInput{}, config)
+	if !assert.NoError(err) {
+		return
+	}
+	expected_json, err := json.Marshal(expected)
+	if !assert.NoError(err) {
+		return
+	}
+	actual_json, err := json.Marshal(swagger)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(string(expected_json), string(actual_json))
+}

--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -30,20 +30,10 @@ import (
 )
 
 // setUp is a convenience function for setting up for (most) tests.
-func setUp(t *testing.T, fullMethods bool) (openAPI, *restful.Container, *assert.Assertions) {
+func setUp(t *testing.T, fullMethods bool) (*openapi.Config, *restful.Container, *assert.Assertions) {
 	assert := assert.New(t)
 	config, container := getConfig(fullMethods)
-	return openAPI{
-		config: config,
-		swagger: &spec.Swagger{
-			SwaggerProps: spec.SwaggerProps{
-				Swagger:     OpenAPIVersion,
-				Definitions: spec.Definitions{},
-				Paths:       &spec.Paths{Paths: map[string]spec.PathItem{}},
-				Info:        config.Info,
-			},
-		},
-	}, container, assert
+	return config, container, assert
 }
 
 func noOp(request *restful.Request, response *restful.Response) {}
@@ -425,8 +415,8 @@ func getTestOutputDefinition() spec.Schema {
 	}
 }
 
-func TestBuildSwaggerSpec(t *testing.T) {
-	o, container, assert := setUp(t, true)
+func TestBuildOpenAPISpec(t *testing.T) {
+	config, container, assert := setUp(t, true)
 	expected := &spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
 			Info: &spec.Info{
@@ -449,7 +439,7 @@ func TestBuildSwaggerSpec(t *testing.T) {
 			},
 		},
 	}
-	err := o.init(container.RegisteredWebServices())
+	swagger, err := BuildOpenAPISpec(container.RegisteredWebServices(), config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -457,7 +447,7 @@ func TestBuildSwaggerSpec(t *testing.T) {
 	if !assert.NoError(err) {
 		return
 	}
-	actual_json, err := json.Marshal(o.swagger)
+	actual_json, err := json.Marshal(swagger)
 	if !assert.NoError(err) {
 		return
 	}


### PR DESCRIPTION
This PR allows for the openapi definitions to be built for a single resource. Needed for server side apply.

**Implementation:**

Split the init([]*restful.WebService) function into three functions:
- init(): runs before the swagger spec is built
- buildPaths([]*restful.WebService): The function which actually builds the swagger spec
- finalizeSwagger(): runs after the spec is built

This way we can substitute a different function in for buildPaths, which doesn't need to take a web service as an argument.

cc @mbohlool @apelisse @seans3 