### PR TITLE
fix path mangling

### DIFF
--- a/pkg/generators/config.go
+++ b/pkg/generators/config.go
@@ -19,7 +19,6 @@ package generators
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/gengo/args"
@@ -64,20 +63,12 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 `)...)
 
-	reportFilename := "-"
+	reportPath := "-"
 	if customArgs, ok := arguments.CustomArgs.(*generatorargs.CustomArgs); ok {
-		reportFilename = customArgs.ReportFilename
+		reportPath = customArgs.ReportFilename
 	}
-	context.FileTypes[apiViolationFileType] = apiViolationFile{}
-	// The report file shouldn't be inside any package, but the framework
-	// doesn't understand packageless files. So we construct a path that
-	// fixes this.
-	siblingPath := ""
-	if len(arguments.OutputBase) > 0 {
-		siblingPath = strings.Repeat(
-			".."+string([]rune{filepath.Separator}),
-			len(filepath.SplitList(arguments.OutputBase)),
-		)
+	context.FileTypes[apiViolationFileType] = apiViolationFile{
+		unmangledPath: reportPath,
 	}
 
 	return generator.Packages{
@@ -91,14 +82,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 						arguments.OutputFileBaseName,
 						arguments.OutputPackagePath,
 					),
+					newAPIViolationGen(),
 				}
-			},
-			FilterFunc: apiTypeFilterFunc,
-		},
-		&generator.DefaultPackage{
-			PackagePath: siblingPath,
-			GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
-				return []generator.Generator{newAPIViolationGen(reportFilename)}
 			},
 			FilterFunc: apiTypeFilterFunc,
 		},

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -188,6 +188,24 @@ func schema__testdata_listtype_Item(ref common.ReferenceCallback) common.OpenAPI
 							Format: "int32",
 						},
 					},
+					"a": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+					"b": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+					"c": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 				Required: []string{"Protocol", "Port"},
 			},


### PR DESCRIPTION
This makes the report file location simple and obvious rather than fighting with the generation framework.

Both variations passed the integration test here but the new one also works with the random path manipulations that upstream kubernetes does.