### PR TITLE
Remove incorrect zero value check

### DIFF
--- a/pkg/validation/validate/type.go
+++ b/pkg/validation/validate/type.go
@@ -132,7 +132,7 @@ func (t *typeValidator) Applies(source interface{}, kind reflect.Kind) bool {
 func (t *typeValidator) Validate(data interface{}) *Result {
 	result := new(Result)
 	result.Inc()
-	if data == nil || reflect.DeepEqual(reflect.Zero(reflect.TypeOf(data)), reflect.ValueOf(data)) {
+	if data == nil {
 		// nil or zero value for the passed structure require Type: null
 		if len(t.Type) > 0 && !t.Type.Contains(nullType) && !t.Nullable { // TODO: if a property is not required it also passes this
 			return errorHelp.sErr(errors.InvalidType(t.Path, t.In, strings.Join(t.Type, ","), nullType))


### PR DESCRIPTION
This check never returned true prior to go1.16, because using DeepEqual on reflect.Value
return values checks their internal fields, and reflect.Zero included a unique unsafe pointer.

In go1.16, reflect.Zero started returning shared zero values, and this check started returning true.

However, requiring nullable on zero values is not correct. A zero value string "" should be valid even
if the schema does not allow the field to be null.

xref https://github.com/go-openapi/validate/pull/138 and https://github.com/golang/go/issues/43993#issuecomment-790948302

/cc @sttts @apelisse 