### PR TITLE
Remove constraint on discriminator type

### DIFF
--- a/pkg/generators/union.go
+++ b/pkg/generators/union.go
@@ -161,10 +161,6 @@ func parseUnionStruct(t *types.Type) (*union, []error) {
 			continue
 		}
 		if types.ExtractCommentTags("+", m.CommentLines)[tagUnionDiscriminator] != nil {
-			if m.Type.String() != "string" && m.Type.String() != "*string" {
-				errors = append(errors, fmt.Errorf("discriminator (%v.%v) must be of type string (or *string)", t.Name, m.Name))
-				continue
-			}
 			errors = append(errors, u.setDiscriminator(jsonName)...)
 		} else {
 			if !hasOptionalTag(&m) {

--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -266,6 +266,8 @@ func (c *convert) VisitKind(k *proto.Kind) {
 		c.reportError(err.Error())
 		return
 	}
+	// TODO: We should check that the fields and discriminator
+	// specified in the union are actual fields in the struct.
 	a.Struct.Unions = unions
 
 	// TODO: Get element relationship when we start adding it to the spec.


### PR DESCRIPTION
This constraint doesn't work because discriminator are often defined as
a type alias to a string.