### PR TITLE
Set path for specific validators when set on parent SchemaValidator and use JSONPath syntax

### DIFF
--- a/pkg/validation/validate/object_validator.go
+++ b/pkg/validation/validate/object_validator.go
@@ -17,7 +17,6 @@ package validate
 import (
 	"reflect"
 	"regexp"
-	"strings"
 
 	"k8s.io/kube-openapi/pkg/validation/errors"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -49,21 +48,6 @@ func (o *objectValidator) Applies(source interface{}, kind reflect.Kind) bool {
 	r := reflect.TypeOf(source) == specSchemaType && (kind == reflect.Map || kind == reflect.Struct)
 	debugLog("object validator for %q applies %t for %T (kind: %v)\n", o.Path, r, source, kind)
 	return r
-}
-
-func (o *objectValidator) isProperties() bool {
-	p := strings.Split(o.Path, ".")
-	return len(p) > 1 && p[len(p)-1] == jsonProperties && p[len(p)-2] != jsonProperties
-}
-
-func (o *objectValidator) isDefault() bool {
-	p := strings.Split(o.Path, ".")
-	return len(p) > 1 && p[len(p)-1] == jsonDefault && p[len(p)-2] != jsonDefault
-}
-
-func (o *objectValidator) isExample() bool {
-	p := strings.Split(o.Path, ".")
-	return len(p) > 1 && (p[len(p)-1] == swaggerExample || p[len(p)-1] == swaggerExamples) && p[len(p)-2] != swaggerExample
 }
 
 func (o *objectValidator) Validate(data interface{}) *Result {

--- a/pkg/validation/validate/schema.go
+++ b/pkg/validation/validate/schema.go
@@ -99,6 +99,9 @@ func NewSchemaValidator(schema *spec.Schema, rootSchema interface{}, root string
 // SetPath sets the path for this schema validator
 func (s *SchemaValidator) SetPath(path string) {
 	s.Path = path
+	for _, v := range s.validators {
+		v.SetPath(path)
+	}
 }
 
 // Applies returns true when this schema validator applies

--- a/pkg/validation/validate/schema_props.go
+++ b/pkg/validation/validate/schema_props.go
@@ -41,6 +41,18 @@ type schemaPropsValidator struct {
 
 func (s *schemaPropsValidator) SetPath(path string) {
 	s.Path = path
+	for _, v := range s.anyOfValidators {
+		v.SetPath(path)
+	}
+	for _, v := range s.allOfValidators {
+		v.SetPath(path)
+	}
+	for _, v := range s.oneOfValidators {
+		v.SetPath(path)
+	}
+	if s.notValidator != nil {
+		s.notValidator.SetPath(path)
+	}
 }
 
 func newSchemaPropsValidator(path string, in string, allOf, oneOf, anyOf []spec.Schema, not *spec.Schema, deps spec.Dependencies, root interface{}, formats strfmt.Registry, options ...Option) *schemaPropsValidator {

--- a/pkg/validation/validate/slice_validator.go
+++ b/pkg/validation/validate/slice_validator.go
@@ -56,7 +56,7 @@ func (s *schemaSliceValidator) Validate(data interface{}) *Result {
 	if s.Items != nil && s.Items.Schema != nil {
 		validator := NewSchemaValidator(s.Items.Schema, s.Root, s.Path, s.KnownFormats, s.Options.Options()...)
 		for i := 0; i < size; i++ {
-			validator.SetPath(fmt.Sprintf("%s.%d", s.Path, i))
+			validator.SetPath(fmt.Sprintf("%s[%d]", s.Path, i))
 			value := val.Index(i)
 			result.Merge(validator.Validate(value.Interface()))
 		}
@@ -66,7 +66,7 @@ func (s *schemaSliceValidator) Validate(data interface{}) *Result {
 	if s.Items != nil && len(s.Items.Schemas) > 0 {
 		itemsSize = len(s.Items.Schemas)
 		for i := 0; i < itemsSize; i++ {
-			validator := NewSchemaValidator(&s.Items.Schemas[i], s.Root, fmt.Sprintf("%s.%d", s.Path, i), s.KnownFormats, s.Options.Options()...)
+			validator := NewSchemaValidator(&s.Items.Schemas[i], s.Root, fmt.Sprintf("%s[%d]", s.Path, i), s.KnownFormats, s.Options.Options()...)
 			if val.Len() <= i {
 				break
 			}
@@ -79,7 +79,7 @@ func (s *schemaSliceValidator) Validate(data interface{}) *Result {
 		}
 		if s.AdditionalItems.Schema != nil {
 			for i := itemsSize; i < size-itemsSize+1; i++ {
-				validator := NewSchemaValidator(s.AdditionalItems.Schema, s.Root, fmt.Sprintf("%s.%d", s.Path, i), s.KnownFormats, s.Options.Options()...)
+				validator := NewSchemaValidator(s.AdditionalItems.Schema, s.Root, fmt.Sprintf("%s[%d]", s.Path, i), s.KnownFormats, s.Options.Options()...)
 				result.Merge(validator.Validate(val.Index(i).Interface()))
 			}
 		}


### PR DESCRIPTION
Currently if we set the path for the SchemaValidator after creation it
does not propagate down to the specific validators embedded within. That
means that subsequent SchemaValidators that are created by the specific
validators will have the wrong path. This updates to set the path for
all specific validators when it is set on their parent SchemaValidator.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates to use proper JSONPath bracket syntax for indices in a path.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/assign @apelisse 

Fixes #262 