### PR TITLE
cmd/openapi-gen: be silent on success

### DIFF
--- a/cmd/openapi-gen/openapi-gen.go
+++ b/cmd/openapi-gen/openapi-gen.go
@@ -54,5 +54,4 @@ func main() {
 	); err != nil {
 		log.Fatalf("OpenAPI code generation error: %v", err)
 	}
-	log.Println("Code for OpenAPI definitions generated")
 }


### PR DESCRIPTION
This logging line isn't particularly useful; it's just noise during the build.