### PR TITLE
support Deprecated field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/emicklei/go-restful/v3 v3.8.0
-	github.com/getkin/kin-openapi v0.76.0
+ 	github.com/getkin/kin-openapi v0.76.0
 	github.com/go-openapi/jsonreference v0.19.3
 	github.com/go-openapi/swag v0.19.5
 	github.com/golang/protobuf v1.5.2
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
-	github.com/mitchellh/mapstructure v1.1.2
+ 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/emicklei/go-restful/v3 v3.8.0
- 	github.com/getkin/kin-openapi v0.76.0
+	github.com/getkin/kin-openapi v0.76.0
 	github.com/go-openapi/jsonreference v0.19.3
 	github.com/go-openapi/swag v0.19.5
 	github.com/golang/protobuf v1.5.2
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
- 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0

--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -286,6 +286,7 @@ func (o *openAPI) buildOperations(route common.Route, inPathCommonParamsMap map[
 			Description: route.Description(),
 			Consumes:    route.Consumes(),
 			Produces:    route.Produces(),
+			Deprecated:  route.Deprecated(),
 			Schemes:     o.config.ProtocolList,
 			Responses: &spec.Responses{
 				ResponsesProps: spec.ResponsesProps{

--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -77,6 +77,7 @@ func (o *openAPI) buildOperations(route common.Route, inPathCommonParamsMap map[
 	ret := &spec3.Operation{
 		OperationProps: spec3.OperationProps{
 			Description: route.Description(),
+			Deprecated:  route.Deprecated(),
 			Responses: &spec3.Responses{
 				ResponsesProps: spec3.ResponsesProps{
 					StatusCodeResponses: make(map[int]*spec3.Response),

--- a/pkg/common/interfaces.go
+++ b/pkg/common/interfaces.go
@@ -36,6 +36,8 @@ type Route interface {
 	// StatusCodeResponses defines a mapping of HTTP Status Codes to the specific response(s).
 	// Multiple responses with the same HTTP Status Code are acceptable.
 	StatusCodeResponses() []StatusCodeResponse
+	// Deprecated marks a route as deprecated
+	Deprecated() bool
 }
 
 // StatusCodeResponse is an explicit response type with an HTTP Status Code.

--- a/pkg/common/restfuladapter/route_adapter.go
+++ b/pkg/common/restfuladapter/route_adapter.go
@@ -66,3 +66,7 @@ func (r *RouteAdapter) RequestPayloadSample() interface{} {
 func (r *RouteAdapter) ResponsePayloadSample() interface{} {
 	return r.Route.WriteSample
 }
+
+func (r *RouteAdapter) Deprecated() bool {
+	return r.Route.Deprecated
+}


### PR DESCRIPTION
go-restful is at version v2.9.5 in k/k already: https://github.com/kubernetes/kubernetes/blob/master/go.mod#L36

This PR supports publishing the deprecated field for an operation in both OpenAPI v2 and v3.

See https://github.com/kubernetes/kubernetes/pull/107622 for how swagger.json changes with this update. 

See https://github.com/kubernetes/kubernetes/issues/107498 for more details on the issue.

/cc @apelisse @liggitt @sttts 