### PR TITLE
Cooldown-based eager marshaling

### DIFF
--- a/pkg/internal/handler/eager.go
+++ b/pkg/internal/handler/eager.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import "time"
+
+// EagerMarshalingCoolDown is the duration after the last update to the spec
+// before an eager marshalling of the spec happens.
+var EagerMarshalingCoolDown = 20 * time.Second


### PR DESCRIPTION
With #251, the marshaling of our OpenAPI spec is delayed until the first request, so that the spec is not re-marshaled every time a new CRD is added, which saves a lot of marshaling time. However, I've encountered the following frustration with our current implementation.

- The API server is idle after CRDs are added and before first request comes. Considering in a real-world scenario, the user usually start adding workload after a few minutes, there is usually plenty of time for the API server to "warm-up" before first request from the user.
- In a replicated/HA control plane, there are multiple instances of API server. The first request warms up only one of the instances. In other words, for N instances, the first N requests are "warm-up"s and slow.

This PR addresses the issues by adding a cooldown. If the spec is not updated within the cooldown, build the cache by marshaling the spec before the first request comes. This way, we can avoid having to frequently re-marshal the spec while keeping first requests fast.