### PR TITLE
kube-openapi release-1.19 uses smd v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac
 	k8s.io/klog/v2 v2.0.0
-	sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,7 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac h1:sAvhNk5RRuc6FNYGqe7Ygz3PSo/2w
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
-sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874 h1:0KsuGbLhWdIxv5DA1OnbFz5hI/Co9kuxMfMUa5YsAHY=
-sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/kube-openapi/pkg/util/proto"
-	"sigs.k8s.io/structured-merge-diff/v3/schema"
+	"sigs.k8s.io/structured-merge-diff/v4/schema"
 )
 
 // ToSchema converts openapi definitions into a schema suitable for structured
@@ -263,7 +263,7 @@ func makeUnion(extensions map[string]interface{}) (schema.Union, error) {
 				return schema.Union{}, fmt.Errorf(`"fields-to-discriminateBy"/%v: value must be a string, got: %#v`, field, value)
 			}
 			union.Fields = append(union.Fields, schema.UnionField{
-				FieldName:       field,
+				FieldName:          field,
 				DiscriminatorValue: discriminated,
 			})
 

--- a/pkg/schemaconv/testdata/atomic-types.yaml
+++ b/pkg/schemaconv/testdata/atomic-types.yaml
@@ -1,33 +1,33 @@
 types:
-  - name: io.k8s.testcase.AtomicMapField
-    map:
-      fields:
-        - name: atomicField
-          type:
-            map:
-              elementType:
-                scalar: string
-              elementRelationship: atomic
-  - name: io.k8s.testcase.DeclaredAtomicMap
-    map:
-      elementRelationship: atomic
-  - name: __untyped_atomic_
-    scalar: untyped
-    list:
-      elementType:
-        namedType: __untyped_atomic_
-      elementRelationship: atomic
-    map:
-      elementType:
-        namedType: __untyped_atomic_
-      elementRelationship: atomic
-  - name: __untyped_deduced_
-    scalar: untyped
-    list:
-      elementType:
-        namedType: __untyped_atomic_
-      elementRelationship: atomic
-    map:
-      elementType:
-        namedType: __untyped_deduced_
-      elementRelationship: separable
+- name: io.k8s.testcase.AtomicMapField
+  map:
+    fields:
+    - name: atomicField
+      type:
+        map:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.testcase.DeclaredAtomicMap
+  map:
+    elementRelationship: atomic
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable


### PR DESCRIPTION
master kube-openapi should use smd v4.