### PR TITLE
OpenAPI Enums: Format update

### DIFF
--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -74,15 +74,15 @@ func (et *enumType) ValueStrings() []string {
 // DescriptionLines returns a description of the enum in this format:
 //
 // Possible enum values:
-//  - `value1`: description 1
-//  - `value2`: description 2
+//  - `"value1"` description 1
+//  - `"value2"` description 2
 func (et *enumType) DescriptionLines() []string {
 	var lines []string
 	for _, value := range et.Values {
 		lines = append(lines, value.Description())
 	}
 	sort.Strings(lines)
-	// Prepend a empty string to initiate a new paragraph.
+	// Prepend an empty string to initiate a new paragraph.
 	return append([]string{"", enumTypeDescriptionHeader}, lines...)
 }
 
@@ -125,7 +125,7 @@ func (et *enumType) appendValue(value *enumValue) {
 
 // Description returns the description line for the enumValue
 // with the format:
-//  - `FooValue`: is the Foo value
+//  - `"FooValue"` is the Foo value
 func (ev *enumValue) Description() string {
 	comment := strings.TrimSpace(ev.Comment)
 	// The comment should starts with the type name, trim it first.
@@ -134,7 +134,7 @@ func (ev *enumValue) Description() string {
 	comment = strings.TrimSpace(comment)
 	// The comment may be multiline, cascade all consecutive whitespaces.
 	comment = whitespaceRegex.ReplaceAllString(comment, " ")
-	return fmt.Sprintf(" - `%s`: %s", ev.Value, comment)
+	return fmt.Sprintf(" - `%q` %s", ev.Value, comment)
 }
 
 // isEnumType checks if a given type is an enum by the definition

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1607,7 +1607,7 @@ Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "Value": {
 SchemaProps: spec.SchemaProps{`+"\n"+
-		"Description: \"Value is the value.\\n\\nPossible enum values:\\n - `a`: is a.\\n - `b`: is b.\","+`
+		"Description: \"Value is the value.\\n\\nPossible enum values:\\n - `\\\"a\\\"` is a.\\n - `\\\"b\\\"` is b.\","+`
 Default: "",
 Type: []string{"string"},
 Format: "",

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -287,7 +287,7 @@ func schema_test_integration_testdata_enumtype_FruitsBasket(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"content": {
 						SchemaProps: spec.SchemaProps{
-							Description: "\n\n\nPossible enum values:\n - `apple`: is the Apple\n - `banana`: is the Banana\n - `onigiri`: is the Rice ball that does not seem to belong to a fruits basket but has a long comment that is so long that it spans multiple lines",
+							Description: "\n\n\nPossible enum values:\n - `\"apple\"` is the Apple\n - `\"banana\"` is the Banana\n - `\"onigiri\"` is the Rice ball that does not seem to belong to a fruits basket but has a long comment that is so long that it spans multiple lines",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
This PR updates the format of enum description so it can be more consistent with existing godoc.

BEFORE
```
Possible enum values:

- `apple`: is the Apple
- `banana`: is the Banana
- `onigiri`: is the Rice ball that does not seem to belong to a fruits basket but has a long comment that is so long that it spans multiple lines"
```

AFTER
```
Possible enum values:

- `"apple"` is the Apple
- `"banana"` is the Banana
- `"onigiri"` is the Rice ball that does not seem to belong to a fruits basket but has a long comment that is so long that it spans multiple lines"
```
