### PR TITLE
yaml unmarshal for OpenAPIv2 types

### DIFF
--- a/pkg/validation/spec/contact_info.go
+++ b/pkg/validation/spec/contact_info.go
@@ -18,7 +18,7 @@ package spec
 //
 // For more information: http://goo.gl/8us55a#contactObject
 type ContactInfo struct {
-	Name  string `json:"name,omitempty"`
-	URL   string `json:"url,omitempty"`
-	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 }

--- a/pkg/validation/spec/external_docs.go
+++ b/pkg/validation/spec/external_docs.go
@@ -19,6 +19,6 @@ package spec
 //
 // For more information: http://goo.gl/8us55a#externalDocumentationObject
 type ExternalDocumentation struct {
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
 }

--- a/pkg/validation/spec/header.go
+++ b/pkg/validation/spec/header.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 
 // HeaderProps describes a response header
 type HeaderProps struct {
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // Header describes a header for a response of the API
@@ -68,4 +69,18 @@ func (h *Header) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &h.HeaderProps)
+}
+
+// UnmarshalJSON unmarshals this header from JSON
+func (h *Header) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&h.CommonValidations); err != nil {
+		return err
+	}
+	if err := value.Decode(&h.SimpleSchema); err != nil {
+		return err
+	}
+	if err := value.Decode(&h.VendorExtensible); err != nil {
+		return err
+	}
+	return value.Decode(&h.HeaderProps)
 }

--- a/pkg/validation/spec/items.go
+++ b/pkg/validation/spec/items.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -26,29 +27,29 @@ const (
 
 // SimpleSchema describe swagger simple schemas for parameters and headers
 type SimpleSchema struct {
-	Type             string      `json:"type,omitempty"`
-	Nullable         bool        `json:"nullable,omitempty"`
-	Format           string      `json:"format,omitempty"`
-	Items            *Items      `json:"items,omitempty"`
-	CollectionFormat string      `json:"collectionFormat,omitempty"`
-	Default          interface{} `json:"default,omitempty"`
-	Example          interface{} `json:"example,omitempty"`
+	Type             string      `json:"type,omitempty" yaml:"type,omitempty"`
+	Nullable         bool        `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	Format           string      `json:"format,omitempty" yaml:"format,omitempty"`
+	Items            *Items      `json:"items,omitempty" yaml:"items,omitempty"`
+	CollectionFormat string      `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
+	Default          interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+	Example          interface{} `json:"example,omitempty" yaml:"example,omitempty"`
 }
 
 // CommonValidations describe common JSON-schema validations
 type CommonValidations struct {
-	Maximum          *float64      `json:"maximum,omitempty"`
-	ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty"`
-	Minimum          *float64      `json:"minimum,omitempty"`
-	ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty"`
-	MaxLength        *int64        `json:"maxLength,omitempty"`
-	MinLength        *int64        `json:"minLength,omitempty"`
-	Pattern          string        `json:"pattern,omitempty"`
-	MaxItems         *int64        `json:"maxItems,omitempty"`
-	MinItems         *int64        `json:"minItems,omitempty"`
-	UniqueItems      bool          `json:"uniqueItems,omitempty"`
-	MultipleOf       *float64      `json:"multipleOf,omitempty"`
-	Enum             []interface{} `json:"enum,omitempty"`
+	Maximum          *float64      `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	Minimum          *float64      `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	MaxLength        *int64        `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinLength        *int64        `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	MaxItems         *int64        `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	MinItems         *int64        `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	MultipleOf       *float64      `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
 }
 
 // Items a limited subset of JSON-Schema's items object.
@@ -60,6 +61,25 @@ type Items struct {
 	CommonValidations
 	SimpleSchema
 	VendorExtensible
+}
+
+func (i *Items) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&i.CommonValidations); err != nil {
+		return err
+	}
+
+	if err := value.Decode(&i.Refable); err != nil {
+		return err
+	}
+
+	if err := value.Decode(&i.SimpleSchema); err != nil {
+		return err
+	}
+
+	if err := i.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
 }
 
 // UnmarshalJSON hydrates this items instance with the data from JSON

--- a/pkg/validation/spec/license.go
+++ b/pkg/validation/spec/license.go
@@ -18,6 +18,6 @@ package spec
 //
 // For more information: http://goo.gl/8us55a#licenseObject
 type License struct {
-	Name string `json:"name,omitempty"`
-	URL  string `json:"url,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
 }

--- a/pkg/validation/spec/operation.go
+++ b/pkg/validation/spec/operation.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // OperationProps describes an operation
@@ -26,18 +27,18 @@ import (
 // - schemes, when present must be from [http, https, ws, wss]: see validate
 // - Security is handled as a special case: see MarshalJSON function
 type OperationProps struct {
-	Description  string                 `json:"description,omitempty"`
-	Consumes     []string               `json:"consumes,omitempty"`
-	Produces     []string               `json:"produces,omitempty"`
-	Schemes      []string               `json:"schemes,omitempty"`
-	Tags         []string               `json:"tags,omitempty"`
-	Summary      string                 `json:"summary,omitempty"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
-	ID           string                 `json:"operationId,omitempty"`
-	Deprecated   bool                   `json:"deprecated,omitempty"`
-	Security     []map[string][]string  `json:"security,omitempty"`
-	Parameters   []Parameter            `json:"parameters,omitempty"`
-	Responses    *Responses             `json:"responses,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Consumes     []string               `json:"consumes,omitempty" yaml:"consumes,omitempty"`
+	Produces     []string               `json:"produces,omitempty" yaml:"produces,omitempty"`
+	Schemes      []string               `json:"schemes,omitempty" yaml:"schemes,omitempty"`
+	Tags         []string               `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Summary      string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	ID           string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Deprecated   bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Security     []map[string][]string  `json:"security,omitempty" yaml:"security,omitempty"`
+	Parameters   []Parameter            `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Responses    *Responses             `json:"responses,omitempty" yaml:"responses,omitempty"`
 }
 
 // MarshalJSON takes care of serializing operation properties to JSON
@@ -49,7 +50,7 @@ func (op OperationProps) MarshalJSON() ([]byte, error) {
 	type Alias OperationProps
 	if op.Security == nil {
 		return json.Marshal(&struct {
-			Security []map[string][]string `json:"security,omitempty"`
+			Security []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
 			*Alias
 		}{
 			Security: op.Security,
@@ -57,7 +58,7 @@ func (op OperationProps) MarshalJSON() ([]byte, error) {
 		})
 	}
 	return json.Marshal(&struct {
-		Security []map[string][]string `json:"security"`
+		Security []map[string][]string `json:"security" yaml:"security"`
 		*Alias
 	}{
 		Security: op.Security,
@@ -71,6 +72,13 @@ func (op OperationProps) MarshalJSON() ([]byte, error) {
 type Operation struct {
 	VendorExtensible
 	OperationProps
+}
+
+func (o *Operation) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&o.OperationProps); err != nil {
+		return err
+	}
+	return o.VendorExtensible.UnmarshalYAML(value)
 }
 
 // UnmarshalJSON hydrates this items instance with the data from JSON

--- a/pkg/validation/spec/parameter.go
+++ b/pkg/validation/spec/parameter.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // ParamProps describes the specific attributes of an operation parameter
@@ -26,12 +27,12 @@ import (
 // - Schema is defined when "in" == "body": see validate
 // - AllowEmptyValue is allowed where "in" == "query" || "formData"
 type ParamProps struct {
-	Description     string  `json:"description,omitempty"`
-	Name            string  `json:"name,omitempty"`
-	In              string  `json:"in,omitempty"`
-	Required        bool    `json:"required,omitempty"`
-	Schema          *Schema `json:"schema,omitempty"`
-	AllowEmptyValue bool    `json:"allowEmptyValue,omitempty"`
+	Description     string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Name            string  `json:"name,omitempty" yaml:"name,omitempty"`
+	In              string  `json:"in,omitempty" yaml:"in,omitempty"`
+	Required        bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
+	AllowEmptyValue bool    `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 }
 
 // Parameter a unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn).
@@ -83,6 +84,22 @@ func (p *Parameter) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &p.ParamProps)
+}
+
+func (p *Parameter) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&p.CommonValidations); err != nil {
+		return err
+	}
+	if err := value.Decode(&p.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&p.SimpleSchema); err != nil {
+		return err
+	}
+	if err := p.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return value.Decode(&p.ParamProps)
 }
 
 // MarshalJSON converts this items object to JSON

--- a/pkg/validation/spec/path_item.go
+++ b/pkg/validation/spec/path_item.go
@@ -18,18 +18,19 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // PathItemProps the path item specific properties
 type PathItemProps struct {
-	Get        *Operation  `json:"get,omitempty"`
-	Put        *Operation  `json:"put,omitempty"`
-	Post       *Operation  `json:"post,omitempty"`
-	Delete     *Operation  `json:"delete,omitempty"`
-	Options    *Operation  `json:"options,omitempty"`
-	Head       *Operation  `json:"head,omitempty"`
-	Patch      *Operation  `json:"patch,omitempty"`
-	Parameters []Parameter `json:"parameters,omitempty"`
+	Get        *Operation  `json:"get,omitempty" yaml:"get,omitempty"`
+	Put        *Operation  `json:"put,omitempty" yaml:"put,omitempty"`
+	Post       *Operation  `json:"post,omitempty" yaml:"post,omitempty"`
+	Delete     *Operation  `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Options    *Operation  `json:"options,omitempty" yaml:"options,omitempty"`
+	Head       *Operation  `json:"head,omitempty" yaml:"head,omitempty"`
+	Patch      *Operation  `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Parameters []Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }
 
 // PathItem describes the operations available on a single path.
@@ -53,6 +54,16 @@ func (p *PathItem) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &p.PathItemProps)
+}
+
+func (p *PathItem) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&p.Refable); err != nil {
+		return err
+	}
+	if err := p.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return value.Decode(&p.PathItemProps)
 }
 
 // MarshalJSON converts this items object to JSON

--- a/pkg/validation/spec/ref.go
+++ b/pkg/validation/spec/ref.go
@@ -21,11 +21,13 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/jsonreference"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/util"
 )
 
 // Refable is a struct for things that accept a $ref property
 type Refable struct {
-	Ref Ref
+	Ref Ref `yaml:"$ref,omitempty"`
 }
 
 // MarshalJSON marshals the ref to json
@@ -146,6 +148,22 @@ func (r *Ref) UnmarshalJSON(d []byte) error {
 		return err
 	}
 	return r.fromMap(v)
+}
+
+func (r *Ref) UnmarshalYAML(n *yaml.Node) error {
+	var valueStr string
+	if err := util.DecodeYAMLString(n, &valueStr); err != nil {
+		return err
+	}
+
+	ref, err := jsonreference.New(valueStr)
+	if err != nil {
+		return err
+	}
+
+	r.Ref = ref
+
+	return nil
 }
 
 func (r *Ref) fromMap(v map[string]interface{}) error {

--- a/pkg/validation/spec/response.go
+++ b/pkg/validation/spec/response.go
@@ -18,14 +18,15 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // ResponseProps properties specific to a response
 type ResponseProps struct {
-	Description string                 `json:"description,omitempty"`
-	Schema      *Schema                `json:"schema,omitempty"`
-	Headers     map[string]Header      `json:"headers,omitempty"`
-	Examples    map[string]interface{} `json:"examples,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Schema      *Schema                `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Headers     map[string]Header      `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Examples    map[string]interface{} `json:"examples,omitempty" yaml:"examples,omitempty"`
 }
 
 // Response describes a single response from an API Operation.
@@ -46,6 +47,16 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &r.VendorExtensible)
+}
+
+func (r *Response) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&r.ResponseProps); err != nil {
+		return err
+	}
+	if err := value.Decode(&r.Refable); err != nil {
+		return err
+	}
+	return r.VendorExtensible.UnmarshalYAML(value)
 }
 
 // MarshalJSON converts this items object to JSON

--- a/pkg/validation/spec/security_scheme.go
+++ b/pkg/validation/spec/security_scheme.go
@@ -18,18 +18,19 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // SecuritySchemeProps describes a swagger security scheme in the securityDefinitions section
 type SecuritySchemeProps struct {
-	Description      string            `json:"description,omitempty"`
-	Type             string            `json:"type"`
-	Name             string            `json:"name,omitempty"`             // api key
-	In               string            `json:"in,omitempty"`               // api key
-	Flow             string            `json:"flow,omitempty"`             // oauth2
-	AuthorizationURL string            `json:"authorizationUrl,omitempty"` // oauth2
-	TokenURL         string            `json:"tokenUrl,omitempty"`         // oauth2
-	Scopes           map[string]string `json:"scopes,omitempty"`           // oauth2
+	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Type             string            `json:"type" yaml:"type"`
+	Name             string            `json:"name,omitempty" yaml:"name,omitempty"`                         // api key
+	In               string            `json:"in,omitempty" yaml:"in,omitempty"`                             // api key
+	Flow             string            `json:"flow,omitempty" yaml:"flow,omitempty"`                         // oauth2
+	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"` // oauth2
+	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`                 // oauth2
+	Scopes           map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`                     // oauth2
 }
 
 // SecurityScheme allows the definition of a security scheme that can be used by the operations.
@@ -61,4 +62,11 @@ func (s *SecurityScheme) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &s.VendorExtensible)
+}
+
+func (s *SecurityScheme) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&s.SecuritySchemeProps); err != nil {
+		return err
+	}
+	return value.Decode(&s.VendorExtensible)
 }

--- a/pkg/validation/spec/swagger_test.go
+++ b/pkg/validation/spec/swagger_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 var spec = Swagger{
@@ -106,6 +107,65 @@ const specJSON = `{
 	"x-schemes": ["unix","amqp"]
 }`
 
+const specYAML = `
+id: http://localhost:3849/api-docs
+consumes:
+- application/json
+- application/x-yaml
+produces:
+- application/json
+schemes:
+- http
+- https
+swagger: '2.0'
+info:
+  contact:
+    name: wordnik api team
+    url: http://developer.wordnik.com
+  description: A sample API that uses a petstore as an example to demonstrate features
+    in the swagger-2.0 specification
+  license:
+    name: Creative Commons 4.0 International
+    url: http://creativecommons.org/licenses/by/4.0/
+  termsOfService: http://helloreverb.com/terms/
+  title: Swagger Sample API
+  version: 1.0.9-abcd
+  x-framework: go-swagger
+host: some.api.out.there
+basePath: "/"
+paths:
+  x-framework: go-swagger
+  "/":
+    "$ref": cats
+definitions:
+  Category:
+    type: string
+parameters:
+  categoryParam:
+    name: category
+    in: query
+    type: string
+responses:
+  EmptyAnswer:
+    description: no data to return for this operation
+securityDefinitions:
+  internalApiKey:
+    type: apiKey
+    in: header
+    name: api_key
+security:
+- internalApiKey: []
+tags:
+- name: pets
+externalDocs:
+  description: the name
+  url: the url
+x-some-extension: vendor
+x-schemes:
+- unix
+- amqp
+`
+
 func TestSwaggerSpec_Serialize(t *testing.T) {
 	expected := make(map[string]interface{})
 	_ = json.Unmarshal([]byte(specJSON), &expected)
@@ -122,6 +182,18 @@ func TestSwaggerSpec_Serialize(t *testing.T) {
 func TestSwaggerSpec_Deserialize(t *testing.T) {
 	var actual Swagger
 	err := json.Unmarshal([]byte(specJSON), &actual)
+	if assert.NoError(t, err) {
+		assert.EqualValues(t, actual, spec)
+	}
+}
+
+func TestSwaggerSpec_DeserializeYAML(t *testing.T) {
+	var actual Swagger
+	var nodes yaml.Node
+	err := yaml.Unmarshal([]byte(specYAML), &nodes)
+	assert.NoError(t, err)
+
+	err = nodes.Decode(&actual)
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, actual, spec)
 	}

--- a/pkg/validation/spec/tag.go
+++ b/pkg/validation/spec/tag.go
@@ -18,13 +18,14 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // TagProps describe a tag entry in the top level tags section of a swagger spec
 type TagProps struct {
-	Description  string                 `json:"description,omitempty"`
-	Name         string                 `json:"name,omitempty"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Name         string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 // Tag allows adding meta data to a single tag that is used by the
@@ -56,4 +57,11 @@ func (t *Tag) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &t.VendorExtensible)
+}
+
+func (t *Tag) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&t.TagProps); err != nil {
+		return err
+	}
+	return t.VendorExtensible.UnmarshalYAML(value)
 }


### PR DESCRIPTION
There is no fast way to deserialize protobuf into kube-openapi types. The obvious choice is to follow this sequence:

`PB` -> `google/gnostic` -> `JSON` -> kube-openapi

However in CLI tools this is slow. On mine and others' systems it takes over half a second to just do the  conversion, let alone the operation the user requested. Too slow for interactivity.

This PR facilitates the intermediate step necessary to perform the following faster conversion:

`PB` -> `google/gnostic` -> `yaml.v3.Node` -> kube-openapi

This method compares favorably to the choice of using JSON as an intermediary.

OpenAPI V2 Conversion Benchmarks:
These benchmarks start with `swagger.json` pulled from a running k8s cluster and measure conversions between various representations of the openapi spec. In the below tests `swagger` refers to `kube-openapi's` `pkg/validation/spec.Swagger`


Ran a benchmark to compare different conversion:
https://github.com/alexzielenski/kube-openapi-gnostic-benchmark

Using JSON:
```
BenchmarkSlowConversion/json->swagger-8         	       2	 557015227 ns/op	95739288 B/op	 1381635 allocs/op
BenchmarkSlowConversion/swagger->json-8         	       8	 128882670 ns/op	71913162 B/op	  274072 allocs/op
BenchmarkSlowConversion/json->gnostic-8         	       5	 216769974 ns/op	81453435 B/op	 1248390 allocs/op
BenchmarkSlowConversion/gnostic->pb-8           	     121	   9842726 ns/op	 2899970 B/op	       1 allocs/op
BenchmarkSlowConversion/pb->gnostic-8           	     100	  15442423 ns/op	 9480707 B/op	  123829 allocs/op
BenchmarkSlowConversion/gnostic->yaml-8         	      42	  28809063 ns/op	32855155 B/op	  264562 allocs/op

BenchmarkSlowConversion/yaml->json-8            	      20	  61439852 ns/op	25325099 B/op	  463786 allocs/op
BenchmarkSlowConversion/json->swagger#01-8      	       2	 524846406 ns/op	95787616 B/op	 1381624 allocs/op
```

Using YAML:
```
BenchmarkFastConversion/json->swagger-8         	       2	 548771326 ns/op	95736376 B/op	 1381630 allocs/op
BenchmarkFastConversion/swagger->json-8         	       8	 147762185 ns/op	67593998 B/op	  274060 allocs/op
BenchmarkFastConversion/json->gnostic-8         	       5	 228517622 ns/op	81446896 B/op	 1248395 allocs/op
BenchmarkFastConversion/gnostic->pb-8           	     100	  10217647 ns/op	 2899968 B/op	       1 allocs/op
BenchmarkFastConversion/pb->gnostic-8           	     100	  12665889 ns/op	 9480707 B/op	  123829 allocs/op
BenchmarkFastConversion/gnostic->yaml-8         	      37	  27832678 ns/op	32855294 B/op	  264562 allocs/op

BenchmarkFastConversion/yaml->swagger-8         	      21	  58512404 ns/op	23687182 B/op	  510369 allocs/op
```

`yaml->swagger` at 58.5ms is 10x faster than `yaml->json` + `json->swagger#01` at 586.2ms

OpenAPI V3 yaml patch is forthcoming in another PR