### PR TITLE
proto: Add "Empty" fake

### DIFF
--- a/pkg/util/proto/testing/openapi.go
+++ b/pkg/util/proto/testing/openapi.go
@@ -60,3 +60,9 @@ func (f *Fake) OpenAPISchema() (*openapi_v2.Document, error) {
 	})
 	return f.document, f.err
 }
+
+type Empty struct{}
+
+func (Empty) OpenAPISchema() (*openapi_v2.Document, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This can be useful if you want to test plumbing, and not the content of
the OpenAPI.