### PR TITLE
Add x-kubernetes-map-type: atomic support

### DIFF
--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -312,6 +312,18 @@ func (c *convert) VisitKind(k *proto.Kind) {
 			NamedType: &deducedName,
 		}
 	}
+
+	ext := k.GetExtensions()
+	if val, ok := ext["x-kubernetes-map-type"]; ok {
+		switch val {
+		case "atomic":
+			a.Map.ElementRelationship = schema.Atomic
+		case "separable":
+			a.Map.ElementRelationship = schema.Separable
+		default:
+			c.reportError("unknown map type %v", val)
+		}
+	}
 }
 
 func toStringSlice(o interface{}) (out []string, ok bool) {
@@ -384,8 +396,17 @@ func (c *convert) VisitMap(m *proto.Map) {
 	a.Map = &schema.Map{}
 	a.Map.ElementType = c.makeRef(m.SubType, c.preserveUnknownFields)
 
-	// TODO: Get element relationship when we start putting it into the
-	// spec.
+	ext := m.GetExtensions()
+	if val, ok := ext["x-kubernetes-map-type"]; ok {
+		switch val {
+		case "atomic":
+			a.Map.ElementRelationship = schema.Atomic
+		case "separable":
+			a.Map.ElementRelationship = schema.Separable
+		default:
+			c.reportError("unknown map type %v", val)
+		}
+	}
 }
 
 func ptr(s schema.Scalar) *schema.Scalar { return &s }

--- a/pkg/schemaconv/smd_test.go
+++ b/pkg/schemaconv/smd_test.go
@@ -27,13 +27,34 @@ import (
 	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"
 )
 
-var (
-	openAPIPath           = filepath.Join("testdata", "swagger.json")
-	fakeSchema            = prototesting.Fake{Path: openAPIPath}
-	expectedNewSchemaPath = filepath.Join("testdata", "new-schema.yaml")
-)
-
 func TestToSchema(t *testing.T) {
+	tests := []struct {
+		name string
+		openAPIFilename string
+		expectedSchemaFilename string
+	}{
+		{
+			name: "kubernetes",
+			openAPIFilename: "swagger.json",
+			expectedSchemaFilename: "new-schema.yaml",
+		},
+		{
+			name: "atomics",
+			openAPIFilename: "atomic-types.json",
+			expectedSchemaFilename: "atomic-types.yaml",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			openAPIPath := filepath.Join("testdata", tc.openAPIFilename)
+			expectedNewSchemaPath := filepath.Join("testdata", tc.expectedSchemaFilename)
+			testToSchema(t, openAPIPath, expectedNewSchemaPath)
+		})
+	}
+}
+
+func testToSchema(t *testing.T, openAPIPath, expectedNewSchemaPath string) {
+	fakeSchema := prototesting.Fake{Path: openAPIPath}
 	s, err := fakeSchema.OpenAPISchema()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/schemaconv/testdata/atomic-types.json
+++ b/pkg/schemaconv/testdata/atomic-types.json
@@ -1,0 +1,30 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Atomic Types",
+    "version": "v1.0.0"
+  },
+  "paths": {
+  },
+  "definitions": {
+    "io.k8s.testcase.AtomicMapField": {
+      "description": "",
+      "properties": {
+        "atomicField": {
+          "description": "",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-kubernetes-map-type": "atomic"
+        }
+      }
+    },
+    "io.k8s.testcase.DeclaredAtomicMap": {
+      "description": "",
+      "properties": {
+      },
+      "x-kubernetes-map-type": "atomic"
+    }
+  }
+}

--- a/pkg/schemaconv/testdata/atomic-types.yaml
+++ b/pkg/schemaconv/testdata/atomic-types.yaml
@@ -1,0 +1,33 @@
+types:
+  - name: io.k8s.testcase.AtomicMapField
+    map:
+      fields:
+        - name: atomicField
+          type:
+            map:
+              elementType:
+                scalar: string
+              elementRelationship: atomic
+  - name: io.k8s.testcase.DeclaredAtomicMap
+    map:
+      elementRelationship: atomic
+  - name: __untyped_atomic_
+    scalar: untyped
+    list:
+      elementType:
+        namedType: __untyped_atomic_
+      elementRelationship: atomic
+    map:
+      elementType:
+        namedType: __untyped_atomic_
+      elementRelationship: atomic
+  - name: __untyped_deduced_
+    scalar: untyped
+    list:
+      elementType:
+        namedType: __untyped_atomic_
+      elementRelationship: atomic
+    map:
+      elementType:
+        namedType: __untyped_deduced_
+      elementRelationship: separable

--- a/pkg/schemaconv/testdata/new-schema.yaml
+++ b/pkg/schemaconv/testdata/new-schema.yaml
@@ -9802,6 +9802,7 @@ types:
         map:
           elementType:
             scalar: string
+    elementRelationship: atomic
 - name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
   map:
     fields:

--- a/pkg/schemaconv/testdata/swagger.json
+++ b/pkg/schemaconv/testdata/swagger.json
@@ -92883,7 +92883,8 @@
        "type": "string"
       }
      }
-    }
+    },
+    "x-kubernetes-map-type": "atomic"
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
     "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -23,6 +23,7 @@ $ go run ../../cmd/openapi-gen/openapi-gen.go \
   -o pkg \
   -p generated \
   -O openapi_generated \
+  -h ../../boilerplate/boilerplate.go.txt \
   -r ./testdata/golden.v2.report
 ```
 The generated file `pkg/generated/openapi_generated.go` should have been created.

--- a/test/integration/builder/main.go
+++ b/test/integration/builder/main.go
@@ -119,6 +119,7 @@ func createWebServices() []*restful.WebService {
 	w.Route(buildRouteForType(w, "maptype", "AtomicMap"))
 	w.Route(buildRouteForType(w, "structtype", "GranularStruct"))
 	w.Route(buildRouteForType(w, "structtype", "AtomicStruct"))
+	w.Route(buildRouteForType(w, "structtype", "DeclaredAtomicStruct"))
 	return []*restful.WebService{w}
 }
 

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -30,28 +30,29 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"k8s.io/kube-openapi/test/integration/testdata/custom.Bac":                 common.EmbedOpenAPIDefinitionIntoV2Extension(custom.Bac{}.OpenAPIV3Definition(), custom.Bac{}.OpenAPIDefinition()),
-		"k8s.io/kube-openapi/test/integration/testdata/custom.Bah":                 schema_test_integration_testdata_custom_Bah(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/custom.Bak":                 custom.Bak{}.OpenAPIDefinition(),
-		"k8s.io/kube-openapi/test/integration/testdata/custom.Bal":                 custom.Bal{}.OpenAPIV3Definition(),
-		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Bar":              schema_test_integration_testdata_dummytype_Bar(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Baz":              schema_test_integration_testdata_dummytype_Baz(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Foo":              schema_test_integration_testdata_dummytype_Foo(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Waldo":            schema_test_integration_testdata_dummytype_Waldo(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/listtype.AtomicList":        schema_test_integration_testdata_listtype_AtomicList(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/listtype.Item":              schema_test_integration_testdata_listtype_Item(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/listtype.MapList":           schema_test_integration_testdata_listtype_MapList(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/listtype.SetList":           schema_test_integration_testdata_listtype_SetList(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/listtype.UntypedList":       schema_test_integration_testdata_listtype_UntypedList(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/maptype.AtomicMap":          schema_test_integration_testdata_maptype_AtomicMap(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/maptype.GranularMap":        schema_test_integration_testdata_maptype_GranularMap(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/structtype.AtomicStruct":    schema_test_integration_testdata_structtype_AtomicStruct(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/structtype.ContainedStruct": schema_test_integration_testdata_structtype_ContainedStruct(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/structtype.GranularStruct":  schema_test_integration_testdata_structtype_GranularStruct(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/uniontype.InlinedUnion":     schema_test_integration_testdata_uniontype_InlinedUnion(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/uniontype.TopLevelUnion":    schema_test_integration_testdata_uniontype_TopLevelUnion(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/uniontype.Union":            schema_test_integration_testdata_uniontype_Union(ref),
-		"k8s.io/kube-openapi/test/integration/testdata/uniontype.Union2":           schema_test_integration_testdata_uniontype_Union2(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/custom.Bac":                      common.EmbedOpenAPIDefinitionIntoV2Extension(custom.Bac{}.OpenAPIV3Definition(), custom.Bac{}.OpenAPIDefinition()),
+		"k8s.io/kube-openapi/test/integration/testdata/custom.Bah":                      schema_test_integration_testdata_custom_Bah(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/custom.Bak":                      custom.Bak{}.OpenAPIDefinition(),
+		"k8s.io/kube-openapi/test/integration/testdata/custom.Bal":                      custom.Bal{}.OpenAPIV3Definition(),
+		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Bar":                   schema_test_integration_testdata_dummytype_Bar(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Baz":                   schema_test_integration_testdata_dummytype_Baz(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Foo":                   schema_test_integration_testdata_dummytype_Foo(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Waldo":                 schema_test_integration_testdata_dummytype_Waldo(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/listtype.AtomicList":             schema_test_integration_testdata_listtype_AtomicList(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/listtype.Item":                   schema_test_integration_testdata_listtype_Item(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/listtype.MapList":                schema_test_integration_testdata_listtype_MapList(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/listtype.SetList":                schema_test_integration_testdata_listtype_SetList(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/listtype.UntypedList":            schema_test_integration_testdata_listtype_UntypedList(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/maptype.AtomicMap":               schema_test_integration_testdata_maptype_AtomicMap(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/maptype.GranularMap":             schema_test_integration_testdata_maptype_GranularMap(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/structtype.AtomicStruct":         schema_test_integration_testdata_structtype_AtomicStruct(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/structtype.ContainedStruct":      schema_test_integration_testdata_structtype_ContainedStruct(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/structtype.DeclaredAtomicStruct": schema_test_integration_testdata_structtype_DeclaredAtomicStruct(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/structtype.GranularStruct":       schema_test_integration_testdata_structtype_GranularStruct(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/uniontype.InlinedUnion":          schema_test_integration_testdata_uniontype_InlinedUnion(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/uniontype.TopLevelUnion":         schema_test_integration_testdata_uniontype_TopLevelUnion(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/uniontype.Union":                 schema_test_integration_testdata_uniontype_Union(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/uniontype.Union2":                schema_test_integration_testdata_uniontype_Union2(ref),
 	}
 }
 
@@ -432,6 +433,30 @@ func schema_test_integration_testdata_structtype_ContainedStruct(ref common.Refe
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
+			},
+		},
+	}
+}
+
+func schema_test_integration_testdata_structtype_DeclaredAtomicStruct(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"Field": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+				},
+				Required: []string{"Field"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
 			},
 		},
 	}

--- a/test/integration/testdata/golden.v2.json
+++ b/test/integration/testdata/golden.v2.json
@@ -271,6 +271,25 @@
      }
     }
    },
+   "/test/structtype/declaredatomicstruct": {
+    "get": {
+     "schemes": [
+      "https"
+     ],
+     "operationId": "func18",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/structtype.DeclaredAtomicStruct"
+       }
+      },
+      "404": {
+       "$ref": "#/responses/NotFound"
+      }
+     }
+    }
+   },
    "/test/structtype/granularstruct": {
     "get": {
      "schemes": [
@@ -530,6 +549,19 @@
    },
    "structtype.ContainedStruct": {
     "type": "object"
+   },
+   "structtype.DeclaredAtomicStruct": {
+    "type": "object",
+    "required": [
+     "Field"
+    ],
+    "properties": {
+     "Field": {
+      "type": "integer",
+      "format": "int32"
+     }
+    },
+    "x-kubernetes-map-type": "atomic"
    },
    "structtype.GranularStruct": {
     "type": "object",

--- a/test/integration/testdata/golden.v2.report
+++ b/test/integration/testdata/golden.v2.report
@@ -17,6 +17,7 @@ API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/ma
 API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/maptype,GranularMap,KeyValue
 API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/structtype,AtomicStruct,Field
 API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/structtype,AtomicStruct,OtherField
+API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/structtype,DeclaredAtomicStruct,Field
 API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/structtype,GranularStruct,Field
 API rule violation: names_match,k8s.io/kube-openapi/test/integration/testdata/structtype,GranularStruct,OtherField
 API rule violation: omitempty_match_case,k8s.io/kube-openapi/test/integration/testdata/listtype,Item,C

--- a/test/integration/testdata/structtype/atomic-struct.go
+++ b/test/integration/testdata/structtype/atomic-struct.go
@@ -9,3 +9,9 @@ type AtomicStruct struct {
 
 // +k8s:openapi-gen=true
 type ContainedStruct struct{}
+
+// +k8s:openapi-gen=true
+// +structType=atomic
+type DeclaredAtomicStruct struct {
+	Field int
+}


### PR DESCRIPTION
In order to fix Kubernetes issue https://github.com/kubernetes/kubernetes/issues/92913 we need to support tagging structs with `+structType: atomic`.

kube-openapi already correctly added `"x-kubernetes-map-type": "atomic"` to an openAPI spec when `+structType: atomic` is set.

The missing bit was that `Map.ElementRelationship` was not getting set when an openapi spec was converted to SMD.

/sig api-machinery