### PR TITLE
Added github-action CI

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,0 +1,36 @@
+name: ci-pipeline
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.13'
+
+    - name: checkout
+      run: |
+        cd /home/runner/go
+        mkdir src/k8s.io -p
+        cd /home/runner/go/src/k8s.io
+        git clone https://github.com/kubernetes/kube-openapi.git
+
+    - name: build
+      run: |
+        cd /home/runner/go/src/k8s.io/kube-openapi
+        go mod tidy && git diff --exit-code
+        go build ./cmd/... ./pkg/...
+
+    - name: test
+      run: |
+        cd /home/runner/go/src/k8s.io/kube-openapi
+        GOPATH=/home/runner/go go test ./cmd/... ./pkg/... ./test/...


### PR DESCRIPTION
Question: What does this PR do ?
Answer: Adds a CI pipeline to run on Github-actions, as per discussion with @dims  https://kubernetes.slack.com/archives/C0EG7JC6T/p1611674631037300

Question: Any problems ?
Answer: Yes. The integration test fails unless the src of the project is put under $GOPATH/src/k8s.io, specifically. There is a go.mod so go test should work under any path. The concern described below can be seen here https://github.com/longwuyuan/kubernetes-kube-openapi/runs/1815796018?check_suite_focus=true
- In the travis ci file called .travis.yml, on line-number 9, in the root of the project, there is a special config for import paths that looks like this
```
go_import_path: k8s.io/kube-openapi
``` 
- Travis has an option to configure something called "go_import_path" https://docs.travis-ci.com/user/languages/go/#go-import-path
- There is no well documented equivalent of this "go_import_path", in github-actions
- As a result, the package name or path "k8s-io/kube-api" https://github.com/kubernetes/kube-openapi/blob/8566a335510fbdd49b876cbf1dba523bf83d077f/.travis.yml#L9  is not being explicitly passed on to "go test ..." in the github-actions CI file
  - Integration test fails if the CI script is very staightforward simple like this ;
    ```
     name: go mod
        run: go mod tidy && git diff --exit-code

      - name: go build
        run: go build ./cmd/... ./pkg/...

      - name: go test
        run: go test ./cmd/... ./pkg/... ./test/...

    ```
  - There are 3 initial STEPS to the integration test ;
    - building openapi-gen
    - processing go idl with openapi-gen
    - writing swagger
       Seen in the screenshot below ;
    ![image](https://user-images.githubusercontent.com/5085914/106279888-28c1b580-6263-11eb-8d0f-f929fd65f789.png)

  - The first error is _"$GOPATH not provided to build"_,  
     Looks like this screenshot below ;
  ![image](https://user-images.githubusercontent.com/5085914/106357145-4c9bfe80-632a-11eb-824c-852e078b783e.png)
 
    - If  a change is made like the "gexec.Build" to "gexec.BuildIn" like thus ;
      Line 80 of file <project-root>/test/integration/integration_test_suite.go, changed 
      from 
       ```
      gexec.Build( "../../cmd/openapi-gen/openapi-gen.go
      ```
      to
      ```
      gexec.BuildIn("/home/runner/go", "../../cmd/openapi-gen/openapi-gen.go
      ```
      as per this documentation https://onsi.github.io/gomega/#gexec-testing-external-processes 

      -  The test framework gomega/gingko gets the GOPATH, explicitly hardcoded, so gets past the error and "building the openapi-gen" STEP works.

      - This is odd & unexpected because that gexec.Build is expected to pick up the GOPATH from the environment as per documentation.

  - Now comes the cause of this concern. It is the second STEP from the 3 mentioned above. The second STEP is failing, with  reason for failure as test fails to find a file called boilerplate.go.txt. 
    - This screenshot below shows this failed to find file error ;
      ![image](https://user-images.githubusercontent.com/5085914/106281574-658eac00-6265-11eb-95da-4df92850d1e8.png)

    - Attempting a "find" command just before the test, to see where that file is. 
       Seen in this screenshot below ;
        ![image](https://user-images.githubusercontent.com/5085914/106281792-b69ea000-6265-11eb-82d9-4d254f78804c.png)

    - But the test always looks for it in this specific location  _k8s.io/kube-openapi/boilerplate/boilerplate.go.txt_ and fails . I have tried to set environment specifics like "working_directory", "path" and even changed the GOPATH to the github-actions workspace folder.  But the test always looks for  _k8s.io/kube-openapi/boilerplate/boilerplate.go.txt_ and fails.
    -  Maybe because of line 42 in ./cmd/openapi-gen/args/args.go
       ```
       genericArgs.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kube-openapi/boil    erplate/boilerplate.go.txt")
       ```
    - As mentioned earlier, the old Travis CI file has a special config for the import path _"k8s.io/kube-openapi"_ . That travis ci configuration seems somewhat related to setting a remote-url import path. That Travis CI config is documented here https://docs.travis-ci.com/user/languages/go/#go-import-path  and that page links to the likely relevance to this issue, here  https://golang.org/cmd/go/#hdr-Remote_import_paths

- I am not a developer, so apologies for any misinformation here.

@dims @nikhita 