### PR TITLE
travis: fix hg SSL issue by using Ubuntu LTS 16.04 Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
+dist: xenial
 language: go
 go_import_path: k8s.io/kube-openapi
 script: go test ./pkg/... ./test/...
-


### PR DESCRIPTION
`go get` failed in travis because of tls issues with the old Debian image in travis.