### PR TITLE
Server-side OpenAPI fixes (RawExtension & type:object for structs)

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -393,6 +393,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		}
 		g.Do("return $.OpenAPIDefinition|raw${\nSchema: spec.Schema{\nSchemaProps: spec.SchemaProps{\n", args)
 		g.generateDescription(t.CommentLines)
+		g.Do("Type: []string{\"object\"},\n", nil)
 		g.Do("Properties: map[string]$.SpecSchemaType|raw${\n", args)
 		required, err := g.generateMembers(t, []string{})
 		if err != nil {

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -37,6 +37,7 @@ import (
 // This is the comment tag that carries parameters for open API generation.
 const tagName = "k8s:openapi-gen"
 const tagOptional = "optional"
+const tagSchemaTypeFormat = tagName + ":schema-type-format"
 
 // Known values for the tag.
 const (
@@ -417,7 +418,11 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		sort.Strings(keys)
 		for _, k := range keys {
 			v := g.refTypes[k]
-			if t, _ := openapi.GetOpenAPITypeFormat(v.String()); t != "" {
+			t, _, err := getOpenAPITypeFormat(v)
+			if err != nil {
+				return err
+			}
+			if t != "" {
 				// This is a known type, we do not need a reference to it
 				// Will eliminate special case of time.Time
 				continue
@@ -427,6 +432,25 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		g.Do("},\n}\n}\n\n", nil)
 	}
 	return nil
+}
+
+func getOpenAPITypeFormat(t *types.Type) (string, string, error) {
+	schemaTypeFormatTag, err := getSingleTagsValue(t.CommentLines, tagSchemaTypeFormat)
+	if err != nil {
+		return "", "", err
+	}
+	if schemaTypeFormatTag == "" {
+		schemaType, format := openapi.GetOpenAPITypeFormat(t.String())
+		return schemaType, format, nil
+	}
+	typeFormatPair := strings.Split(schemaTypeFormatTag, ",")
+	if len(typeFormatPair) == 1 {
+		return typeFormatPair[0], "", nil
+	} else if len(typeFormatPair) == 2 {
+		return typeFormatPair[0], typeFormatPair[1], nil
+	} else {
+		return "", "", fmt.Errorf("tag %s should contain a type and an optional format separated by a comma", tagSchemaTypeFormat)
+	}
 }
 
 func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
@@ -560,7 +584,10 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 	}
 	t := resolveAliasAndPtrType(m.Type)
 	// If we can get a openAPI type and format for this type, we consider it to be simple property
-	typeString, format := openapi.GetOpenAPITypeFormat(t.String())
+	typeString, format, err := getOpenAPITypeFormat(t)
+	if err != nil {
+		return err
+	}
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)
 		g.Do("},\n},\n", nil)
@@ -620,7 +647,10 @@ func (g openAPITypeWriter) generateMapProperty(t *types.Type) error {
 	}
 	g.Do("Type: []string{\"object\"},\n", nil)
 	g.Do("AdditionalProperties: &spec.SchemaOrBool{\nSchema: &spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
-	typeString, format := openapi.GetOpenAPITypeFormat(elemType.String())
+	typeString, format, err := getOpenAPITypeFormat(elemType)
+	if err != nil {
+		return err
+	}
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)
 		g.Do("},\n},\n},\n", nil)
@@ -644,7 +674,10 @@ func (g openAPITypeWriter) generateSliceProperty(t *types.Type) error {
 	elemType := resolveAliasAndPtrType(t.Elem)
 	g.Do("Type: []string{\"array\"},\n", nil)
 	g.Do("Items: &spec.SchemaOrArray{\nSchema: &spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
-	typeString, format := openapi.GetOpenAPITypeFormat(elemType.String())
+	typeString, format, err := getOpenAPITypeFormat(elemType)
+	if err != nil {
+		return err
+	}
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)
 		g.Do("},\n},\n},\n", nil)

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -315,6 +315,49 @@ Dependencies: []string{
 `, funcBuffer.String())
 }
 
+func TestSchemaTypeFormatTag(t *testing.T) {
+	err, assert, buffer := testOpenAPITypeWritter(t, `
+package foo
+
+// Blah is a test.
+// +k8s:openapi-gen=true
+type Blah struct {
+	// Reference to type with schema-type-format tag
+	Foo Foo
+}
+
+// This type will not appear in the OpenAPI schema, because of the +k8s:openapi-gen:schema-type-format tag 
+// +k8s:openapi-gen:schema-type-format=object,
+type Foo struct {
+	String string
+}
+		`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(`"base/foo.Blah": {
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Blah is a test.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"Foo": {
+SchemaProps: spec.SchemaProps{
+Description: "Reference to type with schema-type-format tag",
+Type: []string{"object"},
+Format: "",
+},
+},
+},
+Required: []string{"Foo"},
+},
+},
+Dependencies: []string{
+},
+},
+`, buffer.String())
+}
+
 func TestFailingSample1(t *testing.T) {
 	_, funcErr, assert, _, _ := testOpenAPITypeWriter(t, `
 package foo

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -147,6 +147,7 @@ return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
 Description: "Blah is a test.",
+Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "String": {
 SchemaProps: spec.SchemaProps{
@@ -435,6 +436,7 @@ return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
 Description: "PointerSample demonstrate pointer's properties",
+Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "StringPointer": {
 SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
DO NOT MERGE until v1.12, because clients v1.10 and older break when they encounter a server with these changes. A v1.11+ client won't break.

This PR fixes two things:
- adds type:object to all OpenAPI definitions created from structs
- prevents the RawExtension type from being included in the OpenAPI schema by annotating it with `+k8s:openapi-gen:schema-type-format=object,`