### PR TITLE
Fix hostname validation to allow hypens and digits in the last segment

### DIFF
--- a/pkg/validation/strfmt/default.go
+++ b/pkg/validation/strfmt/default.go
@@ -53,7 +53,8 @@ const (
 	//   - dashes are permitted, but not at the start or the end of a segment
 	//   - long top-level domain names (e.g. example.london) are permitted
 	//   - symbol unicode points are permitted (e.g. emoji) (not for top-level domain)
-	HostnamePattern = `^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$`
+	//   - last segment can contain hypens and digits
+	HostnamePattern = `^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z0-9\p{S}\p{L}])(-?[a-zA-Z0-9\p{S}\p{L}]){1,62})$`
 	// UUIDPattern Regex for UUID that allows uppercase
 	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
 	// UUID3Pattern Regex for UUID3 that allows uppercase

--- a/pkg/validation/strfmt/default_test.go
+++ b/pkg/validation/strfmt/default_test.go
@@ -94,6 +94,7 @@ func TestFormatHostname(t *testing.T) {
 		"x.",
 		"a.b.c.dot-",
 		"a.b.c.é;ö",
+		"one.two-three.-four",
 	}
 	validHostnames := []string{
 		"somewhere.com",
@@ -137,6 +138,9 @@ func TestFormatHostname(t *testing.T) {
 		"www.élégigôö.org",
 		// long top-level domains
 		"www.詹姆斯.london",
+		// last segment with hypens and digits
+		"one.two-three.four-five",
+		"one.two-three.four-five-5",
 	}
 
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)


### PR DESCRIPTION
According to RFC 1034 section 3.5, hypens and digits are allowed for labels which also includes the last segment which currently allows only letters.