### PR TITLE
Update mustNotValidatechemaMsg to mustNotValidateSchemaMsg

### DIFF
--- a/pkg/validation/validate/schema_messages.go
+++ b/pkg/validation/validate/schema_messages.go
@@ -61,7 +61,7 @@ func mustValidateAtLeastOneSchemaMsg(path string) errors.Error {
 func mustValidateAllSchemasMsg(path, additionalMsg string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, MustValidateAllSchemasError, path, additionalMsg)
 }
-func mustNotValidatechemaMsg(path string) errors.Error {
+func mustNotValidateSchemaMsg(path string) errors.Error {
 	return errors.New(errors.CompositeErrorCode, MustNotValidateSchemaError, path)
 }
 func hasADependencyMsg(path, depkey string) errors.Error {

--- a/pkg/validation/validate/schema_props.go
+++ b/pkg/validation/validate/schema_props.go
@@ -208,7 +208,7 @@ func (s *schemaPropsValidator) Validate(data interface{}) *Result {
 		result := s.notValidator.Validate(data)
 		// We keep inner IMPORTANT! errors no matter what MatchCount tells us
 		if result.IsValid() {
-			mainResult.AddErrors(mustNotValidatechemaMsg(s.Path))
+			mainResult.AddErrors(mustNotValidateSchemaMsg(s.Path))
 		}
 	}
 


### PR DESCRIPTION
Fixes small function signature typo in schemaProps validation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>