### PR TITLE
schemaconv: Make RawExtension into an untyped atomic scalar

### DIFF
--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -98,6 +98,13 @@ func (c *convert) insertTypeDef(name string, model proto.Schema) {
 func (c *convert) makeRef(model proto.Schema) schema.TypeRef {
 	var tr schema.TypeRef
 	if r, ok := model.(*proto.Ref); ok {
+		if r.Reference() == "io.k8s.apimachinery.pkg.runtime.RawExtension" {
+			return schema.TypeRef{
+				Inlined: schema.Atom{
+					Untyped: &schema.Untyped{},
+				},
+			}
+		}
 		// reference a named type
 		_, n := path.Split(r.Reference())
 		tr.NamedType = &n

--- a/pkg/schemaconv/testdata/new-schema.yaml
+++ b/pkg/schemaconv/testdata/new-schema.yaml
@@ -229,7 +229,7 @@ types:
         scalar: string
     - name: data
       type:
-        namedType: io.k8s.apimachinery.pkg.runtime.RawExtension
+        untyped: {}
     - name: kind
       type:
         scalar: string
@@ -753,7 +753,7 @@ types:
         scalar: string
     - name: data
       type:
-        namedType: io.k8s.apimachinery.pkg.runtime.RawExtension
+        untyped: {}
     - name: kind
       type:
         scalar: string
@@ -1124,7 +1124,7 @@ types:
         scalar: string
     - name: data
       type:
-        namedType: io.k8s.apimachinery.pkg.runtime.RawExtension
+        untyped: {}
     - name: kind
       type:
         scalar: string
@@ -9901,7 +9901,7 @@ types:
     fields:
     - name: object
       type:
-        namedType: io.k8s.apimachinery.pkg.runtime.RawExtension
+        untyped: {}
     - name: type
       type:
         scalar: string


### PR DESCRIPTION
Because of how RawExtension is built, the schema we generate is slightly confused when we see them in real-life. Make them untyped since there is not much we can do right now.