### PR TITLE
CI go version mapping upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.13', '1.x' ]
+        go: [ '1.16', '1.x' ]
         gostable: [true]
         include:
-        - go: '^1.17'
+        - go: '1.x'
           gostable: false
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         go: [ '1.13', '1.x' ]
         gostable: [true]
         include:
-        - go: '1.17.0-rc2'
+        - go: '^1.17'
           gostable: false
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
A previous PR introduce builds on go 1.17.0-rc, this PR update go to its latest stable version.

Also this PR removed go 1.13 because 
- go 1.13 is long out of maintenance
- no supported Kubernetes versions still use go 1.13. oldest go version of all supported Kubernetes release branch is 1.16
- integration test fails randomly when running with 1.13

As a result, CI runs with the following version:
- go 1.16 stable
- go 1.x stable (currently 1.17.x)
- go 1.x unstable (current 1.17.x because there is no unstable go version)
