### PR TITLE
util/proto: ignore uninterpreted OpenAPI features instead of rejecting

### DIFF
--- a/pkg/util/proto/document.go
+++ b/pkg/util/proto/document.go
@@ -161,7 +161,7 @@ func (d *Definitions) parsePrimitive(s *openapi_v2.Schema, path *Path) (Schema, 
 	case Number: // do nothing
 	case Integer: // do nothing
 	case Boolean: // do nothing
-	// TODO(wrong): this misses "null". Would skip the null case (would be incomplete), but we cannot return an error.
+	case Null: // do nothing
 	default:
 		return nil, newSchemaError(path, "Unknown primitive type: %q", t)
 	}

--- a/pkg/util/proto/document.go
+++ b/pkg/util/proto/document.go
@@ -92,16 +92,8 @@ func NewOpenAPIData(doc *openapi_v2.Document) (Models, error) {
 // We believe the schema is a reference, verify that and returns a new
 // Schema
 func (d *Definitions) parseReference(s *openapi_v2.Schema, path *Path) (Schema, error) {
-	// TODO(wrong): a schema with a $ref can have properties. We can ignore them (would be incomplete), but we cannot return an error.
-	if len(s.GetProperties().GetAdditionalProperties()) > 0 {
-		return nil, newSchemaError(path, "unallowed embedded type definition")
-	}
-	// TODO(wrong): a schema with a $ref can have a type. We can ignore it (would be incomplete), but we cannot return an error.
-	if len(s.GetType().GetValue()) > 0 {
-		return nil, newSchemaError(path, "definition reference can't have a type")
-	}
-
-	// TODO(wrong): $refs outside of the definitions are completely valid. We can ignore them (would be incomplete), but we cannot return an error.
+	// $refs outside of the definitions are valid, but we don't support them in the whole stack,
+	// hence, reject them here.
 	if !strings.HasPrefix(s.GetXRef(), "#/definitions/") {
 		return nil, newSchemaError(path, "unallowed reference to non-definition %q", s.GetXRef())
 	}
@@ -179,19 +171,18 @@ func (d *Definitions) parseArray(s *openapi_v2.Schema, path *Path) (Schema, erro
 	if s.GetType().GetValue()[0] != array {
 		return nil, newSchemaError(path, `array should have type "array"`)
 	}
-	if len(s.GetItems().GetSchema()) != 1 {
-		// TODO(wrong): Items can have multiple elements. We can ignore Items then (would be incomplete), but we cannot return an error.
-		// TODO(wrong): "type: array" witohut any items at all is completely valid.
-		return nil, newSchemaError(path, "array should have exactly one sub-item")
-	}
-	sub, err := d.ParseSchema(s.GetItems().GetSchema()[0], path)
-	if err != nil {
-		return nil, err
-	}
-	return &Array{
+	ret := &Array{
 		BaseSchema: d.parseBaseSchema(s, path),
-		SubType:    sub,
-	}, nil
+	}
+	// TODO(incomplete): support multiple item schemas
+	if len(s.GetItems().GetSchema()) == 1 {
+		sub, err := d.ParseSchema(s.GetItems().GetSchema()[0], path)
+		if err != nil {
+			return nil, err
+		}
+		ret.SubType = sub
+	}
+	return ret, nil
 }
 
 func (d *Definitions) parseKind(s *openapi_v2.Schema, path *Path) (Schema, error) {
@@ -241,19 +232,11 @@ func (d *Definitions) ParseSchema(s *openapi_v2.Schema, path *Path) (Schema, err
 	objectTypes := s.GetType().GetValue()
 	switch len(objectTypes) {
 	case 0:
-		// in the OpenAPI schema served by older k8s versions, object definitions created from structs did not include
-		// the type:object property (they only included the "properties" property), so we need to handle this case
-		// TODO: validate that we ever published empty, non-nil properties. JSON roundtripping nils them.
-		if s.GetProperties() != nil {
-			// TODO(wrong): when verifying a non-object later against this, it will be rejected as invalid type.
-			// TODO(CRD validation schema publishing): we have to filter properties (empty or not) if type=object is not given
-			return d.parseKind(s, path)
-		} else {
-			// Definition has no type and no properties. Treat it as an arbitrary value
-			// TODO(incomplete): what if it has additionalProperties=false or patternProperties?
-			// ANSWER: parseArbitrary is less strict than it has to be with patternProperties (which is ignored). So this is correct (of course not complete).
-			return d.parseArbitrary(s, path)
-		}
+		// Definition has no type. Treat it as an arbitrary value
+		// TODO(incomplete): this ignores many fields, e.g. properties
+		// TODO(incomplete): what if it has additionalProperties=false or patternProperties?
+		// ANSWER: parseArbitrary is less strict than it has to be with patternProperties (which is ignored). So this is correct (of course not complete).
+		return d.parseArbitrary(s, path)
 	case 1:
 		t := objectTypes[0]
 		switch t {
@@ -268,10 +251,9 @@ func (d *Definitions) ParseSchema(s *openapi_v2.Schema, path *Path) (Schema, err
 		}
 		return d.parsePrimitive(s, path)
 	default:
-		// the OpenAPI generator never generates (nor it ever did in the past) OpenAPI type definitions with multiple types
-		// TODO(wrong): this is rejecting a completely valid OpenAPI spec
-		// TODO(CRD validation schema publishing): filter these out
-		return nil, newSchemaError(path, "definitions with multiple types aren't supported")
+		// Definition has many types. We cannot cope with that. Ignore all of them.
+		// TODO(incomplete): add multi-type support
+		return d.parseArbitrary(s, path)
 	}
 }
 

--- a/pkg/util/proto/openapi.go
+++ b/pkg/util/proto/openapi.go
@@ -28,6 +28,7 @@ const (
 	Number  = "number"
 	String  = "string"
 	Boolean = "boolean"
+	Null    = "null"
 
 	// These types are private as they should never leak, and are
 	// represented by actual structs.

--- a/pkg/util/proto/validation/types.go
+++ b/pkg/util/proto/validation/types.go
@@ -226,7 +226,6 @@ func (item *primitiveItem) VisitPrimitive(schema *proto.Primitive) {
 		}
 		return
 	}
-	// TODO(wrong): this misses "null"
 
 	item.AddValidationError(InvalidTypeError{Path: schema.GetPath().String(), Expected: schema.Type, Actual: item.Kind})
 }

--- a/pkg/util/proto/validation/types.go
+++ b/pkg/util/proto/validation/types.go
@@ -214,6 +214,16 @@ func (item *primitiveItem) VisitPrimitive(schema *proto.Primitive) {
 			return
 		}
 	case proto.String:
+		switch item.Kind {
+		case proto.String:
+			return
+		}
+		return
+	case proto.Null:
+		switch item.Kind {
+		case proto.Null:
+			return
+		}
 		return
 	}
 	// TODO(wrong): this misses "null"
@@ -282,6 +292,12 @@ func itemFactory(path proto.Path, v interface{}) (validationItem, error) {
 			baseItem: baseItem{path: path},
 			Value:    v,
 			Kind:     proto.String,
+		}, nil
+	case reflect.Interface:
+		return &primitiveItem{
+			baseItem: baseItem{path: path},
+			Value:    v,
+			Kind:     proto.Null,
 		}, nil
 	case reflect.Array,
 		reflect.Slice:


### PR DESCRIPTION
This is mostly copied from https://github.com/kubernetes/kube-openapi/pull/147. Make the proto validator ignores valid OpenAPI features that it doesn't understand instead of rejecting. 

fixes https://github.com/kubernetes/kubernetes/pull/78326

tested locally and verified that the CR didn't get rejected with `array should have exactly one sub-item`: https://github.com/roycaihw/kubernetes/commits/local-test/proto-validator-fix

Note: 
1. I prefer https://github.com/kubernetes/kube-openapi/pull/147 which is more test-complete
2. go mod in k/k lags behind this repo, so updating dependency in k/k will involve multiple commits

/cc @sttts 