### PR TITLE
Switch location for goautoneg vendored code

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,9 +7,8 @@
 	],
 	"Deps": [
 		{
-		        "ImportPath": "bitbucket.org/ww/goautoneg",
-		        "Comment": "null-5",
-		        "Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+			"ImportPath": "github.com/munnerz/goautoneg",
+			"Rev": "a547fc61f48d567d5b4ec6f8aee5573d8efce11d"
 		},
 		{
 			"ImportPath": "github.com/NYTimes/gziphandler",

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"bitbucket.org/ww/goautoneg"
-
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/NYTimes/gziphandler"
@@ -38,6 +36,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
 	"github.com/googleapis/gnostic/compiler"
+	"github.com/munnerz/goautoneg"
 
 	"k8s.io/kube-openapi/pkg/builder"
 	"k8s.io/kube-openapi/pkg/common"


### PR DESCRIPTION
Move to github.com/munnerz/goautoneg as bitbucket is flaky!

Change-Id: I1c63240a4985b9e4ae33d23af929657d44f356a0