### PR TITLE
handler: convert int types correctly like yaml2 does and gnostic expects

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -27,14 +27,14 @@ import (
 	"time"
 
 	"github.com/NYTimes/gziphandler"
-	restful "github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful"
 	"github.com/go-openapi/spec"
 	"github.com/golang/protobuf/proto"
-	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
+	"github.com/googleapis/gnostic/OpenAPIv2"
 	"github.com/googleapis/gnostic/compiler"
 	"github.com/json-iterator/go"
 	"github.com/munnerz/goautoneg"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"k8s.io/kube-openapi/pkg/builder"
 	"k8s.io/kube-openapi/pkg/common"
@@ -159,6 +159,23 @@ func jsonToYAMLValue(j interface{}) interface{} {
 			ret[i] = jsonToYAMLValue(j[i])
 		}
 		return ret
+	case float64:
+		// replicate the logic in https://github.com/go-yaml/yaml/blob/51d6538a90f86fe93ac480b35f37b2be17fef232/resolve.go#L151
+		if i64 := int64(j); j == float64(i64) {
+			if i := int(i64); i64 == int64(i) {
+				return i
+			}
+			return i64
+		}
+		if ui64 := uint64(j); j == float64(ui64) {
+			return ui64
+		}
+		return j
+	case int64:
+		if i := int(j); j == int64(i) {
+			return i
+		}
+		return j
 	}
 	return j
 }


### PR DESCRIPTION
Json always unmarshals to float64, yaml2 does best effort down-sizing of the returned numbers, returning int, int64, uint64 or float64. Gnostic expects the later.