### PR TITLE
Add type: object to all generated struct objects

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -336,6 +336,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		}
 		g.Do("return $.OpenAPIDefinition|raw${\nSchema: spec.Schema{\nSchemaProps: spec.SchemaProps{\n", args)
 		g.generateDescription(t.CommentLines)
+		g.Do("Type: []string{\"object\"},\n", nil)
 		g.Do("Properties: map[string]$.SpecSchemaType|raw${\n", args)
 		required, err := g.generateMembers(t, []string{})
 		if err != nil {

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -147,6 +147,7 @@ return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
 Description: "Blah is a test.",
+Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "String": {
 SchemaProps: spec.SchemaProps{
@@ -437,6 +438,7 @@ return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
 Description: "PointerSample demonstrate pointer's properties",
+Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "StringPointer": {
 SchemaProps: spec.SchemaProps{
@@ -516,6 +518,7 @@ return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
 Description: "Blah is a test.",
+Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "NestedList": {
 SchemaProps: spec.SchemaProps{
@@ -583,6 +586,7 @@ return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
 Description: "Blah is a test.",
+Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "WithListField": {
 VendorExtensible: spec.VendorExtensible{

--- a/test/integration/testdata/golden.json
+++ b/test/integration/testdata/golden.json
@@ -21,6 +21,7 @@
   },
   "definitions": {
    "dummytype.Bar": {
+    "type": "object",
     "required": [
      "ViolationBehind",
      "Violation"
@@ -35,6 +36,7 @@
     }
    },
    "dummytype.Baz": {
+    "type": "object",
     "required": [
      "Violation",
      "ViolationBehind"
@@ -49,6 +51,7 @@
     }
    },
    "dummytype.Foo": {
+    "type": "object",
     "required": [
      "Second",
      "First"
@@ -64,6 +67,7 @@
     }
    },
    "dummytype.Waldo": {
+    "type": "object",
     "required": [
      "First",
      "Second"
@@ -79,6 +83,7 @@
     }
    },
    "listtype.AtomicList": {
+    "type": "object",
     "required": [
      "Field"
     ],
@@ -93,6 +98,7 @@
     }
    },
    "listtype.Item": {
+    "type": "object",
     "required": [
      "Protocol",
      "Port"
@@ -120,6 +126,7 @@
     }
    },
    "listtype.MapList": {
+    "type": "object",
     "required": [
      "Field"
     ],
@@ -135,6 +142,7 @@
     }
    },
    "listtype.SetList": {
+    "type": "object",
     "required": [
      "Field"
     ],


### PR DESCRIPTION
Look like we did not set type on definitions of struct type. Most of the OpenAPI tools should assume "object" I guess, thats why we didn't catch this.


Ref: https://github.com/kubernetes/kubernetes/issues/56428