### PR TITLE
proto: Support/parse OneOf types in OpenAPI

### DIFF
--- a/pkg/util/proto/openapi_test.go
+++ b/pkg/util/proto/openapi_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proto_test
 
 import (
+	"fmt"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -28,6 +29,7 @@ import (
 
 var fakeSchema = testing.Fake{Path: filepath.Join("testing", "swagger.json")}
 var fakeSchemaNext = testing.Fake{Path: filepath.Join("testing", "swagger_next.json")}
+var fakeOneOfSchema = testing.Fake{Path: filepath.Join("testing", "swagger_oneof.json")}
 
 var _ = Describe("Reading apps/v1beta1/Deployment from v1.8 openAPIData", func() {
 	var models proto.Models
@@ -261,5 +263,33 @@ var _ = Describe("Path", func() {
 		field := array.FieldPath("subKey")
 
 		Expect(field.Get()).To(Equal([]string{"key", "[12]", ".subKey"}))
+	})
+})
+
+var _ = Describe("OneOf", func() {
+	var models proto.Models
+	BeforeEach(func() {
+		s, err := fakeOneOfSchema.OpenAPISchema()
+		Expect(err).To(BeNil())
+		models, err = proto.NewOpenAPIData(s)
+		Expect(err).To(BeNil())
+	})
+
+	model := "A"
+	var schema proto.Schema
+	It("has a model named A", func() {
+		schema = models.LookupModel(model)
+		Expect(schema).ToNot(BeNil())
+	})
+	It("is a `oneof`", func() {
+		fmt.Println(schema.GetExtensions())
+		a := schema.(*proto.OneOf)
+		Expect(a).ToNot(BeNil())
+		Expect(a.Discriminator).To(Equal("fruit"))
+	})
+	It("should have fields like a Kind", func() {
+		a := schema.(*proto.OneOf)
+		Expect(a).ToNot(BeNil())
+		Expect(a.Fields).To(HaveKey("apricot"))
 	})
 })

--- a/pkg/util/proto/testing/swagger_oneof.json
+++ b/pkg/util/proto/testing/swagger_oneof.json
@@ -1,0 +1,49 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Kubernetes",
+    "version": "v1.8.0"
+  },
+  "paths": {},
+  "definitions": {
+    "A": {
+      "description": "The first letter of the alphabet.",
+      "type": "object",
+      "properties": {
+        "apple": {
+          "description": "The round fruit of a tree of the rose family, which typically has thin red or green skin and crisp flesh. Many varieties have been developed as dessert or cooking fruit or for making cider.",
+          "type": "string"
+        },
+        "apricot": {
+          "description": "A juicy, soft fruit, resembling a small peach, of an orange-yellow color.",
+          "type": "string"
+        },
+        "fruit": {
+          "description": "The sweet and fleshy product of a tree or other plant that contains seed and can be eaten as food.",
+          "type": "string"
+        }
+      },
+      "x-kubernetes-oneof": "fruit",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "alphabet",
+          "kind": "letter",
+          "version": "roman"
+        }
+      ]
+    }
+  },
+  "securityDefinitions": {
+    "BearerToken": {
+      "description": "Bearer Token authentication",
+      "type": "apiKey",
+      "name": "authorization",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "BearerToken": []
+    }
+  ]
+}


### PR DESCRIPTION
Currently implementation should be 100% backward compatible. The code
doesn't have to support oneof just yet, as oneof will be converted to
normal types automatically.