### PR TITLE
validation: add OWNERS

### DIFF
--- a/pkg/validation/OWNERS
+++ b/pkg/validation/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  no_parent_owners: true
+approvers:
+- sttts
+- liggitt
+reviewers:
+- sttts
+- liggitt


### PR DESCRIPTION
This code is sensitive because it is both reasonable complex and has influence on the API. Hence, we add an OWNERS file to restrict the set of people as reviewers+approvers who are deeply familiar with the validation logic.