### PR TITLE
Add parsing of openapi oneof/union semantic into smd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,5 +33,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.1
 	k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6
 	k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92
-	sigs.k8s.io/structured-merge-diff v0.0.0-20190416230737-b2ed7e1d99f6
+	sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65
 )

--- a/go.sum
+++ b/go.sum
@@ -60,5 +60,5 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6 h1:4s3/R4+OYYYUKptXPhZKjQ04WJ6Eh
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92 h1:PgoMI/L1Nu5Vmvgm+vGheLuxKST8h6FMOqggyAFtHPc=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190416230737-b2ed7e1d99f6 h1:HxGn4yiP+T5dFdwGo2WX/Jsi3OAjSuSkFLF/7QsshxI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190416230737-b2ed7e1d99f6/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
+sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65 h1:xJNnO2qzHtgVCSPoGkkltSpyEX7D7IJw1TmbE3G/7lY=
+sigs.k8s.io/structured-merge-diff v0.0.0-20190426204423-ea680f03cc65/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/schemaconv/testdata/new-schema.yaml
+++ b/pkg/schemaconv/testdata/new-schema.yaml
@@ -929,6 +929,11 @@ types:
     - name: type
       type:
         scalar: string
+    unions:
+    - discriminator: type
+      fields:
+      - fieldName: rollingUpdate
+        discriminatedBy: RollingUpdate
 - name: io.k8s.api.apps.v1beta1.RollbackConfig
   struct:
     fields:
@@ -6621,6 +6626,62 @@ types:
     - name: vsphereVolume
       type:
         namedType: io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource
+    unions:
+    - fields:
+      - fieldName: awsElasticBlockStore
+        discriminatedBy: AWSElasticBlockStore
+      - fieldName: azureDisk
+        discriminatedBy: AzureDisk
+      - fieldName: azureFile
+        discriminatedBy: AzureFile
+      - fieldName: cephfs
+        discriminatedBy: CephFS
+      - fieldName: cinder
+        discriminatedBy: Cinder
+      - fieldName: configMap
+        discriminatedBy: ConfigMap
+      - fieldName: downwardAPI
+        discriminatedBy: DownwardAPI
+      - fieldName: emptyDir
+        discriminatedBy: EmptyDir
+      - fieldName: fc
+        discriminatedBy: FC
+      - fieldName: flexVolume
+        discriminatedBy: FlexVolume
+      - fieldName: flocker
+        discriminatedBy: Flocker
+      - fieldName: gcePersistentDisk
+        discriminatedBy: GCEPersistentDisk
+      - fieldName: gitRepo
+        discriminatedBy: GitRepo
+      - fieldName: glusterfs
+        discriminatedBy: Glusterfs
+      - fieldName: hostPath
+        discriminatedBy: HostPath
+      - fieldName: iscsi
+        discriminatedBy: ISCSI
+      - fieldName: nfs
+        discriminatedBy: NFS
+      - fieldName: persistentVolumeClaim
+        discriminatedBy: PersistentVolumeClaim
+      - fieldName: photonPersistentDisk
+        discriminatedBy: PhotonPersistentDisk
+      - fieldName: portworxVolume
+        discriminatedBy: PortworxVolume
+      - fieldName: projected
+        discriminatedBy: Projected
+      - fieldName: quobyte
+        discriminatedBy: Quobyte
+      - fieldName: rbd
+        discriminatedBy: RBD
+      - fieldName: scaleIO
+        discriminatedBy: ScaleIO
+      - fieldName: secret
+        discriminatedBy: Secret
+      - fieldName: storageos
+        discriminatedBy: StorageOS
+      - fieldName: vsphereVolume
+        discriminatedBy: VsphereVolume
 - name: io.k8s.api.core.v1.VolumeDevice
   struct:
     fields:

--- a/pkg/schemaconv/testdata/swagger.json
+++ b/pkg/schemaconv/testdata/swagger.json
@@ -78578,6 +78578,12 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentStrategy": {
     "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "x-kubernetes-unions": [{
+     "discriminator": "type",
+     "fields-discriminated": {
+      "rollingUpdate": "RollingUpdate"
+     }
+    }],
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -87522,6 +87528,37 @@
    },
    "io.k8s.api.core.v1.Volume": {
     "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+    "x-kubernetes-unions": [{
+     "fields-discriminated": {
+      "awsElasticBlockStore": "AWSElasticBlockStore",
+      "azureDisk": "AzureDisk",
+      "azureFile": "AzureFile",
+      "cephfs": "CephFS",
+      "cinder": "Cinder",
+      "configMap": "ConfigMap",
+      "downwardAPI": "DownwardAPI",
+      "emptyDir": "EmptyDir",
+      "fc": "FC",
+      "flexVolume": "FlexVolume",
+      "flocker": "Flocker",
+      "gcePersistentDisk": "GCEPersistentDisk",
+      "gitRepo": "GitRepo",
+      "glusterfs": "Glusterfs",
+      "hostPath": "HostPath",
+      "iscsi": "ISCSI",
+      "nfs": "NFS",
+      "persistentVolumeClaim": "PersistentVolumeClaim",
+      "photonPersistentDisk": "PhotonPersistentDisk",
+      "portworxVolume": "PortworxVolume",
+      "projected": "Projected",
+      "quobyte": "Quobyte",
+      "rbd": "RBD",
+      "scaleIO": "ScaleIO",
+      "secret": "Secret",
+      "storageos": "StorageOS",
+      "vsphereVolume": "VsphereVolume"
+     }
+    }],
     "required": [
      "name"
     ],


### PR DESCRIPTION
Implements first part of https://github.com/kubernetes/enhancements/pull/926.
We still need to change the OpenAPI generation to add these extensions.