### PR TITLE
Handle x-kubernetes-preserve-unknown-fields correctly in schemaconv

### DIFF
--- a/pkg/schemaconv/testdata/new-schema.yaml
+++ b/pkg/schemaconv/testdata/new-schema.yaml
@@ -10258,3 +10258,13 @@ types:
     elementType:
       namedType: __untyped_atomic_
     elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable


### PR DESCRIPTION
This is necessary for https://github.com/kubernetes/kubernetes/pull/77354

If we are converting a schema for a CRD that supports field pruning at the top level, then any structs recursively below a field with `x-kubernetes-preserve-unknown-fields` need to allow unknown fields (as map items), otherwise ownership will not be tracked for those items and they would fail validation on apply.

If the CRD does not supports field pruning then we should treat every struct in the schema as having `x-kubernetes-preserve-unknown-fields`