### PR TITLE
generator: make output roundtrippable

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -562,7 +562,7 @@ func (g openAPITypeWriter) generateMapProperty(t *types.Type) error {
 		return fmt.Errorf("map with non-string keys are not supported by OpenAPI in %v", t)
 	}
 	g.Do("Type: []string{\"object\"},\n", nil)
-	g.Do("AdditionalProperties: &spec.SchemaOrBool{\nSchema: &spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
+	g.Do("AdditionalProperties: &spec.SchemaOrBool{\nAllows: true,\nSchema: &spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
 	typeString, format := openapi.GetOpenAPITypeFormat(elemType.String())
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -409,7 +409,7 @@ func (g openAPITypeWriter) emitExtensions(extensions []extension) {
 	for _, extension := range extensions {
 		g.Do("\"$.$\": ", extension.xName)
 		if extension.hasMultipleValues() {
-			g.Do("[]string{\n", nil)
+			g.Do("[]interface{}{\n", nil)
 		}
 		for _, value := range extension.values {
 			g.Do("\"$.$\",\n", value)

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -363,13 +363,14 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			return err
 		}
 		g.Do("},\n", nil)
-		g.Do("Dependencies: []string{\n", args)
+
 		// Map order is undefined, sort them or we may get a different file generated each time.
 		keys := []string{}
 		for k := range g.refTypes {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
+		deps := []string{}
 		for _, k := range keys {
 			v := g.refTypes[k]
 			if t, _ := openapi.GetOpenAPITypeFormat(v.String()); t != "" {
@@ -377,9 +378,16 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 				// Will eliminate special case of time.Time
 				continue
 			}
-			g.Do("\"$.$\",", k)
+			deps = append(deps, k)
 		}
-		g.Do("},\n}\n}\n\n", nil)
+		if len(deps) > 0 {
+			g.Do("Dependencies: []string{\n", args)
+			for _, k := range deps {
+				g.Do("\"$.$\",", k)
+			}
+			g.Do("},\n", nil)
+		}
+		g.Do("}\n}\n\n", nil)
 	}
 	return nil
 }

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -71,11 +71,11 @@ func testOpenAPITypeWriter(t *testing.T, code string) (error, error, *assert.Ass
 
 	callBuffer := &bytes.Buffer{}
 	callSW := generator.NewSnippetWriter(callBuffer, context, "$", "$")
-	callError := newOpenAPITypeWriter(callSW).generateCall(blahT)
+	callError := newOpenAPITypeWriter(callSW, context).generateCall(blahT)
 
 	funcBuffer := &bytes.Buffer{}
 	funcSW := generator.NewSnippetWriter(funcBuffer, context, "$", "$")
-	funcError := newOpenAPITypeWriter(funcSW).generate(blahT)
+	funcError := newOpenAPITypeWriter(funcSW, context).generate(blahT)
 
 	return callError, funcError, assert, callBuffer, funcBuffer
 }
@@ -308,6 +308,36 @@ Extensions: spec.Extensions{
 },
 },
 Dependencies: []string{
+},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestEmptyProperties(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah demonstrate a struct without fields.
+type Blah struct {
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct without fields.",
+Type: []string{"object"},
+},
 },
 }
 }

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -307,8 +307,6 @@ Extensions: spec.Extensions{
 },
 },
 },
-Dependencies: []string{
-},
 }
 }
 
@@ -581,8 +579,6 @@ Extensions: spec.Extensions{
 },
 },
 },
-Dependencies: []string{
-},
 }
 }
 
@@ -650,8 +646,6 @@ Extensions: spec.Extensions{
 "x-kubernetes-type-tag": "type_test",
 },
 },
-},
-Dependencies: []string{
 },
 }
 }

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -591,7 +591,7 @@ Properties: map[string]spec.Schema{
 "WithListField": {
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{
-"x-kubernetes-list-map-keys": []string{
+"x-kubernetes-list-map-keys": []interface{}{
 "port",
 "protocol",
 },

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -472,6 +472,7 @@ SchemaProps: spec.SchemaProps{
 Description: "A map pointer",
 Type: []string{"object"},
 AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
 Type: []string{"string"},


### PR DESCRIPTION
- Extension values are JSON data. `[]string` is not a valid type therefore (only `[]interface{}` is for slices). The `[]string` objects did not roundtrip.
- If `SchemaOrBool.Schema` is non-nil, `Allows` does not matter (both variants are semantically equivalent). But for roundtrip checks it's helpful to set `Allows` to `true` because `SchemaOrBool.UnmarshalJSON` does the same.
- don't create empty `Properties` fields.