### PR TITLE
Converts OpenAPI defaults to structured-merge-diff schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac
 	k8s.io/klog/v2 v2.0.0
-	sigs.k8s.io/structured-merge-diff/v4 v4.0.1
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.2
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,7 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac h1:sAvhNk5RRuc6FNYGqe7Ygz3PSo/2w
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/schemaconv/smd.go
+++ b/pkg/schemaconv/smd.go
@@ -293,8 +293,9 @@ func (c *convert) VisitKind(k *proto.Kind) {
 		member := k.Fields[name]
 		tr := c.makeRef(member, preserveUnknownFields)
 		a.Map.Fields = append(a.Map.Fields, schema.StructField{
-			Name: name,
-			Type: tr,
+			Name:    name,
+			Type:    tr,
+			Default: member.GetDefault(),
 		})
 	}
 

--- a/pkg/schemaconv/smd_test.go
+++ b/pkg/schemaconv/smd_test.go
@@ -29,19 +29,24 @@ import (
 
 func TestToSchema(t *testing.T) {
 	tests := []struct {
-		name string
-		openAPIFilename string
+		name                   string
+		openAPIFilename        string
 		expectedSchemaFilename string
 	}{
 		{
-			name: "kubernetes",
-			openAPIFilename: "swagger.json",
+			name:                   "kubernetes",
+			openAPIFilename:        "swagger.json",
 			expectedSchemaFilename: "new-schema.yaml",
 		},
 		{
-			name: "atomics",
-			openAPIFilename: "atomic-types.json",
+			name:                   "atomics",
+			openAPIFilename:        "atomic-types.json",
 			expectedSchemaFilename: "atomic-types.yaml",
+		},
+		{
+			name:                   "defaults",
+			openAPIFilename:        "defaults.json",
+			expectedSchemaFilename: "defaults.yaml",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/schemaconv/testdata/defaults.json
+++ b/pkg/schemaconv/testdata/defaults.json
@@ -1,0 +1,25 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Atomic Types",
+        "version": "v1.0.0"
+    },
+    "paths": {},
+    "definitions": {
+        "List": {
+            "type": "array",
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-list-map-keys": ["foo"],
+            "default": {"foo": "bar"},
+            "items": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "default": "buz",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pkg/schemaconv/testdata/defaults.yaml
+++ b/pkg/schemaconv/testdata/defaults.yaml
@@ -1,0 +1,33 @@
+types:
+- name: List
+  list:
+    elementType:
+      map:
+        fields:
+        - name: foo
+          type:
+            scalar: string
+          default: buz
+    elementRelationship: associative
+    keys:
+    - foo
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable

--- a/pkg/util/proto/document.go
+++ b/pkg/util/proto/document.go
@@ -109,19 +109,39 @@ func (d *Definitions) parseReference(s *openapi_v2.Schema, path *Path) (Schema, 
 	if _, ok := d.models[reference]; !ok {
 		return nil, newSchemaError(path, "unknown model in reference: %q", reference)
 	}
+	base, err := d.parseBaseSchema(s, path)
+	if err != nil {
+		return nil, err
+	}
 	return &Ref{
-		BaseSchema:  d.parseBaseSchema(s, path),
+		BaseSchema:  base,
 		reference:   reference,
 		definitions: d,
 	}, nil
 }
 
-func (d *Definitions) parseBaseSchema(s *openapi_v2.Schema, path *Path) BaseSchema {
+func parseDefault(def *openapi_v2.Any) (interface{}, error) {
+	if def == nil {
+		return nil, nil
+	}
+	var i interface{}
+	if err := yaml.Unmarshal([]byte(def.Yaml), &i); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+func (d *Definitions) parseBaseSchema(s *openapi_v2.Schema, path *Path) (BaseSchema, error) {
+	def, err := parseDefault(s.GetDefault())
+	if err != nil {
+		return BaseSchema{}, err
+	}
 	return BaseSchema{
 		Description: s.GetDescription(),
+		Default:     def,
 		Extensions:  VendorExtensionToMap(s.GetVendorExtension()),
 		Path:        *path,
-	}
+	}, nil
 }
 
 // We believe the schema is a map, verify and return a new schema
@@ -132,8 +152,12 @@ func (d *Definitions) parseMap(s *openapi_v2.Schema, path *Path) (Schema, error)
 	var sub Schema
 	// TODO(incomplete): this misses the boolean case as AdditionalProperties is a bool+schema sum type.
 	if s.GetAdditionalProperties().GetSchema() == nil {
+		base, err := d.parseBaseSchema(s, path)
+		if err != nil {
+			return nil, err
+		}
 		sub = &Arbitrary{
-			BaseSchema: d.parseBaseSchema(s, path),
+			BaseSchema: base,
 		}
 	} else {
 		var err error
@@ -142,8 +166,12 @@ func (d *Definitions) parseMap(s *openapi_v2.Schema, path *Path) (Schema, error)
 			return nil, err
 		}
 	}
+	base, err := d.parseBaseSchema(s, path)
+	if err != nil {
+		return nil, err
+	}
 	return &Map{
-		BaseSchema: d.parseBaseSchema(s, path),
+		BaseSchema: base,
 		SubType:    sub,
 	}, nil
 }
@@ -165,8 +193,12 @@ func (d *Definitions) parsePrimitive(s *openapi_v2.Schema, path *Path) (Schema, 
 	default:
 		return nil, newSchemaError(path, "Unknown primitive type: %q", t)
 	}
+	base, err := d.parseBaseSchema(s, path)
+	if err != nil {
+		return nil, err
+	}
 	return &Primitive{
-		BaseSchema: d.parseBaseSchema(s, path),
+		BaseSchema: base,
 		Type:       t,
 		Format:     s.GetFormat(),
 	}, nil
@@ -188,8 +220,12 @@ func (d *Definitions) parseArray(s *openapi_v2.Schema, path *Path) (Schema, erro
 	if err != nil {
 		return nil, err
 	}
+	base, err := d.parseBaseSchema(s, path)
+	if err != nil {
+		return nil, err
+	}
 	return &Array{
-		BaseSchema: d.parseBaseSchema(s, path),
+		BaseSchema: base,
 		SubType:    sub,
 	}, nil
 }
@@ -216,8 +252,12 @@ func (d *Definitions) parseKind(s *openapi_v2.Schema, path *Path) (Schema, error
 		fieldOrder = append(fieldOrder, name)
 	}
 
+	base, err := d.parseBaseSchema(s, path)
+	if err != nil {
+		return nil, err
+	}
 	return &Kind{
-		BaseSchema:     d.parseBaseSchema(s, path),
+		BaseSchema:     base,
 		RequiredFields: s.GetRequired(),
 		Fields:         fields,
 		FieldOrder:     fieldOrder,
@@ -225,8 +265,12 @@ func (d *Definitions) parseKind(s *openapi_v2.Schema, path *Path) (Schema, error
 }
 
 func (d *Definitions) parseArbitrary(s *openapi_v2.Schema, path *Path) (Schema, error) {
+	base, err := d.parseBaseSchema(s, path)
+	if err != nil {
+		return nil, err
+	}
 	return &Arbitrary{
-		BaseSchema: d.parseBaseSchema(s, path),
+		BaseSchema: base,
 	}, nil
 }
 

--- a/pkg/util/proto/openapi.go
+++ b/pkg/util/proto/openapi.go
@@ -77,6 +77,8 @@ type Schema interface {
 	GetPath() *Path
 	// Describes the field.
 	GetDescription() string
+	// Default for that schema.
+	GetDefault() interface{}
 	// Returns type extensions.
 	GetExtensions() map[string]interface{}
 }
@@ -129,6 +131,7 @@ func (p *Path) FieldPath(field string) Path {
 type BaseSchema struct {
 	Description string
 	Extensions  map[string]interface{}
+	Default     interface{}
 
 	Path Path
 }
@@ -139,6 +142,10 @@ func (b *BaseSchema) GetDescription() string {
 
 func (b *BaseSchema) GetExtensions() map[string]interface{} {
 	return b.Extensions
+}
+
+func (b *BaseSchema) GetDefault() interface{} {
+	return b.Default
 }
 
 func (b *BaseSchema) GetPath() *Path {


### PR DESCRIPTION
Take the defaults from OpenAPI and push them into the smd schema, only for struct fields since we only care about these.
Also, update smd to its latest version since we need the most recent changes.