### PR TITLE
Allow using top-level Responses Definitions field in openapi v2

### DIFF
--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -91,6 +91,7 @@ func newOpenAPI(config *common.Config) openAPI {
 			SwaggerProps: spec.SwaggerProps{
 				Swagger:     OpenAPIVersion,
 				Definitions: spec.Definitions{},
+				Responses:   config.ResponseDefinitions,
 				Paths:       &spec.Paths{Paths: map[string]spec.PathItem{}},
 				Info:        config.Info,
 			},

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -59,6 +59,12 @@ type Config struct {
 	// will show up as ... "responses" : {"default" : $DefaultResponse} in the spec.
 	DefaultResponse *spec.Response
 
+	// ResponseDefinitions will be added to "responses" under the top-level swagger object. This is an object
+	// that holds responses definitions that can be used across operations. This property does not define
+	// global responses for all operations. For more info please refer:
+	//     https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields
+	ResponseDefinitions map[string]spec.Response
+
 	// CommonResponses will be added as a response to all operation specs. This is a good place to add common
 	// responses such as authorization failed.
 	CommonResponses map[int]spec.Response

--- a/test/integration/builder/main.go
+++ b/test/integration/builder/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/emicklei/go-restful"
 	"github.com/go-openapi/spec"
 	"k8s.io/kube-openapi/pkg/builder"
 	"k8s.io/kube-openapi/pkg/common"
@@ -53,10 +54,21 @@ func main() {
 	// Create a minimal builder config, then call the builder with the definition names.
 	config := createOpenAPIBuilderConfig()
 	config.GetDefinitions = generated.GetOpenAPIDefinitions
-	swagger, serr := builder.BuildOpenAPIDefinitionsForResources(config, defNames...)
+	// Build the Paths using a simple WebService for the final spec
+	swagger, serr := builder.BuildOpenAPISpec(createWebServices(), config)
 	if serr != nil {
 		log.Fatalf("ERROR: %s", serr.Error())
 	}
+	// Generate the definitions for the passed type names to put in the final spec.
+	// Note that in reality one should run BuildOpenAPISpec to build the entire spec. We
+	// separate the steps of building Paths and building Definitions here, because we
+	// only have a simple WebService which doesn't wire the definitions up.
+	definitionSwagger, err := builder.BuildOpenAPIDefinitionsForResources(config, defNames...)
+	if err != nil {
+		log.Fatalf("ERROR: %s", err.Error())
+	}
+	// Copy the generated definitions into the final swagger.
+	swagger.Definitions = definitionSwagger.Definitions
 
 	// Marshal the swagger spec into JSON, then write it out.
 	specBytes, err := json.MarshalIndent(swagger, " ", " ")
@@ -81,5 +93,25 @@ func createOpenAPIBuilderConfig() *common.Config {
 				Version: "1.0",
 			},
 		},
+		ResponseDefinitions: map[string]spec.Response{
+			"NotFound": spec.Response{
+				ResponseProps: spec.ResponseProps{
+					Description: "Entity not found.",
+				},
+			},
+		},
+		CommonResponses: map[int]spec.Response{
+			404: *spec.ResponseRef("#/responses/NotFound"),
+		},
 	}
+}
+
+// createWebServices hard-codes a simple WebService which only defines a GET path
+// for testing.
+func createWebServices() []*restful.WebService {
+	w := new(restful.WebService)
+	// Define a dummy GET /test endpoint
+	w = w.Route(w.GET("test").
+		To(func(*restful.Request, *restful.Response) {}))
+	return []*restful.WebService{w}
 }

--- a/test/integration/testdata/golden.json
+++ b/test/integration/testdata/golden.json
@@ -4,7 +4,21 @@
    "title": "Integration Test",
    "version": "1.0"
   },
-  "paths": {},
+  "paths": {
+   "/test": {
+    "get": {
+     "schemes": [
+      "https"
+     ],
+     "operationId": "func1",
+     "responses": {
+      "404": {
+       "$ref": "#/responses/NotFound"
+      }
+     }
+    }
+   }
+  },
   "definitions": {
    "dummytype.Bar": {
     "required": [
@@ -121,6 +135,11 @@
       "x-kubernetes-list-type": "set"
      }
     }
+   }
+  },
+  "responses": {
+   "NotFound": {
+    "description": "Entity not found."
    }
   }
  }


### PR DESCRIPTION
This PR allows setting a `ResponseDefinitions` field in common config, which will be propagated to the top-level [Responses Definitions field](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields) during building. From the v2 specification, the field is:
> An object to hold responses that can be used across operations. This property does not define global responses for all operations.

The idea comes from the k8s issue https://github.com/kubernetes/kubernetes/issues/69014. We want to document all the possible error codes that apiserver may respond with. Presumably we will add 10+ responses to every operations under every paths. Since all the error responses have same schema in body (metav1.Status), we can put the full response definition in the top-level Responses Definitions field, and have the operation-level responses refer to it, to make the spec size smaller.

Note that `go-openapi` doesn't verify if the referred definition exists when [creating a Response](https://github.com/go-openapi/spec/blob/5bae59e25b21498baea7f9d46e9c147ec106a42e/response.go#L89-L94). It's up to user to set the definition first and write the refURI properly.

The next step will be changing k8s to set `ResponseDefinitions` and `CommonResponses` when [completing the openapi Config](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/config.go#L379-L388).

/assign @mbohlool 
cc @lswith