### PR TITLE
make travis export GO111MODULE=on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ language: go
 go:
 - "1.12"
 
+env:
+- GO111MODULE=on
+
 go_import_path: k8s.io/kube-openapi
 
 script:
-- GO111MODULE=on go mod tidy && git diff --exit-code
-- GO111MODULE=on go build ./cmd/... ./pkg/...
-- GO111MODULE=on go test ./cmd/... ./pkg/... ./test/...
+- go mod tidy && git diff --exit-code
+- go build ./cmd/... ./pkg/...
+- go test ./cmd/... ./pkg/... ./test/...

--- a/boilerplate/boilerplate.go.txt
+++ b/boilerplate/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/cmd/openapi-gen/args/args.go
+++ b/cmd/openapi-gen/args/args.go
@@ -18,6 +18,7 @@ package args
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
 	"k8s.io/gengo/args"
@@ -38,6 +39,8 @@ func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 	// WithoutDefaultFlagParsing() disables implicit addition of command line flags and parsing,
 	// which allows registering custom arguments afterwards
 	genericArgs := args.Default().WithoutDefaultFlagParsing()
+	genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kube-openapi/boilerplate/boilerplate.go.txt")
+
 	customArgs := &CustomArgs{}
 	genericArgs.CustomArgs = customArgs
 


### PR DESCRIPTION
travis exports `GO111MODULE="auto"` by default in GOPATH. This change overwrites the environment

fixes https://github.com/kubernetes/kube-openapi/issues/163