### PR TITLE
cherry-picking #251 to release-1.22

### DIFF
--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -10,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	json "github.com/json-iterator/go"
 	yaml "gopkg.in/yaml.v2"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -176,4 +177,87 @@ func TestToProtoBinary(t *testing.T) {
 		t.Fatal()
 	}
 	// TODO: add some kind of roundtrip test here
+}
+
+func TestCache(t *testing.T) {
+	calledCount := 0
+	expectedBytes := []byte("ABC")
+	cacheObj := cache{
+		BuildCache: func() ([]byte, error) {
+			calledCount++
+			return expectedBytes, nil
+		},
+	}
+	bytes, _, _ := cacheObj.Get()
+	if string(bytes) != string(expectedBytes) {
+		t.Fatalf("got value of %q from cache (expected %q)", bytes, expectedBytes)
+	}
+	cacheObj.Get()
+	if calledCount != 1 {
+		t.Fatalf("expected BuildCache to be called once (called %d times)", calledCount)
+	}
+}
+
+func TestCacheError(t *testing.T) {
+	cacheObj := cache{
+		BuildCache: func() ([]byte, error) {
+			return nil, errors.New("cache error")
+		},
+	}
+	_, _, err := cacheObj.Get()
+	if err == nil {
+		t.Fatalf("expected non-nil err from cache.Get()")
+	}
+}
+
+func TestCacheRefresh(t *testing.T) {
+	// check that returning an error while having no prior cached value results in a nil value from cache.Get()
+	cacheObj := (&cache{}).New(func() ([]byte, error) {
+		return nil, errors.New("returning nil bytes")
+	})
+	// make multiple calls to Get() to ensure errors are preserved across subsequent calls
+	for i := 0; i < 4; i++ {
+		value, _, err := cacheObj.Get()
+		if value != nil {
+			t.Fatalf("expected nil bytes (got %s)", value)
+		}
+		if err == nil {
+			t.Fatalf("expected non-nil err from cache.Get()")
+		}
+	}
+	// check that we can call New() multiple times and get the last known cache value while also returning any errors
+	lastGoodVal := []byte("last good value")
+	cacheObj = cacheObj.New(func() ([]byte, error) {
+		return lastGoodVal, nil
+	})
+	// call Get() once, so lastGoodVal is cached
+	_, lastGoodEtag, _ := cacheObj.Get()
+	for i := 0; i < 4; i++ {
+		cacheObj = cacheObj.New(func() ([]byte, error) {
+			return nil, errors.New("check that c.bytes is preserved across New() calls")
+		})
+		value, newEtag, err := cacheObj.Get()
+		if err == nil {
+			t.Fatalf("expected non-nil err from cache.Get()")
+		}
+		if string(value) != string(lastGoodVal) {
+			t.Fatalf("expected previous value for cache to be returned (got %s, expected %s)", value, lastGoodVal)
+		}
+		// check that etags carry over between calls to cache.New()
+		if lastGoodEtag != newEtag {
+			t.Fatalf("expected etags to match (got %s, expected %s", newEtag, lastGoodEtag)
+		}
+	}
+	// check that if we successfully renew the cache the old last known value is flushed
+	newVal := []byte("new good value")
+	cacheObj = cacheObj.New(func() ([]byte, error) {
+		return newVal, nil
+	})
+	value, _, err := cacheObj.Get()
+	if err != nil {
+		t.Fatalf("expected nil err from cache.Get()")
+	}
+	if string(value) != string(newVal) {
+		t.Fatalf("got value of %s from cache (expected %s)", value, newVal)
+	}
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes/kube-openapi/pull/251 into release-1.22 as discussed in the sig-apimachinery meeting and over Slack. Details about why it's needed are here in [this issue](https://github.com/kubernetes/kubernetes/issues/105932).