### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,14 @@
 reviewers:
 - yujuhong
 - gmarek
-- mbohlool
 - philips
 - seans3
 - apelisse
 - roycaihw
 - sttts
 approvers:
-- mbohlool
 - lavalamp
 - sttts
 - apelisse
+emritus_approvers:
+- mbohlool


### PR DESCRIPTION
For https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members from OWNERS, this commit removes mbohlool from
the OWNERS  file.