### PR TITLE
aggregator: fix x-kubernetes-group-version-kinds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,5 @@ require (
 	k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6
 	k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92
 	sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -62,3 +62,5 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92 h1:PgoMI/L1Nu5Vmvgm+vGheLuxKST8h6
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
+sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
+sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -185,78 +185,63 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 			source = FilterSpecByPathsWithoutSideEffects(source, keepPaths)
 		}
 	}
-	// Check for model conflicts
-	conflicts := false
-	for k, v := range source.Definitions {
-		v2, found := dest.Definitions[k]
-		if found && !deepEqualDefinitionsModuloGVKs(&v2, &v) {
-			if !renameModelConflicts {
-				return fmt.Errorf("model name conflict in merging OpenAPI spec: %s", k)
-			}
-			conflicts = true
-			break
-		}
+
+	// Check for model conflicts and rename to make definitions conflict-free (modulo different GVKs)
+	usedNames := map[string]bool{}
+	for k := range dest.Definitions {
+		usedNames[k] = true
 	}
-
-	if conflicts {
-		usedNames := map[string]bool{}
-		for k := range dest.Definitions {
-			usedNames[k] = true
+	renames := map[string]string{}
+DEFINITIONLOOP:
+	for k, v := range source.Definitions {
+		existing, found := dest.Definitions[k]
+		if !found || deepEqualDefinitionsModuloGVKs(&existing, &v) {
+			// skip for now, we copy them after the rename loop
+			continue
 		}
-		renames := map[string]string{}
 
-	OUTERLOOP:
-		for k, v := range source.Definitions {
-			if usedNames[k] {
-				v2, found := dest.Definitions[k]
-				// Reuse model if they are exactly the same.
-				if found && deepEqualDefinitionsModuloGVKs(&v2, &v) {
-					if gvks, found, err := mergedGVKs(&v2, &v); err != nil {
-						return err
-					} else if found {
-						v2.Extensions[gvkKey] = gvks
-					}
-					continue
-				}
+		if !renameModelConflicts {
+			return fmt.Errorf("model name conflict in merging OpenAPI spec: %s", k)
+		}
 
-				// Reuse previously renamed model if one exists
-				var newName string
-				i := 1
-				for found {
-					i++
-					newName = fmt.Sprintf("%s_v%d", k, i)
-					v2, found = dest.Definitions[newName]
-					if found && deepEqualDefinitionsModuloGVKs(&v2, &v) {
-						renames[k] = newName
-						if gvks, found, err := mergedGVKs(&v2, &v); err != nil {
-							return err
-						} else if found {
-							v2.Extensions[gvkKey] = gvks
-						}
-						continue OUTERLOOP
-					}
-				}
-
-				_, foundInSource := source.Definitions[newName]
-				for usedNames[newName] || foundInSource {
-					i++
-					newName = fmt.Sprintf("%s_v%d", k, i)
-					_, foundInSource = source.Definitions[newName]
-				}
+		// Reuse previously renamed model if one exists
+		var newName string
+		i := 1
+		for found {
+			i++
+			newName = fmt.Sprintf("%s_v%d", k, i)
+			existing, found = dest.Definitions[newName]
+			if found && deepEqualDefinitionsModuloGVKs(&existing, &v) {
 				renames[k] = newName
-				usedNames[newName] = true
+				continue DEFINITIONLOOP
 			}
 		}
-		source = renameDefinition(source, renames)
+
+		_, foundInSource := source.Definitions[newName]
+		for usedNames[newName] || foundInSource {
+			i++
+			newName = fmt.Sprintf("%s_v%d", k, i)
+			_, foundInSource = source.Definitions[newName]
+		}
+		renames[k] = newName
+		usedNames[newName] = true
 	}
+	source = renameDefinition(source, renames)
+
+	// now without conflict (modulo different GVKs), copy definitions to dest
 	for k, v := range source.Definitions {
-		if _, found := dest.Definitions[k]; !found {
+		if existing, found := dest.Definitions[k]; !found {
 			if dest.Definitions == nil {
 				dest.Definitions = spec.Definitions{}
 			}
 			dest.Definitions[k] = v
+		} else if merged, changed, err := mergedGVKs(&existing, &v); err != nil {
+			return err
+		} else if changed {
+			existing.Extensions[gvkKey] = merged
 		}
 	}
+
 	// Check for path conflicts
 	for k, v := range source.Paths.Paths {
 		if _, found := dest.Paths.Paths[k]; found {
@@ -268,6 +253,7 @@ func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConf
 		}
 		dest.Paths.Paths[k] = v
 	}
+
 	return nil
 }
 

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -1997,6 +1997,7 @@ func TestMergedGVKs(t *testing.T) {
 	gvk1 := map[string]interface{}{"group": "group1", "version": "v1", "kind": "Foo"}
 	gvk2 := map[string]interface{}{"group": "group2", "version": "v1", "kind": "Bar"}
 	gvk3 := map[string]interface{}{"group": "group3", "version": "v1", "kind": "Abc"}
+	gvk4 := map[string]interface{}{"group": "group4", "version": "v1", "kind": "Abc"}
 
 	tests := []struct {
 		name        string
@@ -2011,6 +2012,8 @@ func TestMergedGVKs(t *testing.T) {
 		{"second only", nil, []interface{}{gvk1, gvk2}, []interface{}{gvk1, gvk2}, true, false},
 		{"both", []interface{}{gvk1, gvk2}, []interface{}{gvk3}, []interface{}{gvk1, gvk2, gvk3}, true, false},
 		{"equal, different order", []interface{}{gvk1, gvk2, gvk3}, []interface{}{gvk3, gvk2, gvk1}, []interface{}{gvk1, gvk2, gvk3}, false, false},
+		{"ordered", []interface{}{gvk3, gvk1, gvk4}, []interface{}{gvk2}, []interface{}{gvk1, gvk2, gvk3, gvk4}, true, false},
+		{"not ordered when not changed", []interface{}{gvk3, gvk1, gvk4}, []interface{}{}, []interface{}{gvk3, gvk1, gvk4}, false, false},
 		{"empty", []interface{}{}, []interface{}{}, []interface{}{}, false, false},
 		{"overlapping", []interface{}{gvk1, gvk2}, []interface{}{gvk2, gvk3}, []interface{}{gvk1, gvk2, gvk3}, true, false},
 		{"first no slice", 42, []interface{}{gvk1}, nil, false, true},

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -24,11 +24,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/go-openapi/spec"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/kube-openapi/pkg/handler"
+	"sigs.k8s.io/yaml"
 )
 
 type DebugSpec struct {
@@ -1325,7 +1325,7 @@ definitions:
 
 func TestSafeMergeSpecsReuseModel(t *testing.T) {
 	var fooSpec, barSpec, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	if err := yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /foo:
@@ -1349,9 +1349,18 @@ definitions:
       id:
         type: "integer"
         format: "int64"
-`), &fooSpec)
+    x-kubernetes-group-version-kind:
+    - group: group1
+      version: v1
+      kind: Foo
+    - group: group3
+      version: v1
+      kind: Foo
+`), &fooSpec); err != nil {
+		t.Fatal(err)
+	}
 
-	yaml.Unmarshal([]byte(`
+	if err := yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /refoo:
@@ -1375,9 +1384,15 @@ definitions:
       id:
         type: "integer"
         format: "int64"
-`), &barSpec)
+    x-kubernetes-group-version-kind:
+    - group: group2
+      version: v1
+      kind: Foo
+`), &barSpec); err != nil {
+		t.Fatal(err)
+	}
 
-	yaml.Unmarshal([]byte(`
+	if err := yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /foo:
@@ -1415,7 +1430,19 @@ definitions:
         id:
           type: "integer"
           format: "int64"
-  `), &expected)
+      x-kubernetes-group-version-kind:
+      - group: group1
+        version: v1
+        kind: Foo
+      - group: group2
+        version: v1
+        kind: Foo
+      - group: group3
+        version: v1
+        kind: Foo
+  `), &expected); err != nil {
+		t.Fatal(err)
+	}
 
 	ast := assert.New(t)
 	orig_barSpec, err := cloneSpec(barSpec)


### PR DESCRIPTION
When there was no definition schema conflict, we did not merge the `x-kubernetes-group-version-kind` lists. The PR fixes that.