### PR TITLE
Prevent listType annotation on Items fields in List types

### DIFF
--- a/pkg/generators/rules/idl_tag.go
+++ b/pkg/generators/rules/idl_tag.go
@@ -24,7 +24,16 @@ func (l *ListTypeMissing) Validate(t *types.Type) ([]string, error) {
 	switch t.Kind {
 	case types.Struct:
 		for _, m := range t.Members {
-			if m.Type.Kind == types.Slice && types.ExtractCommentTags("+", m.CommentLines)[ListTypeIDLTag] == nil {
+			hasListType := types.ExtractCommentTags("+", m.CommentLines)[ListTypeIDLTag] != nil
+
+			if m.Name == "Items" && m.Type.Kind == types.Slice && hasNamedMember(t, "ListMeta") {
+				if hasListType {
+					fields = append(fields, m.Name)
+				}
+				continue
+			}
+
+			if m.Type.Kind == types.Slice && !hasListType {
 				fields = append(fields, m.Name)
 				continue
 			}
@@ -32,5 +41,13 @@ func (l *ListTypeMissing) Validate(t *types.Type) ([]string, error) {
 	}
 
 	return fields, nil
+}
 
+func hasNamedMember(t *types.Type, name string) bool {
+	for _, m := range t.Members {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/generators/rules/idl_tag_test.go
+++ b/pkg/generators/rules/idl_tag_test.go
@@ -52,6 +52,69 @@ func TestListTypeMissing(t *testing.T) {
 			},
 			expected: []string{},
 		},
+
+		{
+			name: "list Items field should not be annotated",
+			t: &types.Type{
+				Kind: types.Struct,
+				Members: []types.Member{
+					types.Member{
+						Name: "Items",
+						Type: &types.Type{
+							Kind: types.Slice,
+						},
+						CommentLines: []string{"+listType=map"},
+					},
+					types.Member{
+						Name:     "ListMeta",
+						Embedded: true,
+						Type: &types.Type{
+							Kind: types.Struct,
+						},
+					},
+				},
+			},
+			expected: []string{"Items"},
+		},
+
+		{
+			name: "list Items field without annotation should pass validation",
+			t: &types.Type{
+				Kind: types.Struct,
+				Members: []types.Member{
+					types.Member{
+						Name: "Items",
+						Type: &types.Type{
+							Kind: types.Slice,
+						},
+					},
+					types.Member{
+						Name:     "ListMeta",
+						Embedded: true,
+						Type: &types.Type{
+							Kind: types.Struct,
+						},
+					},
+				},
+			},
+			expected: []string{},
+		},
+
+		{
+			name: "a list that happens to be called Items (i.e. nested, not top-level list) needs annotations",
+			t: &types.Type{
+				Kind: types.Struct,
+				Members: []types.Member{
+					types.Member{
+						Name: "Items",
+						Type: &types.Type{
+							Kind: types.Slice,
+						},
+					},
+				},
+			},
+			expected: []string{"Items"},
+		},
 	}
 
 	rule := &ListTypeMissing{}
@@ -61,5 +124,4 @@ func TestListTypeMissing(t *testing.T) {
 				tc.name, tc.expected, violations)
 		}
 	}
-
 }


### PR DESCRIPTION
xref: https://github.com/kubernetes/kube-openapi/issues/185

In the Kubernetes API, Lists are modeled as structs that contain
* an Items field, of type slice
* a ListMeta field.

For this category of slices (i.e. the ones that hold the contents of a
list), we want to require that API developers do NOT specify a +listType
annotation

Signed-off-by: Maria Ntalla <mntalla@pivotal.io>