### PR TITLE
WIP - Add enum support

### DIFF
--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1100,3 +1100,59 @@ map[string]interface{}{
 
 `, funcBuffer.String())
 }
+
+func TestEnum(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah is a test.
+// +k8s:openapi-gen=true
+// +k8s:openapi-gen=x-kubernetes-type-tag:type_test
+type Blah struct {
+	Enumeration TestEnum `+"`"+`json:"enumeration"`+"`"+`
+}
+
+// +k8s:openapi-gen=true
+type TestEnum string
+
+const (
+  One TestEnum = "one"
+  Two TestEnum = "two"
+)
+		`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Blah is a test.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"enumeration": {
+SchemaProps: spec.SchemaProps{
+Enum: []interface{}{"One", "Two"},
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+Required: []string{"enumeration"},
+},
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"x-kubernetes-type-tag": "type_test",
+},
+},
+},
+}
+}
+
+`, funcBuffer.String())
+}


### PR DESCRIPTION
This depends on https://github.com/kubernetes/gengo/pull/157

TODO:
- [ ] Should we require a tag? E.g. `// +enum` above the type alias?
- [ ] For backward compatibility, add this as part of OpenAPI v3 and leave OpenAPI v2 unchanged?

This recognizes go type declaration like:

```
// MatchPolicyType specifies the type of match policy
type MatchPolicyType string

const (
	// Exact means requests should only be sent to the webhook if they exactly match a given rule
	Exact MatchPolicyType = "Exact"
	// Equivalent means requests should be sent to the webhook if they modify a resource listed in rules via another API group or version.
	Equivalent MatchPolicyType = "Equivalent"
)
```

and translates them as an OpenAPI enum:

```
"matchPolicy": {
  "description": "...",
  "type": "string",
  "enum": ["Exact", "Equivalent"]
},
```

without this fix, the enum field was missing and so the type was just a plain string.