### PR TITLE
Add limited support for map[string]map[string]xxx

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -647,27 +647,17 @@ func (g openAPITypeWriter) generateMapProperty(t *types.Type) error {
 	case types.Struct:
 		g.generateReferenceProperty(elemType)
 	case types.Slice, types.Array:
-		g.generateSliceProperty(elemType)
+		if err := g.generateSliceProperty(elemType); err != nil {
+			return err
+		}
 	case types.Map:
-		g.generateSubMapLimitedSupport(t.Name, elemType)
+		if err := g.generateMapProperty(elemType); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("map Element kind %v is not supported in %v", elemType.Kind, t.Name)
 	}
 	g.Do("},\n},\n},\n", nil)
-	return nil
-}
-
-func (g openAPITypeWriter) generateSubMapLimitedSupport(parentName types.Name, t *types.Type) error {
-	keyType := resolveAliasAndPtrType(t.Key)
-	elemType := resolveAliasAndPtrType(t.Elem)
-
-	// According to OpenAPI examples, only map from string is supported
-	if keyType.Name.Name != "string" {
-		return fmt.Errorf("map with non-string keys are not supported by OpenAPI in %v", t)
-	}
-	g.Do(fmt.Sprintf("// limited support by openapi-gen\n"), nil)
-	g.Do(fmt.Sprintf("//    name: %v\n", parentName.Name), nil)
-	g.Do(fmt.Sprintf("//    type: map[string]map[string]%v\n", elemType), nil)
 	return nil
 }
 
@@ -687,7 +677,13 @@ func (g openAPITypeWriter) generateSliceProperty(t *types.Type) error {
 	case types.Struct:
 		g.generateReferenceProperty(elemType)
 	case types.Slice, types.Array:
-		g.generateSliceProperty(elemType)
+		if err := g.generateSliceProperty(elemType); err != nil {
+			return err
+		}
+	case types.Map:
+		if err := g.generateMapProperty(elemType); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("slice Element kind %v is not supported in %v", elemType.Kind, t)
 	}

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -343,7 +343,7 @@ Type: []string{"object"},
 `, funcBuffer.String())
 }
 
-func TestFailingSample1(t *testing.T) {
+func TestNestedMapString(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
@@ -376,9 +376,16 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-// limited support by openapi-gen
-//    name: map[string]map[string]string
-//    type: map[string]map[string]string
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"string"},
+Format: "",
+},
+},
+},
 },
 },
 },
@@ -392,6 +399,137 @@ Required: []string{"StringToArray"},
 }
 
 `, funcBuffer.String())
+}
+
+func TestNestedMapInt(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Map sample tests openAPIGen.generateMapProperty method.
+type Blah struct {
+	// A sample String to String map
+	StringToArray map[string]map[string]int
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Map sample tests openAPIGen.generateMapProperty method.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"StringToArray": {
+SchemaProps: spec.SchemaProps{
+Description: "A sample String to String map",
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"integer"},
+Format: "int32",
+},
+},
+},
+},
+},
+},
+},
+},
+},
+Required: []string{"StringToArray"},
+},
+},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestNestedMapBoolean(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Map sample tests openAPIGen.generateMapProperty method.
+type Blah struct {
+	// A sample String to String map
+	StringToArray map[string]map[string]bool
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Map sample tests openAPIGen.generateMapProperty method.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"StringToArray": {
+SchemaProps: spec.SchemaProps{
+Description: "A sample String to String map",
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"boolean"},
+Format: "",
+},
+},
+},
+},
+},
+},
+},
+},
+},
+Required: []string{"StringToArray"},
+},
+},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestFailingSample1(t *testing.T) {
+	_, funcErr, assert, _, _ := testOpenAPITypeWriter(t, `
+package foo
+
+// Map sample tests openAPIGen.generateMapProperty method.
+type Blah struct {
+	// A sample String to String map
+	StringToArray map[string]map[string]map[int]string
+}
+	`)
+	if assert.Error(funcErr, "An error was expected") {
+		assert.Equal(funcErr, fmt.Errorf("map with non-string keys are not supported by OpenAPI in map[int]string"))
+	}
 }
 
 func TestFailingSample2(t *testing.T) {
@@ -728,6 +866,77 @@ Format: "int64",
 },
 },
 Required: []string{"NestedList"},
+},
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"x-kubernetes-type-tag": "type_test",
+},
+},
+},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestNestListOfMaps(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah is a test.
+// +k8s:openapi-gen=true
+// +k8s:openapi-gen=x-kubernetes-type-tag:type_test
+type Blah struct {
+	// Nested list of maps
+	NestedListOfMaps [][]map[string]string
+}
+`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Blah is a test.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"NestedListOfMaps": {
+SchemaProps: spec.SchemaProps{
+Description: "Nested list of maps",
+Type: []string{"array"},
+Items: &spec.SchemaOrArray{
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"array"},
+Items: &spec.SchemaOrArray{
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+},
+},
+},
+},
+},
+},
+},
+},
+},
+Required: []string{"NestedListOfMaps"},
 },
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -344,7 +344,7 @@ Type: []string{"object"},
 }
 
 func TestFailingSample1(t *testing.T) {
-	_, funcErr, assert, _, _ := testOpenAPITypeWriter(t, `
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
 // Map sample tests openAPIGen.generateMapProperty method.
@@ -353,9 +353,45 @@ type Blah struct {
 	StringToArray map[string]map[string]string
 }
 	`)
-	if assert.Error(funcErr, "An error was expected") {
-		assert.Equal(funcErr, fmt.Errorf("map Element kind Map is not supported in map[string]map[string]string"))
+	if callErr != nil {
+		t.Fatal(callErr)
 	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Map sample tests openAPIGen.generateMapProperty method.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"StringToArray": {
+SchemaProps: spec.SchemaProps{
+Description: "A sample String to String map",
+Type: []string{"object"},
+AdditionalProperties: &spec.SchemaOrBool{
+Allows: true,
+Schema: &spec.Schema{
+SchemaProps: spec.SchemaProps{
+// limited support by openapi-gen
+//    name: map[string]map[string]string
+//    type: map[string]map[string]string
+},
+},
+},
+},
+},
+},
+Required: []string{"StringToArray"},
+},
+},
+}
+}
+
+`, funcBuffer.String())
 }
 
 func TestFailingSample2(t *testing.T) {


### PR DESCRIPTION
The goal of this PR is to get openapi-gen to handle map[string]map[string]xxx in a similar way controller-gen supports it for the schema definition within the CRD.yaml and for the deep copy operation.
 
with this PR, openapi-gen start to support the construct:

```bash
openapi-gen -i "k8s.io/apimachinery/pkg/apis/meta/v1,github.com/keleustes/armada-crd/pkg/apis/armada/v1alpha1"   -o pkg   -p generated   -O openapi_generated   -r ./swagger/golden.report
```

```go
                                        "labels": {
                                                SchemaProps: spec.SchemaProps{
                                                        Description: "labels contains tbd",
                                                        Type:        []string{"object"},
                                                        AdditionalProperties: &spec.SchemaOrBool{
                                                                Allows: true,
                                                                Schema: &spec.Schema{
                                                                        SchemaProps: spec.SchemaProps{
                                                                                // limited support by openapi-gen
                                                                                //    name: map[string]github.com/keleustes/armada-crd/pkg/apis/armada/v1alpha1.ArmadaMapString
                                                                                //    type: map[string]map[string]string
                                                                        },
                                                                },
                                                        },
                                                },
                                        },

```
controller-gen seems to be able to deal with map[string]map[string]string construct

When generating the CRD.yaml with schema:
```bash
GO111MODULE=on controller-gen crd paths=./pkg/apis/armada/... crd:trivialVersions=true output:crd:dir=./kubectl output:none
```

```yaml
                labels:
                  additionalProperties:
                    additionalProperties:
                      type: string
                    type: object
                  description: labels contains tbd
                  type: object
```

controller-gen is able to deal deep-copy

```bash
GO111MODULE=on controller-gen object paths=./pkg/apis/armada/... output:object:dir=./pkg/apis/armada/v1alpha1 output:none
```

```go
        if in.Labels != nil {
                in, out := &in.Labels, &out.Labels
                *out = new(map[string]ArmadaMapString)
                if **in != nil {
                        in, out := *in, *out
                        *out = make(map[string]ArmadaMapString, len(*in))
                        for key, val := range *in {
                                var outVal map[string]string
                                if val == nil {
                                        (*out)[key] = nil
                                } else {
                                        in, out := &val, &outVal
                                        *out = make(ArmadaMapString, len(*in))
                                        for key, val := range *in {
                                                (*out)[key] = val
                                        }
                                }
                                (*out)[key] = outVal
                        }
                }
        }
```