### PR TITLE
Add analysis of pkg/util/proto/validator

### DIFF
--- a/pkg/util/proto/document.go
+++ b/pkg/util/proto/document.go
@@ -92,13 +92,16 @@ func NewOpenAPIData(doc *openapi_v2.Document) (Models, error) {
 // We believe the schema is a reference, verify that and returns a new
 // Schema
 func (d *Definitions) parseReference(s *openapi_v2.Schema, path *Path) (Schema, error) {
+	// TODO(wrong): a schema with a $ref can have properties. We can ignore them (would be incomplete), but we cannot return an error.
 	if len(s.GetProperties().GetAdditionalProperties()) > 0 {
 		return nil, newSchemaError(path, "unallowed embedded type definition")
 	}
+	// TODO(wrong): a schema with a $ref can have a type. We can ignore it (would be incomplete), but we cannot return an error.
 	if len(s.GetType().GetValue()) > 0 {
 		return nil, newSchemaError(path, "definition reference can't have a type")
 	}
 
+	// TODO(wrong): $refs outside of the definitions are completely valid. We can ignore them (would be incomplete), but we cannot return an error.
 	if !strings.HasPrefix(s.GetXRef(), "#/definitions/") {
 		return nil, newSchemaError(path, "unallowed reference to non-definition %q", s.GetXRef())
 	}
@@ -127,6 +130,7 @@ func (d *Definitions) parseMap(s *openapi_v2.Schema, path *Path) (Schema, error)
 		return nil, newSchemaError(path, "invalid object type")
 	}
 	var sub Schema
+	// TODO(incomplete): this misses the boolean case as AdditionalProperties is a bool+schema sum type.
 	if s.GetAdditionalProperties().GetSchema() == nil {
 		sub = &Arbitrary{
 			BaseSchema: d.parseBaseSchema(s, path),
@@ -157,6 +161,7 @@ func (d *Definitions) parsePrimitive(s *openapi_v2.Schema, path *Path) (Schema, 
 	case Number: // do nothing
 	case Integer: // do nothing
 	case Boolean: // do nothing
+	// TODO(wrong): this misses "null". Would skip the null case (would be incomplete), but we cannot return an error.
 	default:
 		return nil, newSchemaError(path, "Unknown primitive type: %q", t)
 	}
@@ -175,6 +180,7 @@ func (d *Definitions) parseArray(s *openapi_v2.Schema, path *Path) (Schema, erro
 		return nil, newSchemaError(path, `array should have type "array"`)
 	}
 	if len(s.GetItems().GetSchema()) != 1 {
+		// TODO(wrong): Items can have multiple elements. We can ignore Items then (would be incomplete), but we cannot return an error.
 		return nil, newSchemaError(path, "array should have exactly one sub-item")
 	}
 	sub, err := d.ParseSchema(s.GetItems().GetSchema()[0], path)
@@ -227,6 +233,8 @@ func (d *Definitions) parseArbitrary(s *openapi_v2.Schema, path *Path) (Schema, 
 // this function is public, it doesn't leak through the interface.
 func (d *Definitions) ParseSchema(s *openapi_v2.Schema, path *Path) (Schema, error) {
 	if s.GetXRef() != "" {
+		// TODO(incomplete): ignoring the rest of s is wrong. As long as there are no conflict, everything from s must be considered
+		// Reference: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#path-item-object
 		return d.parseReference(s, path)
 	}
 	objectTypes := s.GetType().GetValue()
@@ -234,11 +242,15 @@ func (d *Definitions) ParseSchema(s *openapi_v2.Schema, path *Path) (Schema, err
 	case 0:
 		// in the OpenAPI schema served by older k8s versions, object definitions created from structs did not include
 		// the type:object property (they only included the "properties" property), so we need to handle this case
+		// TODO: validate that we ever published empty, non-nil properties. JSON roundtripping nils them.
 		if s.GetProperties() != nil {
+			// TODO(wrong): when verifying a non-object later against this, it will be rejected as invalid type.
+			// TODO(CRD validation schema publishing): we have to filter properties (empty or not) if type=object is not given
 			return d.parseKind(s, path)
 		} else {
 			// Definition has no type and no properties. Treat it as an arbitrary value
-			// TODO: what if it has additionalProperties or patternProperties?
+			// TODO(incomplete): what if it has additionalProperties=false or patternProperties?
+			// ANSWER: parseArbitrary is less strict than it has to be with patternProperties (which is ignored). So this is correct (of course not complete).
 			return d.parseArbitrary(s, path)
 		}
 	case 1:
@@ -256,6 +268,8 @@ func (d *Definitions) ParseSchema(s *openapi_v2.Schema, path *Path) (Schema, err
 		return d.parsePrimitive(s, path)
 	default:
 		// the OpenAPI generator never generates (nor it ever did in the past) OpenAPI type definitions with multiple types
+		// TODO(wrong): this is rejecting a completely valid OpenAPI spec
+		// TODO(CRD validation schema publishing): filter these out
 		return nil, newSchemaError(path, "definitions with multiple types aren't supported")
 	}
 }

--- a/pkg/util/proto/document.go
+++ b/pkg/util/proto/document.go
@@ -181,6 +181,7 @@ func (d *Definitions) parseArray(s *openapi_v2.Schema, path *Path) (Schema, erro
 	}
 	if len(s.GetItems().GetSchema()) != 1 {
 		// TODO(wrong): Items can have multiple elements. We can ignore Items then (would be incomplete), but we cannot return an error.
+		// TODO(wrong): "type: array" witohut any items at all is completely valid.
 		return nil, newSchemaError(path, "array should have exactly one sub-item")
 	}
 	sub, err := d.ParseSchema(s.GetItems().GetSchema()[0], path)

--- a/pkg/util/proto/validation/types.go
+++ b/pkg/util/proto/validation/types.go
@@ -216,6 +216,7 @@ func (item *primitiveItem) VisitPrimitive(schema *proto.Primitive) {
 	case proto.String:
 		return
 	}
+	// TODO(wrong): this misses "null"
 
 	item.AddValidationError(InvalidTypeError{Path: schema.GetPath().String(), Expected: schema.Type, Actual: item.Kind})
 }


### PR DESCRIPTION
The OpenAPI validator used in kubectl is full of wrong assumptions. We cannot reject OpenAPI spec features because openapi-gen does not generate them. Other providers (other aggregated apiservers, CRDs) can make use of them.

As general rule of thumb, we have to apply: we can ignore features, making us incomplete (which we are anyway because we do not check for many/most OpenAPI features), but keeping us correct. But we cannot return errors for features we do not understand.

tl/dr: less strict validation is fine.

This PR add analysis comments of the following shape:

- `TODO(wrong)`: here the validation is returning errors which aren't errors according to the OpenAPI standard.
- `TODO(incomplete)`: here the valiation could return an error, but doesn't.

The first class is critical and we should get rid of them ASAP. The second class is cosmetics, no need for action.

Note: As we support one version of skew between master and kubectl, we have to generate reduced (= stripped) CRD validation schemata for at least one master version such that existing, old kubectl will not fall over.