### PR TITLE
Fix openAPI x-kubernetes-map-type enum to be "granular"

### DIFF
--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -318,7 +318,7 @@ func (c *convert) VisitKind(k *proto.Kind) {
 		switch val {
 		case "atomic":
 			a.Map.ElementRelationship = schema.Atomic
-		case "separable":
+		case "granular":
 			a.Map.ElementRelationship = schema.Separable
 		default:
 			c.reportError("unknown map type %v", val)
@@ -401,7 +401,7 @@ func (c *convert) VisitMap(m *proto.Map) {
 		switch val {
 		case "atomic":
 			a.Map.ElementRelationship = schema.Atomic
-		case "separable":
+		case "granular":
 			a.Map.ElementRelationship = schema.Separable
 		default:
 			c.reportError("unknown map type %v", val)


### PR DESCRIPTION
Mistakenly set it to "separable" in https://github.com/kubernetes/kubernetes/pull/93901. It needs to be "granular".

see https://github.com/kubernetes/kubernetes/pull/93901#discussion_r468848080

/cc @apelisse @liggitt 
/sig api-machinery
/priority important-soon