### PR TITLE
Remove klog dependency

### DIFF
--- a/cmd/openapi-gen/openapi-gen.go
+++ b/cmd/openapi-gen/openapi-gen.go
@@ -28,12 +28,9 @@ import (
 	"k8s.io/kube-openapi/pkg/generators"
 
 	"github.com/spf13/pflag"
-
-	"k8s.io/klog"
 )
 
 func main() {
-	klog.InitFlags(nil)
 	genericArgs, customArgs := generatorargs.NewDefaults()
 
 	genericArgs.AddFlags(pflag.CommandLine)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09 // indirect
 	gopkg.in/yaml.v2 v2.2.1
 	k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6
-	k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92
+	k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92 // indirect
 	sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/generators/api_linter.go
+++ b/pkg/generators/api_linter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"sort"
 
@@ -28,7 +29,6 @@ import (
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
 )
 
 const apiViolationFileType = "api-violation"
@@ -41,7 +41,7 @@ type apiViolationFile struct {
 
 func (a apiViolationFile) AssembleFile(f *generator.File, path string) error {
 	path = a.unmangledPath
-	klog.V(2).Infof("Assembling file %q", path)
+	log.Printf("Assembling file %q", path)
 	if path == "-" {
 		_, err := io.Copy(os.Stdout, &f.Body)
 		return err
@@ -106,7 +106,7 @@ func (v *apiViolationGen) Filename() string {
 }
 
 func (v *apiViolationGen) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
-	klog.V(5).Infof("validating API rules for type %v", t)
+	log.Printf("validating API rules for type %v", t)
 	if err := v.linter.validate(t); err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ type APIRule interface {
 // validate runs all API rules on type t and records any API rule violation
 func (l *apiLinter) validate(t *types.Type) error {
 	for _, r := range l.rules {
-		klog.V(5).Infof("validating API rule %v for type %v", r.Name(), t)
+		log.Printf("validating API rule %v for type %v", r.Name(), t)
 		fields, err := r.Validate(t)
 		if err != nil {
 			return err

--- a/pkg/generators/config.go
+++ b/pkg/generators/config.go
@@ -18,13 +18,13 @@ package generators
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
 
 	generatorargs "k8s.io/kube-openapi/cmd/openapi-gen/args"
 )
@@ -54,7 +54,7 @@ func DefaultNameSystem() string {
 func Packages(context *generator.Context, arguments *args.GeneratorArgs) generator.Packages {
 	boilerplate, err := arguments.LoadGoBoilerplate()
 	if err != nil {
-		klog.Fatalf("Failed loading boilerplate: %v", err)
+		log.Fatalf("Failed loading boilerplate: %v", err)
 	}
 	header := append([]byte(fmt.Sprintf("// +build !%s\n\n", arguments.GeneratedBuildTag)), boilerplate...)
 	header = append(header, []byte(

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -29,8 +30,6 @@ import (
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 	openapi "k8s.io/kube-openapi/pkg/common"
-
-	"k8s.io/klog"
 )
 
 // This is the comment tag that carries parameters for open API generation.
@@ -184,7 +183,7 @@ func (g *openAPIGen) Init(c *generator.Context, w io.Writer) error {
 }
 
 func (g *openAPIGen) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
-	klog.V(5).Infof("generating for type %v", t)
+	log.Printf("generating for type %v", t)
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	err := newOpenAPITypeWriter(sw, c).generate(t)
 	if err != nil {
@@ -301,7 +300,7 @@ func (g openAPITypeWriter) generateMembers(t *types.Type, required []string) ([]
 			required = append(required, name)
 		}
 		if err = g.generateProperty(&m, t); err != nil {
-			klog.Errorf("Error when generating: %v, %v\n", name, m)
+			log.Printf("Error when generating: %v, %v\n", name, m)
 			return required, err
 		}
 	}
@@ -435,13 +434,13 @@ func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
 	// Initially, we will only log struct extension errors.
 	if len(errors) > 0 {
 		for _, e := range errors {
-			klog.Errorf("[%s]: %s\n", t.String(), e)
+			log.Printf("[%s]: %s\n", t.String(), e)
 		}
 	}
 	unions, errors := parseUnions(t)
 	if len(errors) > 0 {
 		for _, e := range errors {
-			klog.Errorf("[%s]: %s\n", t.String(), e)
+			log.Printf("[%s]: %s\n", t.String(), e)
 		}
 	}
 
@@ -458,7 +457,7 @@ func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *typ
 	if len(errors) > 0 {
 		errorPrefix := fmt.Sprintf("[%s] %s:", parent.String(), m.String())
 		for _, e := range errors {
-			klog.V(2).Infof("%s %s\n", errorPrefix, e)
+			log.Printf("%s %s\n", errorPrefix, e)
 		}
 	}
 	g.emitExtensions(extensions, nil)

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -300,7 +301,7 @@ func (g openAPITypeWriter) generateMembers(t *types.Type, required []string) ([]
 			required = append(required, name)
 		}
 		if err = g.generateProperty(&m, t); err != nil {
-			log.Printf("Error when generating: %v, %v\n", name, m)
+			fmt.Fprintf(os.Stderr, "Error when generating: %v, %v\n", name, m)
 			return required, err
 		}
 	}
@@ -434,13 +435,13 @@ func (g openAPITypeWriter) generateStructExtensions(t *types.Type) error {
 	// Initially, we will only log struct extension errors.
 	if len(errors) > 0 {
 		for _, e := range errors {
-			log.Printf("[%s]: %s\n", t.String(), e)
+			fmt.Fprintf(os.Stderr, "[%s]: %s\n", t.String(), e)
 		}
 	}
 	unions, errors := parseUnions(t)
 	if len(errors) > 0 {
 		for _, e := range errors {
-			log.Printf("[%s]: %s\n", t.String(), e)
+			fmt.Fprintf(os.Stderr, "[%s]: %s\n", t.String(), e)
 		}
 	}
 
@@ -457,7 +458,7 @@ func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *typ
 	if len(errors) > 0 {
 		errorPrefix := fmt.Sprintf("[%s] %s:", parent.String(), m.String())
 		for _, e := range errors {
-			log.Printf("%s %s\n", errorPrefix, e)
+			fmt.Fprintf(os.Stderr, "%s %s\n", errorPrefix, e)
 		}
 	}
 	g.emitExtensions(extensions, nil)


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kube-openapi/issues/117

Remove `klog` dep as mentioned in https://github.com/kubernetes/kube-openapi/pull/115

Quite unsure if I did this correctly. Happy to take feedback.
Is this the change ye intended?: @roycaihw  @lavalamp