### PR TITLE
include descriptions in types with custom defs

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -383,8 +383,9 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		if hasOpenAPIDefinitionMethods(t) {
 			g.Do("return $.OpenAPIDefinition|raw${\n"+
 				"Schema: spec.Schema{\n"+
-				"SchemaProps: spec.SchemaProps{\n"+
-				"Type:$.type|raw${}.OpenAPISchemaType(),\n"+
+				"SchemaProps: spec.SchemaProps{\n", args)
+			g.generateDescription(t.CommentLines)
+			g.Do("Type:$.type|raw${}.OpenAPISchemaType(),\n"+
 				"Format:$.type|raw${}.OpenAPISchemaFormat(),\n"+
 				"},\n"+
 				"},\n"+

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -378,6 +378,7 @@ func TestCustomDefs(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
+// Blah is a custom type
 type Blah struct {
 }
 
@@ -396,6 +397,7 @@ func (_ Blah) OpenAPISchemaFormat() string { return "date-time" }
 return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
+Description: "Blah is a custom type",
 Type:foo.Blah{}.OpenAPISchemaType(),
 Format:foo.Blah{}.OpenAPISchemaFormat(),
 },


### PR DESCRIPTION
Include description so that custom types can be documented as well.

See in action in https://github.com/kubernetes/kubernetes/pull/65256
