### PR TITLE
aggregator: fix and extend mutating walker tests

### DIFF
--- a/pkg/aggregator/mutating_walker_test.go
+++ b/pkg/aggregator/mutating_walker_test.go
@@ -88,6 +88,20 @@ func fuzzFuncs(f *fuzz.Fuzzer, refFunc func(ref *spec.Ref, c fuzz.Continue, visi
 			c.Fuzz(&s.Definitions)
 			c.Fuzz(&s.Paths)
 		},
+		func(p *spec.PathItem, c fuzz.Continue) {
+			enter(p, false, c)
+			defer leave(false)
+
+			// only fuzz those fields we walk into with invisible==false
+			c.Fuzz(&p.Parameters)
+			c.Fuzz(&p.Delete)
+			c.Fuzz(&p.Get)
+			c.Fuzz(&p.Head)
+			c.Fuzz(&p.Options)
+			c.Fuzz(&p.Patch)
+			c.Fuzz(&p.Post)
+			c.Fuzz(&p.Put)
+		},
 		func(p *spec.Parameter, c fuzz.Continue) {
 			enter(p, false, c)
 			defer leave(false)

--- a/pkg/aggregator/mutating_walker_test.go
+++ b/pkg/aggregator/mutating_walker_test.go
@@ -128,15 +128,19 @@ func TestReplaceReferences(t *testing.T) {
 			//seed = int64(1548953540354558000)
 			f.RandSource(rand.New(rand.NewSource(seed)))
 
+			visibleRefsNum := 0
+			invisibleRefsNum := 0
 			fuzzFuncs(f,
 				func(ref *spec.Ref, c fuzz.Continue, visible bool) {
 					var url string
 					if visible {
 						// this is a ref that is seen by the walker (we have some exceptions where we don't walk into)
-						url = fmt.Sprintf("http://ref-%d", visibleRefs.Len())
+						url = fmt.Sprintf("http://ref-%d", visibleRefsNum)
+						visibleRefsNum++
 					} else {
 						// this is a ref that is not seen by the walker (we have some exceptions where we don't walk into)
-						url = fmt.Sprintf("http://invisible-%d", invisibleRefs.Len())
+						url = fmt.Sprintf("http://invisible-%d", invisibleRefsNum)
+						invisibleRefsNum++
 					}
 
 					r, err := spec.NewRef(url)


### PR DESCRIPTION
- fix mutating ref numbering
- implement max depth fuzzing logic
- test mutated subsets, not only one ref at a time