### PR TITLE
Update field name to x-kubernetes-validations

### DIFF
--- a/pkg/generators/extension.go
+++ b/pkg/generators/extension.go
@@ -67,7 +67,7 @@ var tagToExtension = map[string]extensionAttributes{
 		allowedValues: sets.NewString("atomic", "granular"),
 	},
 	"validator": {
-		xName: "x-kubernetes-validators",
+		xName: "x-kubernetes-validations",
 		kind:  types.Struct,
 	},
 }

--- a/pkg/util/cel/compilation.go
+++ b/pkg/util/cel/compilation.go
@@ -35,9 +35,9 @@ const ScopedVarName = "self"
 func Compile(schema *spec.Schema) ([]cel.Program, []error) {
 	var allErrors []error
 	celRules := &spec.ValidationRules{}
-	err := schema.Extensions.GetObject("x-kubernetes-validators", celRules)
+	err := schema.Extensions.GetObject("x-kubernetes-validations", celRules)
 	if err != nil {
-		allErrors = append(allErrors, fmt.Errorf("unexpected error accessing x-kubernetes-validators: %v", err.Error()))
+		allErrors = append(allErrors, fmt.Errorf("unexpected error accessing x-kubernetes-validations: %v", err.Error()))
 		return nil, allErrors
 	}
 

--- a/pkg/util/cel/compilation_test.go
+++ b/pkg/util/cel/compilation_test.go
@@ -50,7 +50,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "minReplicas < maxReplicas",
 								"message": "minReplicas should be smaller than maxReplicas",
@@ -70,7 +70,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "self.startsWith('s')",
 								"message": "scoped field should start with 's'",
@@ -91,7 +91,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "string(self).endsWith('s')",
 								"message": "scoped field should end with 's'",
@@ -111,7 +111,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "self == true",
 								"message": "scoped field should be true",
@@ -131,7 +131,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "self > 0",
 								"message": "scoped field should be greater than 0",
@@ -151,7 +151,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "self > 1.0",
 								"message": "scoped field should be greater than 1.0",
@@ -186,7 +186,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "nestedObj.val == 10",
 								"message": "val should be equal to 10",
@@ -227,7 +227,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "size(self.nestedObj[0]) == 10",
 								"message": "size of first element in nestedObj should be equal to 10",
@@ -268,7 +268,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "size(self[0][0]) == 10",
 								"message": "size of items under items of scoped field should be equal to 10",
@@ -310,7 +310,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "self[0].nestedObj.val == 10",
 								"message": "val under nestedObj under properties under items should be equal to 10",
@@ -339,7 +339,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "size(self) > 0",
 								"message": "size of scoped field should be greater than 0",
@@ -359,7 +359,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "size(self) == 10",
 								"message": "size of scoped field should be equal to 10",
@@ -380,7 +380,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"rule":    "size(self) == 10",
 								"message": "size of scoped field should be equal to 10",
@@ -401,7 +401,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"message": "size of scoped field should be equal to 10",
 							},
@@ -421,7 +421,7 @@ func TestCelCompilation(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validators": []interface{}{
+						"x-kubernetes-validations": []interface{}{
 							map[string]interface{}{
 								"message": "size of scoped field should be equal to 10",
 							},

--- a/pkg/validation/errors/schema.go
+++ b/pkg/validation/errors/schema.go
@@ -568,11 +568,11 @@ func MultipleOfMustBePositive(name, in string, factor interface{}) *Validation {
 	}
 }
 
-// FailedValidatorRule error for when a value fails a x-kubernetes-validators rule.
+// FailedValidatorRule error for when a value fails a x-kubernetes-validations rule.
 func FailedValidatorRule(name, in, rule, message string, value interface{}) *Validation {
 	var msg string
 	if message != "" {
-		// If x-kubernetes-validators rule provided a custom message, use it.
+		// If x-kubernetes-validations rule provided a custom message, use it.
 		msg = fmt.Sprintf("%s: %s", name, message)
 	} else {
 		msg = fmt.Sprintf("%s failed validator rule '%s'", name, rule)
@@ -587,7 +587,7 @@ func FailedValidatorRule(name, in, rule, message string, value interface{}) *Val
 	}
 }
 
-// ErrorExecutingValidatorRule error for when execution of a x-kubernetes-validators rule results in an error.
+// ErrorExecutingValidatorRule error for when execution of a x-kubernetes-validations rule results in an error.
 func ErrorExecutingValidatorRule(name, in, rule string, err error, value interface{}) *Validation {
 	var msg = fmt.Sprintf("%s failed to execute validator rule '%s' due to error: %v", name, rule, err)
 

--- a/pkg/validation/spec/info.go
+++ b/pkg/validation/spec/info.go
@@ -87,7 +87,7 @@ func (e Extensions) GetObject(key string, out interface{}) error {
 	return nil
 }
 
-// ValidationRules defines the format of the x-kubernetes-validators schema extension.
+// ValidationRules defines the format of the x-kubernetes-validations schema extension.
 type ValidationRules []ValidationRule
 
 // ValidationRule defines the format of each rule in CELValidationRules.

--- a/pkg/validation/validate/cel_expression_validator.go
+++ b/pkg/validation/validate/cel_expression_validator.go
@@ -25,10 +25,10 @@ import (
 
 func newCelExpressionValidator(path string, schema *spec.Schema) valueValidator {
 	rules := &spec.ValidationRules{}
-	err := schema.Extensions.GetObject("x-kubernetes-validators", rules)
+	err := schema.Extensions.GetObject("x-kubernetes-validations", rules)
 	if err != nil {
-		// The x-kubernetes-validators fields are validated at CRD registration time, so must be valid by the time they are used for validation
-		panic(fmt.Sprintf("Unexpected error accessing x-kubernetes-validators at %s: %v", err, path))
+		// The x-kubernetes-validations fields are validated at CRD registration time, so must be valid by the time they are used for validation
+		panic(fmt.Sprintf("Unexpected error accessing x-kubernetes-validations at %s: %v", err, path))
 	}
 	if len(*rules) == 0 {
 		return nil

--- a/pkg/validation/validate/cel_expression_validator_test.go
+++ b/pkg/validation/validate/cel_expression_validator_test.go
@@ -200,7 +200,7 @@ func TestCelValueValidator(t *testing.T) {
 			}()
 			if tc.expr != "" {
 				schema.Extensions = map[string]interface{}{
-					"x-kubernetes-validators": []interface{}{
+					"x-kubernetes-validations": []interface{}{
 						map[string]interface{}{
 							"rule": tc.expr,
 						},

--- a/pkg/validation/validate/schema_option.go
+++ b/pkg/validation/validate/schema_option.go
@@ -30,7 +30,7 @@ func (svo SchemaValidatorOptions) Options() []Option {
 	return []Option{}
 }
 
-// ValidationRulesEnabled enables validation of rules defined in x-kubernetes-validators
+// ValidationRulesEnabled enables validation of rules defined in x-kubernetes-validations
 // schema extensions.
 var ValidationRulesEnabled = func(opts *SchemaValidatorOptions) {
 	opts.validationRulesEnabled = true

--- a/pkg/validation/validate/schema_test.go
+++ b/pkg/validation/validate/schema_test.go
@@ -192,7 +192,7 @@ func TestCelExpressionValidator(t *testing.T) {
 				"spec": {
 					VendorExtensible: spec.VendorExtensible{
 						Extensions: map[string]interface{}{
-							"x-kubernetes-validators": []interface{}{
+							"x-kubernetes-validations": []interface{}{
 								map[string]interface{}{
 									"rule": "minReplicas < maxReplicas",
 								},
@@ -209,7 +209,7 @@ func TestCelExpressionValidator(t *testing.T) {
 								},
 								VendorExtensible: spec.VendorExtensible{
 									Extensions: map[string]interface{}{
-										"x-kubernetes-validators": []interface{}{
+										"x-kubernetes-validations": []interface{}{
 											map[string]interface{}{
 												"rule": "self >= 0",
 											},
@@ -224,7 +224,7 @@ func TestCelExpressionValidator(t *testing.T) {
 								},
 								VendorExtensible: spec.VendorExtensible{
 									Extensions: map[string]interface{}{
-										"x-kubernetes-validators": []interface{}{
+										"x-kubernetes-validations": []interface{}{
 											map[string]interface{}{
 												"rule": "self >= 0",
 											},
@@ -235,7 +235,7 @@ func TestCelExpressionValidator(t *testing.T) {
 							"nestedObj": {
 								VendorExtensible: spec.VendorExtensible{
 									Extensions: map[string]interface{}{
-										"x-kubernetes-validators": []interface{}{
+										"x-kubernetes-validations": []interface{}{
 											map[string]interface{}{
 												"rule":    "val < 10",
 												"message": "val is a bit too big",
@@ -262,7 +262,7 @@ func TestCelExpressionValidator(t *testing.T) {
 							"objMap": {
 								VendorExtensible: spec.VendorExtensible{
 									Extensions: map[string]interface{}{
-										"x-kubernetes-validators": []interface{}{
+										"x-kubernetes-validations": []interface{}{
 											map[string]interface{}{
 												"rule": "self.all(m, self[m].val > 10)",
 											},
@@ -292,7 +292,7 @@ func TestCelExpressionValidator(t *testing.T) {
 							"details": {
 								VendorExtensible: spec.VendorExtensible{
 									Extensions: map[string]interface{}{
-										"x-kubernetes-validators": []interface{}{
+										"x-kubernetes-validations": []interface{}{
 											map[string]interface{}{
 												"rule": "messages.all(m, m.val > 10)",
 											},


### PR DESCRIPTION
Based on API review comment got here: https://github.com/kubernetes/kubernetes/pull/105477#discussion_r738562621, update field name to `x-kubernetes-validators`