### PR TITLE
fix handling of inlined embedded struct pointer fields

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -282,6 +282,9 @@ func typeShortName(t *types.Type) string {
 
 func (g openAPITypeWriter) generateMembers(t *types.Type, required []string) ([]string, error) {
 	var err error
+	for t.Kind == types.Pointer { // fast-forward to effective type containing members
+		t = t.Elem
+	}
 	for _, m := range t.Members {
 		if hasOpenAPITagValue(m.CommentLines, tagValueFalse) {
 			continue

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -347,12 +347,13 @@ func TestNestedStruct(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
-// Blah demonstrate a struct with struct field.
+// Nested is used as struct field
 type Nested struct {
   // A simple string
   String string
 }
 
+// Blah demonstrate a struct with struct field.
 type Blah struct {
   // A struct field
   Field Nested
@@ -370,6 +371,7 @@ type Blah struct {
 return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct with struct field.",
 Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "Field": {
@@ -394,12 +396,13 @@ func TestNestedStructPointer(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
-// Blah demonstrate a struct with struct pointer field.
+// Nested is used as struct pointer field
 type Nested struct {
   // A simple string
   String string
 }
 
+// Blah demonstrate a struct with struct pointer field.
 type Blah struct {
   // A struct pointer field
   Field *Nested
@@ -417,6 +420,7 @@ type Blah struct {
 return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct with struct pointer field.",
 Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "Field": {
@@ -441,12 +445,13 @@ func TestEmbeddedStruct(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
-// Blah demonstrate a struct with embedded struct field.
+// Nested is used as embedded struct field
 type Nested struct {
   // A simple string
   String string
 }
 
+// Blah demonstrate a struct with embedded struct field.
 type Blah struct {
   // An embedded struct field
   Nested
@@ -464,6 +469,7 @@ type Blah struct {
 return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct with embedded struct field.",
 Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "Nested": {
@@ -488,12 +494,13 @@ func TestEmbeddedInlineStruct(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
-// Blah demonstrate a struct with embedded inline struct field.
+// Nested is used as embedded inline struct field
 type Nested struct {
   // A simple string
   String string
 }
 
+// Blah demonstrate a struct with embedded inline struct field.
 type Blah struct {
   // An embedded inline struct field
   Nested `+"`"+`json:",inline,omitempty"`+"`"+`
@@ -511,6 +518,7 @@ type Blah struct {
 return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct with embedded inline struct field.",
 Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "String": {
@@ -534,12 +542,13 @@ func TestEmbeddedInlineStructPointer(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo
 
-// Blah demonstrate a struct with embedded inline struct pointer field.
+// Nested is used as embedded inline struct pointer field.
 type Nested struct {
   // A simple string
   String string
 }
 
+// Blah demonstrate a struct with embedded inline struct pointer field.
 type Blah struct {
   // An embedded inline struct pointer field
   *Nested `+"`"+`json:",inline,omitempty"`+"`"+`
@@ -557,6 +566,7 @@ type Blah struct {
 return common.OpenAPIDefinition{
 Schema: spec.Schema{
 SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct with embedded inline struct pointer field.",
 Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "String": {

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -343,6 +343,239 @@ Type: []string{"object"},
 `, funcBuffer.String())
 }
 
+func TestNestedStruct(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah demonstrate a struct with struct field.
+type Nested struct {
+  // A simple string
+  String string
+}
+
+type Blah struct {
+  // A struct field
+  Field Nested
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"Field": {
+SchemaProps: spec.SchemaProps{
+Description: "A struct field",
+Ref: ref("base/foo.Nested"),
+},
+},
+},
+Required: []string{"Field"},
+},
+},
+Dependencies: []string{
+"base/foo.Nested",},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestNestedStructPointer(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah demonstrate a struct with struct pointer field.
+type Nested struct {
+  // A simple string
+  String string
+}
+
+type Blah struct {
+  // A struct pointer field
+  Field *Nested
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"Field": {
+SchemaProps: spec.SchemaProps{
+Description: "A struct pointer field",
+Ref: ref("base/foo.Nested"),
+},
+},
+},
+Required: []string{"Field"},
+},
+},
+Dependencies: []string{
+"base/foo.Nested",},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestEmbeddedStruct(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah demonstrate a struct with embedded struct field.
+type Nested struct {
+  // A simple string
+  String string
+}
+
+type Blah struct {
+  // An embedded struct field
+  Nested
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"Nested": {
+SchemaProps: spec.SchemaProps{
+Description: "An embedded struct field",
+Ref: ref("base/foo.Nested"),
+},
+},
+},
+Required: []string{"Nested"},
+},
+},
+Dependencies: []string{
+"base/foo.Nested",},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestEmbeddedInlineStruct(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah demonstrate a struct with embedded inline struct field.
+type Nested struct {
+  // A simple string
+  String string
+}
+
+type Blah struct {
+  // An embedded inline struct field
+  Nested `+"`"+`json:",inline,omitempty"`+"`"+`
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"String": {
+SchemaProps: spec.SchemaProps{
+Description: "A simple string",
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+Required: []string{"String"},
+},
+},
+}
+}
+
+`, funcBuffer.String())
+}
+
+func TestEmbeddedInlineStructPointer(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
+package foo
+
+// Blah demonstrate a struct with embedded inline struct pointer field.
+type Nested struct {
+  // A simple string
+  String string
+}
+
+type Blah struct {
+  // An embedded inline struct pointer field
+  *Nested `+"`"+`json:",inline,omitempty"`+"`"+`
+}
+	`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"String": {
+SchemaProps: spec.SchemaProps{
+Description: "A simple string",
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+Required: []string{"String"},
+},
+},
+}
+}
+
+`, funcBuffer.String())
+}
+
 func TestNestedMapString(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer := testOpenAPITypeWriter(t, `
 package foo


### PR DESCRIPTION
Inlined embedded struct pointer fields are ignored during open api generation:

```go
// Blah demonstrate a struct with embedded inline struct pointer field.
type Nested struct {
  // A simple string
  String string
}

type Blah struct {
  // An embedded inline struct pointer field
  *Nested `json:",inline,omitempty"`
}
```

The reason is that types of inlined types are directly searched for members.
The fix just follows pointer types until a non-pointer type before examining the type for members.

There are no tests for inline types. Those are added, including one test with an inlined pointer type,
 