### PR TITLE
Add preserve unknown fields test case

### DIFF
--- a/pkg/schemaconv/smd_test.go
+++ b/pkg/schemaconv/smd_test.go
@@ -48,6 +48,11 @@ func TestToSchema(t *testing.T) {
 			openAPIFilename:        "defaults.json",
 			expectedSchemaFilename: "defaults.yaml",
 		},
+		{
+			name:                   "preserve-unknown",
+			openAPIFilename:        "preserve-unknown.json",
+			expectedSchemaFilename: "preserve-unknown.yaml",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -62,7 +67,7 @@ func testToSchema(t *testing.T, openAPIPath, expectedNewSchemaPath string) {
 	fakeSchema := prototesting.Fake{Path: openAPIPath}
 	s, err := fakeSchema.OpenAPISchema()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to get schema for %s: %v", openAPIPath, err)
 	}
 	models, err := proto.NewOpenAPIData(s)
 	if err != nil {

--- a/pkg/schemaconv/testdata/preserve-unknown.json
+++ b/pkg/schemaconv/testdata/preserve-unknown.json
@@ -1,0 +1,40 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Atomic Types",
+    "version": "v1.0.0"
+  },
+  "paths": {
+  },
+  "definitions": {
+    "io.k8s.testcase.Empty": {
+      "description": "",
+      "type": "object",
+    },
+    "io.k8s.testcase.EmptyPreserveUnknownFieldsObject": {
+      "description": "",
+      "properties": {
+        "preserveField": {
+          "description": "",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      }
+    },
+    "io.k8s.testcase.PopulatedPreserveUnknownFieldsObject": {
+      "description": "",
+      "properties": {
+        "preserveField": {
+          "description": "",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true,
+	  "properties": {
+	    "innerField": {
+	      "type": "string"
+	    }
+	  }
+        }
+      }
+    }
+  }
+}

--- a/pkg/schemaconv/testdata/preserve-unknown.yaml
+++ b/pkg/schemaconv/testdata/preserve-unknown.yaml
@@ -1,0 +1,61 @@
+types:
+- name: io.k8s.testcase.Empty
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: io.k8s.testcase.EmptyPreserveUnknownFieldsObject
+  map:
+    fields:
+    - name: preserveField
+      type:
+        map:
+          elementType:
+            scalar: untyped
+            list:
+              elementType:
+                namedType: __untyped_atomic_
+              elementRelationship: atomic
+            map:
+              elementType:
+                namedType: __untyped_deduced_
+              elementRelationship: separable
+- name: io.k8s.testcase.PopulatedPreserveUnknownFieldsObject
+  map:
+    fields:
+    - name: preserveField
+      type:
+        map:
+          fields:
+          - name: innerField
+            type:
+              scalar: string
+          elementType:
+            namedType: __untyped_deduced_
+- name: __untyped_atomic_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+- name: __untyped_deduced_
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable


### PR DESCRIPTION
Adding this primarily to document the mapping between openAPI and SMD schema for x-kubernetes-preserve-unknown-fields