### PR TITLE
[wip] yaml unmarshal for OpenAPIv3 types

### DIFF
--- a/pkg/spec3/component.go
+++ b/pkg/spec3/component.go
@@ -25,21 +25,21 @@ import "k8s.io/kube-openapi/pkg/validation/spec"
 // more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject
 type Components struct {
 	// Schemas holds reusable Schema Objects
-	Schemas map[string]*spec.Schema `json:"schemas,omitempty"`
+	Schemas map[string]*spec.Schema `json:"schemas,omitempty" yaml:"schemas,omitempty"`
 	// SecuritySchemes holds reusable Security Scheme Objects, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
-	SecuritySchemes SecuritySchemes `json:"securitySchemes,omitempty"`
+	SecuritySchemes SecuritySchemes `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
 	// Responses holds reusable Responses Objects
-	Responses map[string]*Response `json:"responses,omitempty"`
+	Responses map[string]*Response `json:"responses,omitempty" yaml:"responses,omitempty"`
 	// Parameters holds reusable Parameters Objects
-	Parameters map[string]*Parameter `json:"parameters,omitempty"`
+	Parameters map[string]*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	// Example holds reusable Example objects
-	Examples map[string]*Example `json:"examples,omitempty"`
+	Examples map[string]*Example `json:"examples,omitempty" yaml:"examples,omitempty"`
 	// RequestBodies holds reusable Request Body objects
-	RequestBodies map[string]*RequestBody `json:"requestBodies,omitempty"`
+	RequestBodies map[string]*RequestBody `json:"requestBodies,omitempty" yaml:"requestBodies,omitempty"`
 	// Links is a map of operations links that can be followed from the response
-	Links map[string]*Link `json:"links,omitempty"`
+	Links map[string]*Link `json:"links,omitempty" yaml:"links,omitempty"`
 	// Headers holds a maps of a headers name to its definition
-	Headers map[string]*Header `json:"headers,omitempty"`
+	Headers map[string]*Header `json:"headers,omitempty" yaml:"headers,omitempty"`
 	// all fields are defined at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject
 }
 

--- a/pkg/spec3/component_test.go
+++ b/pkg/spec3/component_test.go
@@ -21,139 +21,275 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
-	"k8s.io/kube-openapi/pkg/spec3"
 	"reflect"
+
+	"k8s.io/kube-openapi/pkg/spec3"
 )
 
-func TestSchemasJSONSerialization(t *testing.T) {
-	cases := []struct {
-		name           string
-		target         spec3.Components
-		expectedOutput string
-	}{
-		{
-			name: "scenario1: smoke test serialization of spec3.Components.Schemas",
-			target: spec3.Components{
-				Schemas: map[string]*spec.Schema{
-					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
-						SchemaProps: spec.SchemaProps{
-							Description: "MutatingWebhook describes an admission webhook and the resources and operations it applies to.",
-							Type:        []string{"object"},
-							Properties: map[string]spec.Schema{
-								"name": {
-									SchemaProps: spec.SchemaProps{
-										Description: "The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.",
-										Type:        []string{"string"},
-										Format:      "",
-									},
+var componentCases = []struct {
+	name           string
+	target         spec3.Components
+	expectedOutput string
+	yaml           []byte
+}{
+	{
+		name: "scenario1: smoke test serialization of spec3.Components.Schemas",
+		target: spec3.Components{
+			Schemas: map[string]*spec.Schema{
+				"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Description: "MutatingWebhook describes an admission webhook and the resources and operations it applies to.",
+						Type:        []string{"object"},
+						Properties: map[string]spec.Schema{
+							"name": {
+								SchemaProps: spec.SchemaProps{
+									Description: "The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.",
+									Type:        []string{"string"},
+									Format:      "",
 								},
-								"clientConfig": {
-									SchemaProps: spec.SchemaProps{
-										Description: "ClientConfig defines how to communicate with the hook. Required",
-										Ref:         spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
-									},
+							},
+							"clientConfig": {
+								SchemaProps: spec.SchemaProps{
+									Description: "ClientConfig defines how to communicate with the hook. Required",
+									Ref:         spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
 								},
-								"rules": {
-									SchemaProps: spec.SchemaProps{
-										Description: "Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.",
-										Type:        []string{"array"},
-										Items: &spec.SchemaOrArray{
-											Schema: &spec.Schema{
-												SchemaProps: spec.SchemaProps{
-													Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.RuleWithOperations"),
-												},
+							},
+							"rules": {
+								SchemaProps: spec.SchemaProps{
+									Description: "Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.",
+									Type:        []string{"array"},
+									Items: &spec.SchemaOrArray{
+										Schema: &spec.Schema{
+											SchemaProps: spec.SchemaProps{
+												Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.RuleWithOperations"),
 											},
 										},
-									},
-								},
-								"failurePolicy": {
-									SchemaProps: spec.SchemaProps{
-										Description: "FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.",
-										Type:        []string{"string"},
-										Format:      "",
-									},
-								},
-								"matchPolicy": {
-									SchemaProps: spec.SchemaProps{
-										Description: "matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".\n\n- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.\n\n- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.\n\nDefaults to \"Exact\"",
-										Type:        []string{"string"},
-										Format:      "",
-									},
-								},
-								"namespaceSelector": {
-									SchemaProps: spec.SchemaProps{
-										Description: "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything.",
-										Ref:         spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
-									},
-								},
-								"objectSelector": {
-									SchemaProps: spec.SchemaProps{
-										Description: "ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.",
-										Ref:         spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
-									},
-								},
-								"sideEffects": {
-									SchemaProps: spec.SchemaProps{
-										Description: "SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.",
-										Type:        []string{"string"},
-										Format:      "",
-									},
-								},
-								"timeoutSeconds": {
-									SchemaProps: spec.SchemaProps{
-										Description: "TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.",
-										Type:        []string{"integer"},
-										Format:      "int32",
-									},
-								},
-								"admissionReviewVersions": {
-									SchemaProps: spec.SchemaProps{
-										Description: "AdmissionReviewVersions is an ordered list of preferred AdmissionReview versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to ['v1beta1'].",
-										Type:        []string{"array"},
-										Items: &spec.SchemaOrArray{
-											Schema: &spec.Schema{
-												SchemaProps: spec.SchemaProps{
-													Type:   []string{"string"},
-													Format: "",
-												},
-											},
-										},
-									},
-								},
-								"reinvocationPolicy": {
-									SchemaProps: spec.SchemaProps{
-										Description: "reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: the webhook will not be called more than once in a single admission evaluation.\n\nIfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.\n\nDefaults to \"Never\".",
-										Type:        []string{"string"},
-										Format:      "",
 									},
 								},
 							},
-							Required: []string{"name", "clientConfig"},
+							"failurePolicy": {
+								SchemaProps: spec.SchemaProps{
+									Description: "FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.",
+									Type:        []string{"string"},
+									Format:      "",
+								},
+							},
+							"matchPolicy": {
+								SchemaProps: spec.SchemaProps{
+									Description: "matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".\n\n- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.\n\n- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.\n\nDefaults to \"Exact\"",
+									Type:        []string{"string"},
+									Format:      "",
+								},
+							},
+							"namespaceSelector": {
+								SchemaProps: spec.SchemaProps{
+									Description: "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything.",
+									Ref:         spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+								},
+							},
+							"objectSelector": {
+								SchemaProps: spec.SchemaProps{
+									Description: "ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.",
+									Ref:         spec.MustCreateRef("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+								},
+							},
+							"sideEffects": {
+								SchemaProps: spec.SchemaProps{
+									Description: "SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.",
+									Type:        []string{"string"},
+									Format:      "",
+								},
+							},
+							"timeoutSeconds": {
+								SchemaProps: spec.SchemaProps{
+									Description: "TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.",
+									Type:        []string{"integer"},
+									Format:      "int32",
+								},
+							},
+							"admissionReviewVersions": {
+								SchemaProps: spec.SchemaProps{
+									Description: "AdmissionReviewVersions is an ordered list of preferred AdmissionReview versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to ['v1beta1'].",
+									Type:        []string{"array"},
+									Items: &spec.SchemaOrArray{
+										Schema: &spec.Schema{
+											SchemaProps: spec.SchemaProps{
+												Type:   []string{"string"},
+												Format: "",
+											},
+										},
+									},
+								},
+							},
+							"reinvocationPolicy": {
+								SchemaProps: spec.SchemaProps{
+									Description: "reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: the webhook will not be called more than once in a single admission evaluation.\n\nIfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.\n\nDefaults to \"Never\".",
+									Type:        []string{"string"},
+									Format:      "",
+								},
+							},
 						},
+						Required: []string{"name", "clientConfig"},
 					},
 				},
 			},
-			expectedOutput: `{"schemas":{"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook":{"description":"MutatingWebhook describes an admission webhook and the resources and operations it applies to.","type":"object","required":["name","clientConfig"],"properties":{"admissionReviewVersions":{"description":"AdmissionReviewVersions is an ordered list of preferred AdmissionReview versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to ['v1beta1'].","type":"array","items":{"type":"string"}},"clientConfig":{"description":"ClientConfig defines how to communicate with the hook. Required","$ref":"k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"},"failurePolicy":{"description":"FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.","type":"string"},"matchPolicy":{"description":"matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".\n\n- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.\n\n- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.\n\nDefaults to \"Exact\"","type":"string"},"name":{"description":"The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.","type":"string"},"namespaceSelector":{"description":"NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything.","$ref":"k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},"objectSelector":{"description":"ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.","$ref":"k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},"reinvocationPolicy":{"description":"reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: the webhook will not be called more than once in a single admission evaluation.\n\nIfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.\n\nDefaults to \"Never\".","type":"string"},"rules":{"description":"Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.","type":"array","items":{"$ref":"k8s.io/api/admissionregistration/v1beta1.RuleWithOperations"}},"sideEffects":{"description":"SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.","type":"string"},"timeoutSeconds":{"description":"TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.","type":"integer","format":"int32"}}}}}`,
 		},
+		expectedOutput: `{"schemas":{"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook":{"description":"MutatingWebhook describes an admission webhook and the resources and operations it applies to.","type":"object","required":["name","clientConfig"],"properties":{"admissionReviewVersions":{"description":"AdmissionReviewVersions is an ordered list of preferred AdmissionReview versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to ['v1beta1'].","type":"array","items":{"type":"string"}},"clientConfig":{"description":"ClientConfig defines how to communicate with the hook. Required","$ref":"k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"},"failurePolicy":{"description":"FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.","type":"string"},"matchPolicy":{"description":"matchPolicy defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" or \"Equivalent\".\n\n- Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.\n\n- Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and \"rules\" only included apiGroups:[\"apps\"], apiVersions:[\"v1\"], resources: [\"deployments\"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.\n\nDefaults to \"Exact\"","type":"string"},"name":{"description":"The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where \"imagepolicy\" is the name of the webhook, and kubernetes.io is the name of the organization. Required.","type":"string"},"namespaceSelector":{"description":"NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything.","$ref":"k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},"objectSelector":{"description":"ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.","$ref":"k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"},"reinvocationPolicy":{"description":"reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: the webhook will not be called more than once in a single admission evaluation.\n\nIfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.\n\nDefaults to \"Never\".","type":"string"},"rules":{"description":"Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.","type":"array","items":{"$ref":"k8s.io/api/admissionregistration/v1beta1.RuleWithOperations"}},"sideEffects":{"description":"SideEffects states whether this webhookk has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.","type":"string"},"timeoutSeconds":{"description":"TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.","type":"integer","format":"int32"}}}}}`,
+		yaml: []byte(`
+schemas:
+  io.k8s.api.admissionregistration.v1beta1.MutatingWebhook:
+    description: MutatingWebhook describes an admission webhook and the resources
+      and operations it applies to.
+    type: object
+    required:
+    - name
+    - clientConfig
+    properties:
+      admissionReviewVersions:
+        description: AdmissionReviewVersions is an ordered list of preferred AdmissionReview
+          versions the Webhook expects. API server will try to use first version in
+          the list which it supports. If none of the versions specified in this list
+          supported by API server, validation will fail for this object. If a persisted
+          webhook configuration specifies allowed versions and does not include any
+          versions known to the API Server, calls to the webhook will fail and be
+          subject to the failure policy. Default to ['v1beta1'].
+        type: array
+        items:
+          type: string
+      clientConfig:
+        description: ClientConfig defines how to communicate with the hook. Required
+        "$ref": k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig
+      failurePolicy:
+        description: FailurePolicy defines how unrecognized errors from the admission
+          endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
+        type: string
+      matchPolicy:
+        description: |-
+          matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
 
-		// scenario 2
-		{
-			name: "scenario2: schema can be defined as a ref, see: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject",
-			target: spec3.Components{
-				Schemas: map[string]*spec.Schema{
-					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
-						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
-						},
+          - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"], a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+          - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"], a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+          Defaults to "Exact"
+        type: string
+      name:
+        description: The name of the admission webhook. Name should be fully qualified,
+          e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the
+          webhook, and kubernetes.io is the name of the organization. Required.
+        type: string
+      namespaceSelector:
+        description: |-
+          NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+          For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+            "matchExpressions": [
+              {
+                "key": "runlevel",
+                "operator": "NotIn",
+                "values": [
+                  "0",
+                  "1"
+                ]
+              }
+            ]
+          }
+
+          If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+            "matchExpressions": [
+              {
+                "key": "environment",
+                "operator": "In",
+                "values": [
+                  "prod",
+                  "staging"
+                ]
+              }
+            ]
+          }
+
+          See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+          Default to the empty LabelSelector, which matches everything.
+        "$ref": k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector
+      objectSelector:
+        description: ObjectSelector decides whether to run the webhook based on if
+          the object has matching labels. objectSelector is evaluated against both
+          the oldObject and newObject that would be sent to the webhook, and is considered
+          to match if either object matches the selector. A null object (oldObject
+          in the case of create, or newObject in the case of delete) or an object
+          that cannot have labels (like a DeploymentRollback or a PodProxyOptions
+          object) is not considered to match. Use the object selector only if the
+          webhook is opt-in, because end users may skip the admission webhook by setting
+          the labels. Default to the empty LabelSelector, which matches everything.
+        "$ref": k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector
+      reinvocationPolicy:
+        description: |-
+          reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are "Never" and "IfNeeded".
+
+          Never: the webhook will not be called more than once in a single admission evaluation.
+
+          IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+
+          Defaults to "Never".
+        type: string
+      rules:
+        description: Rules describes what operations on what resources/subresources
+          the webhook cares about. The webhook cares about an operation if it matches
+          _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and
+          MutatingAdmissionWebhooks from putting the cluster in a state which cannot
+          be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks
+          and MutatingAdmissionWebhooks are never called on admission requests for
+          ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        type: array
+        items:
+          "$ref": k8s.io/api/admissionregistration/v1beta1.RuleWithOperations
+      sideEffects:
+        description: 'SideEffects states whether this webhookk has side effects. Acceptable
+          values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects
+          MUST implement a reconciliation system, since a request may be rejected
+          by a future step in the admission change and the side effects therefore
+          need to be undone. Requests with the dryRun attribute will be auto-rejected
+          if they match a webhook with sideEffects == Unknown or Some. Defaults to
+          Unknown.'
+        type: string
+      timeoutSeconds:
+        description: TimeoutSeconds specifies the timeout for this webhook. After
+          the timeout passes, the webhook call will be ignored or the API call will
+          fail based on the failure policy. The timeout value must be between 1 and
+          30 seconds. Default to 30 seconds.
+        type: integer
+        format: int32
+`),
+	},
+
+	// scenario 2
+	{
+		name: "scenario2: schema can be defined as a ref, see: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject",
+		target: spec3.Components{
+			Schemas: map[string]*spec.Schema{
+				"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
 					},
 				},
 			},
-			expectedOutput: `{"schemas":{"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook":{"$ref":"k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"}}}`,
 		},
-	}
-	for _, tc := range cases {
+		expectedOutput: `{"schemas":{"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook":{"$ref":"k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"}}}`,
+		yaml: []byte(`
+schemas:
+  io.k8s.api.admissionregistration.v1beta1.MutatingWebhook:
+    "$ref": k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig
+`),
+	},
+}
+
+func TestSchemasJSONSerialization(t *testing.T) {
+	for _, tc := range componentCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rawTarget, err := json.Marshal(tc.target)
 			if err != nil {
@@ -170,6 +306,22 @@ func TestSchemasJSONSerialization(t *testing.T) {
 			if !reflect.DeepEqual(expected, tc.target) {
 				t.Fatalf("round trip error %s", tc.name)
 			}
+		})
+	}
+}
+
+func TestSchemasYAMLDeserialization(t *testing.T) {
+	for _, tc := range componentCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// var nodes yaml.Node
+			var actual spec3.Components
+
+			err := yaml.Unmarshal(tc.yaml, &actual)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			require.EqualValues(t, tc.target, actual, "round trip")
 		})
 	}
 }

--- a/pkg/spec3/encoding.go
+++ b/pkg/spec3/encoding.go
@@ -18,7 +18,9 @@ package spec3
 
 import (
 	"encoding/json"
+
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -50,15 +52,25 @@ func (e *Encoding) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *Encoding) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&e.EncodingProps); err != nil {
+		return err
+	}
+	if err := e.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 type EncodingProps struct {
 	// Content Type for encoding a specific property
-	ContentType string `json:"contentType,omitempty"`
+	ContentType string `json:"contentType,omitempty" yaml:"contentType,omitempty"`
 	// A map allowing additional information to be provided as headers
-	Headers map[string]*Header `json:"headers,omitempty"`
+	Headers map[string]*Header `json:"headers,omitempty" yaml:"headers,omitempty"`
 	// Describes how a specific property value will be serialized depending on its type
-	Style string `json:"style,omitempty"`
+	Style string `json:"style,omitempty" yaml:"style,omitempty"`
 	// When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map. For other types of properties this property has no effect
-	Explode string `json:"explode,omitempty"`
+	Explode string `json:"explode,omitempty" yaml:"explode,omitempty"`
 	// AllowReserved determines whether the parameter value SHOULD allow reserved characters, as defined by RFC3986
-	AllowReserved bool `json:"allowReserved,omitempty"`
+	AllowReserved bool `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 }

--- a/pkg/spec3/example.go
+++ b/pkg/spec3/example.go
@@ -19,8 +19,9 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Example https://swagger.io/specification/#example-object
@@ -61,13 +62,26 @@ func (e *Example) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *Example) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&e.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&e.ExampleProps); err != nil {
+		return err
+	}
+	if err := e.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 type ExampleProps struct {
 	// Summary holds a short description of the example
-	Summary string `json:"summary,omitempty"`
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
 	// Description holds a long description of the example
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Embedded literal example.
-	Value interface{} `json:"value,omitempty"`
+	Value interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 	// A URL that points to the literal example. This provides the capability to reference examples that cannot easily be included in JSON or YAML documents.
-	ExternalValue string `json:"externalValue,omitempty"`
+	ExternalValue string `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
 }

--- a/pkg/spec3/external_documentation.go
+++ b/pkg/spec3/external_documentation.go
@@ -18,8 +18,10 @@ package spec3
 
 import (
 	"encoding/json"
-	"k8s.io/kube-openapi/pkg/validation/spec"
+
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 type ExternalDocumentation struct {
@@ -29,9 +31,9 @@ type ExternalDocumentation struct {
 
 type ExternalDocumentationProps struct {
 	// Description is a short description of the target documentation. CommonMark syntax MAY be used for rich text representation.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// URL is the URL for the target documentation.
-	URL string `json:"url"`
+	URL string `json:"url" yaml:"url"`
 }
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
@@ -52,6 +54,16 @@ func (e *ExternalDocumentation) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if err := json.Unmarshal(data, &e.VendorExtensible); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *ExternalDocumentation) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&e.ExternalDocumentationProps); err != nil {
+		return err
+	}
+	if err := e.VendorExtensible.UnmarshalYAML(value); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/spec3/header.go
+++ b/pkg/spec3/header.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -63,28 +64,41 @@ func (h *Header) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (h *Header) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&h.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&h.HeaderProps); err != nil {
+		return err
+	}
+	if err := h.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // HeaderProps a struct that describes a header object
 type HeaderProps struct {
 	// Description holds a brief description of the parameter
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Required determines whether this parameter is mandatory
-	Required bool `json:"required,omitempty"`
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 	// Deprecated declares this operation to be deprecated
-	Deprecated bool `json:"deprecated,omitempty"`
+	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	// AllowEmptyValue sets the ability to pass empty-valued parameters
-	AllowEmptyValue bool `json:"allowEmptyValue,omitempty"`
+	AllowEmptyValue bool `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 	// Style describes how the parameter value will be serialized depending on the type of the parameter value
-	Style string `json:"style,omitempty"`
+	Style string `json:"style,omitempty" yaml:"style,omitempty"`
 	// Explode when true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map
-	Explode bool `json:"explode,omitempty"`
+	Explode bool `json:"explode,omitempty" yaml:"explode,omitempty"`
 	// AllowReserved determines whether the parameter value SHOULD allow reserved characters, as defined by RFC3986
-	AllowReserved bool `json:"allowReserved,omitempty"`
+	AllowReserved bool `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 	// Schema holds the schema defining the type used for the parameter
-	Schema *spec.Schema `json:"schema,omitempty"`
+	Schema *spec.Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
 	// Content holds a map containing the representations for the parameter
-	Content map[string]*MediaType `json:"content,omitempty"`
+	Content map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
 	// Example of the header
-	Example interface{} `json:"example,omitempty"`
+	Example interface{} `json:"example,omitempty" yaml:"example,omitempty"`
 	// Examples of the header
-	Examples map[string]*Example `json:"examples,omitempty"`
+	Examples map[string]*Example `json:"examples,omitempty" yaml:"examples,omitempty"`
 }

--- a/pkg/spec3/media_type.go
+++ b/pkg/spec3/media_type.go
@@ -18,7 +18,9 @@ package spec3
 
 import (
 	"encoding/json"
+
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -53,14 +55,24 @@ func (m *MediaType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (m *MediaType) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&m.MediaTypeProps); err != nil {
+		return err
+	}
+	if err := m.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // MediaTypeProps a struct that allows you to specify content format, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#mediaTypeObject
 type MediaTypeProps struct {
 	// Schema holds the schema defining the type used for the media type
-	Schema    *spec.Schema `json:"schema,omitempty"`
+	Schema *spec.Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
 	// Example of the media type
-	Example interface{} `json:"example,omitempty"`
+	Example interface{} `json:"example,omitempty" yaml:"example,omitempty"`
 	// Examples of the media type. Each example object should match the media type and specific schema if present
-	Examples map[string]*Example `json:"examples,omitempty"`
+	Examples map[string]*Example `json:"examples,omitempty" yaml:"examples,omitempty"`
 	// A map between a property name and its encoding information. The key, being the property name, MUST exist in the schema as a property. The encoding object SHALL only apply to requestBody objects when the media type is multipart or application/x-www-form-urlencoded
-	Encoding map[string]*Encoding `json:"encoding,omitempty"`
+	Encoding map[string]*Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }

--- a/pkg/spec3/operation.go
+++ b/pkg/spec3/operation.go
@@ -19,8 +19,9 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Operation describes a single API operation on a path, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject
@@ -52,28 +53,38 @@ func (o *Operation) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &o.VendorExtensible)
 }
 
+func (o *Operation) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&o.OperationProps); err != nil {
+		return err
+	}
+	if err := o.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // OperationProps describes a single API operation on a path, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject
 type OperationProps struct {
 	// Tags holds a list of tags for API documentation control
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	// Summary holds a short summary of what the operation does
-	Summary string `json:"summary,omitempty"`
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
 	// Description holds a verbose explanation of the operation behavior
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// ExternalDocs holds additional external documentation for this operation
-	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 	// OperationId holds a unique string used to identify the operation
-	OperationId string `json:"operationId,omitempty"`
+	OperationId string `json:"operationId,omitempty" yaml:"operationId,omitempty"`
 	// Parameters a list of parameters that are applicable for this operation
-	Parameters []*Parameter `json:"parameters,omitempty"`
+	Parameters []*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	// RequestBody holds the request body applicable for this operation
-	RequestBody *RequestBody `json:"requestBody,omitempty"`
+	RequestBody *RequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 	// Responses holds the list of possible responses as they are returned from executing this operation
-	Responses *Responses `json:"responses,omitempty"`
+	Responses *Responses `json:"responses,omitempty" yaml:"responses,omitempty"`
 	// Deprecated declares this operation to be deprecated
-	Deprecated bool `json:"deprecated,omitempty"`
+	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	// SecurityRequirement holds a declaration of which security mechanisms can be used for this operation
-	SecurityRequirement []*SecurityRequirement `json:"security,omitempty"`
+	SecurityRequirement []*SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
 	// Servers contains an alternative server array to service this operation
-	Servers []*Server `json:"servers,omitempty"`
+	Servers []*Server `json:"servers,omitempty" yaml:"servers,omitempty"`
 }

--- a/pkg/spec3/operation_test.go
+++ b/pkg/spec3/operation_test.go
@@ -21,58 +21,59 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
-func TestOperationJSONSerialization(t *testing.T) {
-	cases := []struct {
-		name           string
-		target         *spec3.Operation
-		expectedOutput string
-	}{
-		{
-			name: "basic",
-			target: &spec3.Operation{
-				OperationProps: spec3.OperationProps{
-					Tags:        []string{"pet"},
-					Summary:     "Updates a pet in the store with form data",
-					OperationId: "updatePetWithForm",
-					Parameters: []*spec3.Parameter{
-						&spec3.Parameter{
-							ParameterProps: spec3.ParameterProps{
-								Name:        "petId",
-								In:          "path",
-								Description: "ID of pet that needs to be updated",
-								Required:    true,
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Type: []string{"string"},
-									},
+var operationCases = []struct {
+	name           string
+	target         *spec3.Operation
+	expectedOutput string
+	yaml           []byte
+}{
+	{
+		name: "basic",
+		target: &spec3.Operation{
+			OperationProps: spec3.OperationProps{
+				Tags:        []string{"pet"},
+				Summary:     "Updates a pet in the store with form data",
+				OperationId: "updatePetWithForm",
+				Parameters: []*spec3.Parameter{
+					&spec3.Parameter{
+						ParameterProps: spec3.ParameterProps{
+							Name:        "petId",
+							In:          "path",
+							Description: "ID of pet that needs to be updated",
+							Required:    true,
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Type: []string{"string"},
 								},
 							},
 						},
 					},
-					RequestBody: &spec3.RequestBody{
-						RequestBodyProps: spec3.RequestBodyProps{
-							Content: map[string]*spec3.MediaType{
-								"application/x-www-form-urlencoded": &spec3.MediaType{
-									MediaTypeProps: spec3.MediaTypeProps{
-										Schema: &spec.Schema{
-											SchemaProps: spec.SchemaProps{
-												Type: []string{"object"},
-												Properties: map[string]spec.Schema{
-													"name": spec.Schema{
-														SchemaProps: spec.SchemaProps{
-															Description: "Updated name of the pet",
-															Type:        []string{"string"},
-														},
+				},
+				RequestBody: &spec3.RequestBody{
+					RequestBodyProps: spec3.RequestBodyProps{
+						Content: map[string]*spec3.MediaType{
+							"application/x-www-form-urlencoded": &spec3.MediaType{
+								MediaTypeProps: spec3.MediaTypeProps{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Type: []string{"object"},
+											Properties: map[string]spec.Schema{
+												"name": spec.Schema{
+													SchemaProps: spec.SchemaProps{
+														Description: "Updated name of the pet",
+														Type:        []string{"string"},
 													},
-													"status": spec.Schema{
-														SchemaProps: spec.SchemaProps{
-															Description: "Updated status of the pet",
-															Type:        []string{"string"},
-														},
+												},
+												"status": spec.Schema{
+													SchemaProps: spec.SchemaProps{
+														Description: "Updated status of the pet",
+														Type:        []string{"string"},
 													},
 												},
 											},
@@ -82,16 +83,16 @@ func TestOperationJSONSerialization(t *testing.T) {
 							},
 						},
 					},
-					Responses: &spec3.Responses{
-						ResponsesProps: spec3.ResponsesProps{
-							StatusCodeResponses: map[int]*spec3.Response{
-								200: &spec3.Response{
-									ResponseProps: spec3.ResponseProps{
-										Description: "Pet updated.",
-										Content: map[string]*spec3.MediaType{
-											"application/json": &spec3.MediaType{},
-											"application/xml": &spec3.MediaType{},
-										},
+				},
+				Responses: &spec3.Responses{
+					ResponsesProps: spec3.ResponsesProps{
+						StatusCodeResponses: map[int]*spec3.Response{
+							200: &spec3.Response{
+								ResponseProps: spec3.ResponseProps{
+									Description: "Pet updated.",
+									Content: map[string]*spec3.MediaType{
+										"application/json": &spec3.MediaType{},
+										"application/xml":  &spec3.MediaType{},
 									},
 								},
 							},
@@ -99,10 +100,44 @@ func TestOperationJSONSerialization(t *testing.T) {
 					},
 				},
 			},
-			expectedOutput: `{"tags":["pet"],"summary":"Updates a pet in the store with form data","operationId":"updatePetWithForm","parameters":[{"name":"petId","in":"path","description":"ID of pet that needs to be updated","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"type":"object","properties":{"name":{"description":"Updated name of the pet","type":"string"},"status":{"description":"Updated status of the pet","type":"string"}}}}}},"responses":{"200":{"description":"Pet updated.","content":{"application/json":{},"application/xml":{}}}}}`,
 		},
-	}
-	for _, tc := range cases {
+		expectedOutput: `{"tags":["pet"],"summary":"Updates a pet in the store with form data","operationId":"updatePetWithForm","parameters":[{"name":"petId","in":"path","description":"ID of pet that needs to be updated","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/x-www-form-urlencoded":{"schema":{"type":"object","properties":{"name":{"description":"Updated name of the pet","type":"string"},"status":{"description":"Updated status of the pet","type":"string"}}}}}},"responses":{"200":{"description":"Pet updated.","content":{"application/json":{},"application/xml":{}}}}}`,
+		yaml: []byte(`
+tags:
+- pet
+summary: Updates a pet in the store with form data
+operationId: updatePetWithForm
+parameters:
+- name: petId
+  in: path
+  description: ID of pet that needs to be updated
+  required: true
+  schema:
+    type: string
+requestBody:
+  content:
+    application/x-www-form-urlencoded:
+      schema:
+        type: object
+        properties:
+          name:
+            description: Updated name of the pet
+            type: string
+          status:
+            description: Updated status of the pet
+            type: string
+responses:
+  '200':
+    description: Pet updated.
+    content:
+      application/json: {}
+      application/xml: {}
+`),
+	},
+}
+
+func TestOperationJSONSerialization(t *testing.T) {
+	for _, tc := range operationCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rawTarget, err := json.Marshal(tc.target)
 			if err != nil {
@@ -112,6 +147,22 @@ func TestOperationJSONSerialization(t *testing.T) {
 			if !cmp.Equal(serializedTarget, tc.expectedOutput) {
 				t.Fatalf("diff %s", cmp.Diff(serializedTarget, tc.expectedOutput))
 			}
+		})
+	}
+}
+
+func TestOperationYAMLDeserialization(t *testing.T) {
+	for _, tc := range operationCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// var nodes yaml.Node
+			var actual spec3.Operation
+
+			err := yaml.Unmarshal(tc.yaml, &actual)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			require.EqualValues(t, tc.target, &actual, "round trip")
 		})
 	}
 }

--- a/pkg/spec3/parameter.go
+++ b/pkg/spec3/parameter.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -63,32 +64,45 @@ func (p *Parameter) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *Parameter) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&p.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&p.ParameterProps); err != nil {
+		return err
+	}
+	if err := p.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ParameterProps a struct that describes a single operation parameter, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject
 type ParameterProps struct {
 	// Name holds the name of the parameter
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// In holds the location of the parameter
-	In string `json:"in,omitempty"`
+	In string `json:"in,omitempty" yaml:"in,omitempty"`
 	// Description holds a brief description of the parameter
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Required determines whether this parameter is mandatory
-	Required bool `json:"required,omitempty"`
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 	// Deprecated declares this operation to be deprecated
-	Deprecated bool `json:"deprecated,omitempty"`
+	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	// AllowEmptyValue sets the ability to pass empty-valued parameters
-	AllowEmptyValue bool `json:"allowEmptyValue,omitempty"`
+	AllowEmptyValue bool `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 	// Style describes how the parameter value will be serialized depending on the type of the parameter value
-	Style string `json:"style,omitempty"`
+	Style string `json:"style,omitempty" yaml:"style,omitempty"`
 	// Explode when true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map
-	Explode bool `json:"explode,omitempty"`
+	Explode bool `json:"explode,omitempty" yaml:"explode,omitempty"`
 	// AllowReserved determines whether the parameter value SHOULD allow reserved characters, as defined by RFC3986
-	AllowReserved bool `json:"allowReserved,omitempty"`
+	AllowReserved bool `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 	// Schema holds the schema defining the type used for the parameter
-	Schema *spec.Schema `json:"schema,omitempty"`
+	Schema *spec.Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
 	// Content holds a map containing the representations for the parameter
-	Content map[string]*MediaType `json:"content,omitempty"`
+	Content map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
 	// Example of the parameter's potential value
-	Example interface{} `json:"example,omitempty"`
+	Example interface{} `json:"example,omitempty" yaml:"example,omitempty"`
 	// Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding
-	Examples map[string]*Example `json:"examples,omitempty"`
+	Examples map[string]*Example `json:"examples,omitempty" yaml:"examples,omitempty"`
 }

--- a/pkg/spec3/request_body.go
+++ b/pkg/spec3/request_body.go
@@ -19,8 +19,9 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // RequestBody describes a single request body, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject
@@ -62,12 +63,25 @@ func (r *RequestBody) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (r *RequestBody) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&r.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&r.RequestBodyProps); err != nil {
+		return err
+	}
+	if err := r.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // RequestBodyProps describes a single request body, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject
 type RequestBodyProps struct {
 	// Description holds a brief description of the request body
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Content is the content of the request body. The key is a media type or media type range and the value describes it
-	Content map[string]*MediaType `json:"content,omitempty"`
+	Content map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
 	// Required determines if the request body is required in the request
-	Required bool `json:"required,omitempty"`
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 }

--- a/pkg/spec3/request_body_test.go
+++ b/pkg/spec3/request_body_test.go
@@ -21,38 +21,49 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
-func TestRequestBodyJSONSerialization(t *testing.T) {
-	cases := []struct {
-		name           string
-		target         *spec3.RequestBody
-		expectedOutput string
-	}{
-		{
-			name: "basic",
-			target: &spec3.RequestBody{
-				RequestBodyProps: spec3.RequestBodyProps{
-					Description: "user to add to the system",
-					Content: map[string]*spec3.MediaType{
-						"application/json": &spec3.MediaType{
-							MediaTypeProps: spec3.MediaTypeProps{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/components/schemas/User"),
-									},
+var requestBodyCases = []struct {
+	name           string
+	target         *spec3.RequestBody
+	expectedOutput string
+	yaml           []byte
+}{
+	{
+		name: "basic",
+		target: &spec3.RequestBody{
+			RequestBodyProps: spec3.RequestBodyProps{
+				Description: "user to add to the system",
+				Content: map[string]*spec3.MediaType{
+					"application/json": &spec3.MediaType{
+						MediaTypeProps: spec3.MediaTypeProps{
+							Schema: &spec.Schema{
+								SchemaProps: spec.SchemaProps{
+									Ref: spec.MustCreateRef("#/components/schemas/User"),
 								},
 							},
 						},
 					},
 				},
 			},
-			expectedOutput: `{"description":"user to add to the system","content":{"application/json":{"schema":{"$ref":"#/components/schemas/User"}}}}`,
 		},
-	}
-	for _, tc := range cases {
+		expectedOutput: `{"description":"user to add to the system","content":{"application/json":{"schema":{"$ref":"#/components/schemas/User"}}}}`,
+		yaml: []byte(`
+description: user to add to the system
+content:
+  application/json:
+    schema:
+      "$ref": "#/components/schemas/User"
+`),
+	},
+}
+
+func TestRequestBodyJSONSerialization(t *testing.T) {
+	for _, tc := range requestBodyCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rawTarget, err := json.Marshal(tc.target)
 			if err != nil {
@@ -62,6 +73,22 @@ func TestRequestBodyJSONSerialization(t *testing.T) {
 			if !cmp.Equal(serializedTarget, tc.expectedOutput) {
 				t.Fatalf("diff %s", cmp.Diff(serializedTarget, tc.expectedOutput))
 			}
+		})
+	}
+}
+
+func TestRequestBodyYAMLDeserialization(t *testing.T) {
+	for _, tc := range requestBodyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// var nodes yaml.Node
+			var actual spec3.RequestBody
+
+			err := yaml.Unmarshal(tc.yaml, &actual)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			require.EqualValues(t, tc.target, &actual, "round trip")
 		})
 	}
 }

--- a/pkg/spec3/security_requirement.go
+++ b/pkg/spec3/security_requirement.go
@@ -19,8 +19,9 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // SecurityRequirementProps describes the required security schemes to execute an operation, more at https://swagger.io/specification/#security-requirement-object
@@ -50,6 +51,16 @@ func (s *SecurityRequirement) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &s.VendorExtensible)
+}
+
+func (s *SecurityRequirement) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&s.SecurityRequirementProps); err != nil {
+		return err
+	}
+	if err := s.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SecurityRequirementProps describes the required security schemes to execute an operation, more at https://swagger.io/specification/#security-requirement-object

--- a/pkg/spec3/security_scheme.go
+++ b/pkg/spec3/security_scheme.go
@@ -19,8 +19,9 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // SecurityScheme defines reusable Security Scheme Object, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
@@ -58,24 +59,37 @@ func (s *SecurityScheme) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &s.Refable)
 }
 
+func (s *SecurityScheme) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&s.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&s.SecuritySchemeProps); err != nil {
+		return err
+	}
+	if err := s.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SecuritySchemeProps defines a security scheme that can be used by the operations
 type SecuritySchemeProps struct {
 	// Type of the security scheme
-	Type string `json:"type,omitempty"`
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
 	// Description holds a short description for security scheme
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Name holds the name of the header, query or cookie parameter to be used
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// In holds the location of the API key
-	In string `json:"in,omitempty"`
+	In string `json:"in,omitempty" yaml:"in,omitempty"`
 	// Scheme holds the name of the HTTP Authorization scheme to be used in the Authorization header
-	Scheme string `json:"scheme,omitempty"`
+	Scheme string `json:"scheme,omitempty" yaml:"scheme,omitempty"`
 	// BearerFormat holds a hint to the client to identify how the bearer token is formatted
-	BearerFormat string `json:"bearerFormat,omitempty"`
+	BearerFormat string `json:"bearerFormat,omitempty" yaml:"bearerFormat,omitempty"`
 	// Flows contains configuration information for the flow types supported.
-	Flows map[string]*OAuthFlow `json:"flows,omitempty"`
+	Flows map[string]*OAuthFlow `json:"flows,omitempty" yaml:"flows,omitempty"`
 	// OpenIdConnectUrl holds an url to discover OAuth2 configuration values from
-	OpenIdConnectUrl string `json:"openIdConnectUrl,omitempty"`
+	OpenIdConnectUrl string `json:"openIdConnectUrl,omitempty" yaml:"openIdConnectUrl,omitempty"`
 }
 
 // OAuthFlow contains configuration information for the flow types supported.
@@ -105,14 +119,24 @@ func (o *OAuthFlow) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &o.VendorExtensible)
 }
 
+func (o *OAuthFlow) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&o.OAuthFlowProps); err != nil {
+		return err
+	}
+	if err := o.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 // OAuthFlowProps holds configuration details for a supported OAuth Flow
 type OAuthFlowProps struct {
 	// AuthorizationUrl hold the authorization URL to be used for this flow
-	AuthorizationUrl string `json:"authorizationUrl,omitempty"`
+	AuthorizationUrl string `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 	// TokenUrl holds the token URL to be used for this flow
-	TokenUrl string `json:"tokenUrl,omitempty"`
+	TokenUrl string `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
 	// RefreshUrl holds the URL to be used for obtaining refresh tokens
-	RefreshUrl string `json:"refreshUrl,omitempty"`
+	RefreshUrl string `json:"refreshUrl,omitempty" yaml:"refreshUrl,omitempty"`
 	// Scopes holds the available scopes for the OAuth2 security scheme
-	Scopes map[string]string `json:"scopes,omitempty"`
+	Scopes map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 }

--- a/pkg/spec3/server.go
+++ b/pkg/spec3/server.go
@@ -18,9 +18,10 @@ package spec3
 
 import (
 	"encoding/json"
-	"k8s.io/kube-openapi/pkg/validation/spec"
-	"github.com/go-openapi/swag"
 
+	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 type Server struct {
@@ -30,11 +31,11 @@ type Server struct {
 
 type ServerProps struct {
 	// Description is a short description of the target documentation. CommonMark syntax MAY be used for rich text representation.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// URL is the URL for the target documentation.
-	URL string `json:"url"`
+	URL string `json:"url" yaml:"url"`
 	// Variables contains a map between a variable name and its value. The value is used for substitution in the server's URL templeate
-	Variables map[string]*ServerVariable `json:"variables,omitempty"`
+	Variables map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
 }
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
@@ -60,6 +61,16 @@ func (s *Server) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (s *Server) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&s.ServerProps); err != nil {
+		return err
+	}
+	if err := s.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
+}
+
 type ServerVariable struct {
 	ServerVariableProps
 	spec.VendorExtensible
@@ -67,11 +78,11 @@ type ServerVariable struct {
 
 type ServerVariableProps struct {
 	// Enum is an enumeration of string values to be used if the substitution options are from a limited set
-	Enum []string `json:"enum,omitempty"`
+	Enum []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 	// Default is the default value to use for substitution, which SHALL be sent if an alternate value is not supplied
-	Default string `json:"default"`
+	Default string `json:"default" yaml:"default"`
 	// Description is a description for the server variable
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
@@ -92,6 +103,16 @@ func (s *ServerVariable) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if err := json.Unmarshal(data, &s.VendorExtensible); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ServerVariable) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&s.ServerVariableProps); err != nil {
+		return err
+	}
+	if err := s.VendorExtensible.UnmarshalYAML(value); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/spec3/spec.go
+++ b/pkg/spec3/spec.go
@@ -23,15 +23,15 @@ import (
 // OpenAPI is an object that describes an API and conforms to the OpenAPI Specification.
 type OpenAPI struct {
 	// Version represents the semantic version number of the OpenAPI Specification that this document uses
-	Version string `json:"openapi"`
+	Version string `json:"openapi" yaml:"openapi"`
 	// Info provides metadata about the API
-	Info *spec.Info `json:"info"`
+	Info *spec.Info `json:"info" yaml:"info"`
 	// Paths holds the available target and operations for the API
-	Paths *Paths `json:"paths,omitempty"`
+	Paths *Paths `json:"paths,omitempty" yaml:"paths,omitempty"`
 	// Servers is an array of Server objects which provide connectivity information to a target server
-	Servers []*Server `json:"servers,omitempty"`
+	Servers []*Server `json:"servers,omitempty" yaml:"servers,omitempty"`
 	// Components hold various schemas for the specification
-	Components *Components `json:"components,omitempty"`
+	Components *Components `json:"components,omitempty" yaml:"components,omitempty"`
 	// ExternalDocs holds additional external documentation
-	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }

--- a/pkg/validation/spec/contact_info.go
+++ b/pkg/validation/spec/contact_info.go
@@ -18,7 +18,7 @@ package spec
 //
 // For more information: http://goo.gl/8us55a#contactObject
 type ContactInfo struct {
-	Name  string `json:"name,omitempty"`
-	URL   string `json:"url,omitempty"`
-	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 }

--- a/pkg/validation/spec/external_docs.go
+++ b/pkg/validation/spec/external_docs.go
@@ -19,6 +19,6 @@ package spec
 //
 // For more information: http://goo.gl/8us55a#externalDocumentationObject
 type ExternalDocumentation struct {
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
 }

--- a/pkg/validation/spec/header.go
+++ b/pkg/validation/spec/header.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 
 // HeaderProps describes a response header
 type HeaderProps struct {
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // Header describes a header for a response of the API
@@ -68,4 +69,18 @@ func (h *Header) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &h.HeaderProps)
+}
+
+// UnmarshalJSON unmarshals this header from JSON
+func (h *Header) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&h.CommonValidations); err != nil {
+		return err
+	}
+	if err := value.Decode(&h.SimpleSchema); err != nil {
+		return err
+	}
+	if err := value.Decode(&h.VendorExtensible); err != nil {
+		return err
+	}
+	return value.Decode(&h.HeaderProps)
 }

--- a/pkg/validation/spec/items.go
+++ b/pkg/validation/spec/items.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -26,29 +27,29 @@ const (
 
 // SimpleSchema describe swagger simple schemas for parameters and headers
 type SimpleSchema struct {
-	Type             string      `json:"type,omitempty"`
-	Nullable         bool        `json:"nullable,omitempty"`
-	Format           string      `json:"format,omitempty"`
-	Items            *Items      `json:"items,omitempty"`
-	CollectionFormat string      `json:"collectionFormat,omitempty"`
-	Default          interface{} `json:"default,omitempty"`
-	Example          interface{} `json:"example,omitempty"`
+	Type             string      `json:"type,omitempty" yaml:"type,omitempty"`
+	Nullable         bool        `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	Format           string      `json:"format,omitempty" yaml:"format,omitempty"`
+	Items            *Items      `json:"items,omitempty" yaml:"items,omitempty"`
+	CollectionFormat string      `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
+	Default          interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+	Example          interface{} `json:"example,omitempty" yaml:"example,omitempty"`
 }
 
 // CommonValidations describe common JSON-schema validations
 type CommonValidations struct {
-	Maximum          *float64      `json:"maximum,omitempty"`
-	ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty"`
-	Minimum          *float64      `json:"minimum,omitempty"`
-	ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty"`
-	MaxLength        *int64        `json:"maxLength,omitempty"`
-	MinLength        *int64        `json:"minLength,omitempty"`
-	Pattern          string        `json:"pattern,omitempty"`
-	MaxItems         *int64        `json:"maxItems,omitempty"`
-	MinItems         *int64        `json:"minItems,omitempty"`
-	UniqueItems      bool          `json:"uniqueItems,omitempty"`
-	MultipleOf       *float64      `json:"multipleOf,omitempty"`
-	Enum             []interface{} `json:"enum,omitempty"`
+	Maximum          *float64      `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	Minimum          *float64      `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	MaxLength        *int64        `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinLength        *int64        `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	MaxItems         *int64        `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	MinItems         *int64        `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	MultipleOf       *float64      `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
 }
 
 // Items a limited subset of JSON-Schema's items object.
@@ -60,6 +61,25 @@ type Items struct {
 	CommonValidations
 	SimpleSchema
 	VendorExtensible
+}
+
+func (i *Items) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&i.CommonValidations); err != nil {
+		return err
+	}
+
+	if err := value.Decode(&i.Refable); err != nil {
+		return err
+	}
+
+	if err := value.Decode(&i.SimpleSchema); err != nil {
+		return err
+	}
+
+	if err := i.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return nil
 }
 
 // UnmarshalJSON hydrates this items instance with the data from JSON

--- a/pkg/validation/spec/license.go
+++ b/pkg/validation/spec/license.go
@@ -18,6 +18,6 @@ package spec
 //
 // For more information: http://goo.gl/8us55a#licenseObject
 type License struct {
-	Name string `json:"name,omitempty"`
-	URL  string `json:"url,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
 }

--- a/pkg/validation/spec/operation.go
+++ b/pkg/validation/spec/operation.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // OperationProps describes an operation
@@ -26,18 +27,18 @@ import (
 // - schemes, when present must be from [http, https, ws, wss]: see validate
 // - Security is handled as a special case: see MarshalJSON function
 type OperationProps struct {
-	Description  string                 `json:"description,omitempty"`
-	Consumes     []string               `json:"consumes,omitempty"`
-	Produces     []string               `json:"produces,omitempty"`
-	Schemes      []string               `json:"schemes,omitempty"`
-	Tags         []string               `json:"tags,omitempty"`
-	Summary      string                 `json:"summary,omitempty"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
-	ID           string                 `json:"operationId,omitempty"`
-	Deprecated   bool                   `json:"deprecated,omitempty"`
-	Security     []map[string][]string  `json:"security,omitempty"`
-	Parameters   []Parameter            `json:"parameters,omitempty"`
-	Responses    *Responses             `json:"responses,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Consumes     []string               `json:"consumes,omitempty" yaml:"consumes,omitempty"`
+	Produces     []string               `json:"produces,omitempty" yaml:"produces,omitempty"`
+	Schemes      []string               `json:"schemes,omitempty" yaml:"schemes,omitempty"`
+	Tags         []string               `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Summary      string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	ID           string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Deprecated   bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Security     []map[string][]string  `json:"security,omitempty" yaml:"security,omitempty"`
+	Parameters   []Parameter            `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Responses    *Responses             `json:"responses,omitempty" yaml:"responses,omitempty"`
 }
 
 // MarshalJSON takes care of serializing operation properties to JSON
@@ -49,7 +50,7 @@ func (op OperationProps) MarshalJSON() ([]byte, error) {
 	type Alias OperationProps
 	if op.Security == nil {
 		return json.Marshal(&struct {
-			Security []map[string][]string `json:"security,omitempty"`
+			Security []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
 			*Alias
 		}{
 			Security: op.Security,
@@ -57,7 +58,7 @@ func (op OperationProps) MarshalJSON() ([]byte, error) {
 		})
 	}
 	return json.Marshal(&struct {
-		Security []map[string][]string `json:"security"`
+		Security []map[string][]string `json:"security" yaml:"security"`
 		*Alias
 	}{
 		Security: op.Security,
@@ -71,6 +72,13 @@ func (op OperationProps) MarshalJSON() ([]byte, error) {
 type Operation struct {
 	VendorExtensible
 	OperationProps
+}
+
+func (o *Operation) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&o.OperationProps); err != nil {
+		return err
+	}
+	return o.VendorExtensible.UnmarshalYAML(value)
 }
 
 // UnmarshalJSON hydrates this items instance with the data from JSON

--- a/pkg/validation/spec/parameter.go
+++ b/pkg/validation/spec/parameter.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // ParamProps describes the specific attributes of an operation parameter
@@ -26,12 +27,12 @@ import (
 // - Schema is defined when "in" == "body": see validate
 // - AllowEmptyValue is allowed where "in" == "query" || "formData"
 type ParamProps struct {
-	Description     string  `json:"description,omitempty"`
-	Name            string  `json:"name,omitempty"`
-	In              string  `json:"in,omitempty"`
-	Required        bool    `json:"required,omitempty"`
-	Schema          *Schema `json:"schema,omitempty"`
-	AllowEmptyValue bool    `json:"allowEmptyValue,omitempty"`
+	Description     string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Name            string  `json:"name,omitempty" yaml:"name,omitempty"`
+	In              string  `json:"in,omitempty" yaml:"in,omitempty"`
+	Required        bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
+	AllowEmptyValue bool    `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 }
 
 // Parameter a unique parameter is defined by a combination of a [name](#parameterName) and [location](#parameterIn).
@@ -83,6 +84,22 @@ func (p *Parameter) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &p.ParamProps)
+}
+
+func (p *Parameter) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&p.CommonValidations); err != nil {
+		return err
+	}
+	if err := value.Decode(&p.Refable); err != nil {
+		return err
+	}
+	if err := value.Decode(&p.SimpleSchema); err != nil {
+		return err
+	}
+	if err := p.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return value.Decode(&p.ParamProps)
 }
 
 // MarshalJSON converts this items object to JSON

--- a/pkg/validation/spec/path_item.go
+++ b/pkg/validation/spec/path_item.go
@@ -18,18 +18,19 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // PathItemProps the path item specific properties
 type PathItemProps struct {
-	Get        *Operation  `json:"get,omitempty"`
-	Put        *Operation  `json:"put,omitempty"`
-	Post       *Operation  `json:"post,omitempty"`
-	Delete     *Operation  `json:"delete,omitempty"`
-	Options    *Operation  `json:"options,omitempty"`
-	Head       *Operation  `json:"head,omitempty"`
-	Patch      *Operation  `json:"patch,omitempty"`
-	Parameters []Parameter `json:"parameters,omitempty"`
+	Get        *Operation  `json:"get,omitempty" yaml:"get,omitempty"`
+	Put        *Operation  `json:"put,omitempty" yaml:"put,omitempty"`
+	Post       *Operation  `json:"post,omitempty" yaml:"post,omitempty"`
+	Delete     *Operation  `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Options    *Operation  `json:"options,omitempty" yaml:"options,omitempty"`
+	Head       *Operation  `json:"head,omitempty" yaml:"head,omitempty"`
+	Patch      *Operation  `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Parameters []Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }
 
 // PathItem describes the operations available on a single path.
@@ -53,6 +54,16 @@ func (p *PathItem) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &p.PathItemProps)
+}
+
+func (p *PathItem) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&p.Refable); err != nil {
+		return err
+	}
+	if err := p.VendorExtensible.UnmarshalYAML(value); err != nil {
+		return err
+	}
+	return value.Decode(&p.PathItemProps)
 }
 
 // MarshalJSON converts this items object to JSON

--- a/pkg/validation/spec/ref.go
+++ b/pkg/validation/spec/ref.go
@@ -21,11 +21,13 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/jsonreference"
+	"gopkg.in/yaml.v3"
+	"k8s.io/kube-openapi/pkg/util"
 )
 
 // Refable is a struct for things that accept a $ref property
 type Refable struct {
-	Ref Ref
+	Ref Ref `yaml:"$ref,omitempty"`
 }
 
 // MarshalJSON marshals the ref to json
@@ -146,6 +148,22 @@ func (r *Ref) UnmarshalJSON(d []byte) error {
 		return err
 	}
 	return r.fromMap(v)
+}
+
+func (r *Ref) UnmarshalYAML(n *yaml.Node) error {
+	var valueStr string
+	if err := util.DecodeYAMLString(n, &valueStr); err != nil {
+		return err
+	}
+
+	ref, err := jsonreference.New(valueStr)
+	if err != nil {
+		return err
+	}
+
+	r.Ref = ref
+
+	return nil
 }
 
 func (r *Ref) fromMap(v map[string]interface{}) error {

--- a/pkg/validation/spec/response.go
+++ b/pkg/validation/spec/response.go
@@ -18,14 +18,15 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // ResponseProps properties specific to a response
 type ResponseProps struct {
-	Description string                 `json:"description,omitempty"`
-	Schema      *Schema                `json:"schema,omitempty"`
-	Headers     map[string]Header      `json:"headers,omitempty"`
-	Examples    map[string]interface{} `json:"examples,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Schema      *Schema                `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Headers     map[string]Header      `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Examples    map[string]interface{} `json:"examples,omitempty" yaml:"examples,omitempty"`
 }
 
 // Response describes a single response from an API Operation.
@@ -46,6 +47,16 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &r.VendorExtensible)
+}
+
+func (r *Response) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&r.ResponseProps); err != nil {
+		return err
+	}
+	if err := value.Decode(&r.Refable); err != nil {
+		return err
+	}
+	return r.VendorExtensible.UnmarshalYAML(value)
 }
 
 // MarshalJSON converts this items object to JSON

--- a/pkg/validation/spec/security_scheme.go
+++ b/pkg/validation/spec/security_scheme.go
@@ -18,18 +18,19 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // SecuritySchemeProps describes a swagger security scheme in the securityDefinitions section
 type SecuritySchemeProps struct {
-	Description      string            `json:"description,omitempty"`
-	Type             string            `json:"type"`
-	Name             string            `json:"name,omitempty"`             // api key
-	In               string            `json:"in,omitempty"`               // api key
-	Flow             string            `json:"flow,omitempty"`             // oauth2
-	AuthorizationURL string            `json:"authorizationUrl,omitempty"` // oauth2
-	TokenURL         string            `json:"tokenUrl,omitempty"`         // oauth2
-	Scopes           map[string]string `json:"scopes,omitempty"`           // oauth2
+	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Type             string            `json:"type" yaml:"type"`
+	Name             string            `json:"name,omitempty" yaml:"name,omitempty"`                         // api key
+	In               string            `json:"in,omitempty" yaml:"in,omitempty"`                             // api key
+	Flow             string            `json:"flow,omitempty" yaml:"flow,omitempty"`                         // oauth2
+	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"` // oauth2
+	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`                 // oauth2
+	Scopes           map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`                     // oauth2
 }
 
 // SecurityScheme allows the definition of a security scheme that can be used by the operations.
@@ -61,4 +62,11 @@ func (s *SecurityScheme) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &s.VendorExtensible)
+}
+
+func (s *SecurityScheme) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&s.SecuritySchemeProps); err != nil {
+		return err
+	}
+	return value.Decode(&s.VendorExtensible)
 }

--- a/pkg/validation/spec/swagger_test.go
+++ b/pkg/validation/spec/swagger_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 var spec = Swagger{
@@ -106,6 +107,65 @@ const specJSON = `{
 	"x-schemes": ["unix","amqp"]
 }`
 
+const specYAML = `
+id: http://localhost:3849/api-docs
+consumes:
+- application/json
+- application/x-yaml
+produces:
+- application/json
+schemes:
+- http
+- https
+swagger: '2.0'
+info:
+  contact:
+    name: wordnik api team
+    url: http://developer.wordnik.com
+  description: A sample API that uses a petstore as an example to demonstrate features
+    in the swagger-2.0 specification
+  license:
+    name: Creative Commons 4.0 International
+    url: http://creativecommons.org/licenses/by/4.0/
+  termsOfService: http://helloreverb.com/terms/
+  title: Swagger Sample API
+  version: 1.0.9-abcd
+  x-framework: go-swagger
+host: some.api.out.there
+basePath: "/"
+paths:
+  x-framework: go-swagger
+  "/":
+    "$ref": cats
+definitions:
+  Category:
+    type: string
+parameters:
+  categoryParam:
+    name: category
+    in: query
+    type: string
+responses:
+  EmptyAnswer:
+    description: no data to return for this operation
+securityDefinitions:
+  internalApiKey:
+    type: apiKey
+    in: header
+    name: api_key
+security:
+- internalApiKey: []
+tags:
+- name: pets
+externalDocs:
+  description: the name
+  url: the url
+x-some-extension: vendor
+x-schemes:
+- unix
+- amqp
+`
+
 func TestSwaggerSpec_Serialize(t *testing.T) {
 	expected := make(map[string]interface{})
 	_ = json.Unmarshal([]byte(specJSON), &expected)
@@ -122,6 +182,18 @@ func TestSwaggerSpec_Serialize(t *testing.T) {
 func TestSwaggerSpec_Deserialize(t *testing.T) {
 	var actual Swagger
 	err := json.Unmarshal([]byte(specJSON), &actual)
+	if assert.NoError(t, err) {
+		assert.EqualValues(t, actual, spec)
+	}
+}
+
+func TestSwaggerSpec_DeserializeYAML(t *testing.T) {
+	var actual Swagger
+	var nodes yaml.Node
+	err := yaml.Unmarshal([]byte(specYAML), &nodes)
+	assert.NoError(t, err)
+
+	err = nodes.Decode(&actual)
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, actual, spec)
 	}

--- a/pkg/validation/spec/tag.go
+++ b/pkg/validation/spec/tag.go
@@ -18,13 +18,14 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"gopkg.in/yaml.v3"
 )
 
 // TagProps describe a tag entry in the top level tags section of a swagger spec
 type TagProps struct {
-	Description  string                 `json:"description,omitempty"`
-	Name         string                 `json:"name,omitempty"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Name         string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 // Tag allows adding meta data to a single tag that is used by the
@@ -56,4 +57,11 @@ func (t *Tag) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return json.Unmarshal(data, &t.VendorExtensible)
+}
+
+func (t *Tag) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&t.TagProps); err != nil {
+		return err
+	}
+	return t.VendorExtensible.UnmarshalYAML(value)
 }


### PR DESCRIPTION
This PR mirrors #279 but for the OpenAPI v3 types.
Motivatoin/detials are in that issue

Benchmark Results
From: https://github.com/alexzielenski/kube-openapi-gnostic-benchmark

Using JSON:
```
BenchmarkSlowConversionV3
BenchmarkSlowConversionV3/json->kube
BenchmarkSlowConversionV3/json->kube-8         	       2	 585903594 ns/op	149246568 B/op	 1835197 allocs/op
BenchmarkSlowConversionV3/json->gnostic
BenchmarkSlowConversionV3/json->gnostic-8      	       4	 290851778 ns/op	116498218 B/op	 1528737 allocs/op
BenchmarkSlowConversionV3/gnostic->pb
BenchmarkSlowConversionV3/gnostic->pb-8        	      72	  15533586 ns/op	 4304896 B/op	      47 allocs/op
BenchmarkSlowConversionV3/pb->gnostic
BenchmarkSlowConversionV3/pb->gnostic-8        	      58	  19689780 ns/op	14967265 B/op	  170123 allocs/op
BenchmarkSlowConversionV3/gnostic->json
BenchmarkSlowConversionV3/gnostic->json-8      	      50	  24571630 ns/op	 5867870 B/op	      47 allocs/op
BenchmarkSlowConversionV3/json->kube#01
BenchmarkSlowConversionV3/json->kube#01-8      	       2	 625525483 ns/op	149450440 B/op	 1835730 allocs/op
```

In total a conversion from

PB -> Gnostic -> JSON -> Kube-OpenAPIv3 was approx 670ms

Using YAML:

```
BenchmarkFastConversionV3
BenchmarkFastConversionV3/json->kube
BenchmarkFastConversionV3/json->kube-8         	       2	 573242620 ns/op	149247712 B/op	 1835203 allocs/op
BenchmarkFastConversionV3/json->gnostic
BenchmarkFastConversionV3/json->gnostic-8      	       4	 294514478 ns/op	116470526 B/op	 1528736 allocs/op
BenchmarkFastConversionV3/gnostic->pb
BenchmarkFastConversionV3/gnostic->pb-8        	      69	  16159228 ns/op	 4304929 B/op	      47 allocs/op
BenchmarkFastConversionV3/pb->gnostic
BenchmarkFastConversionV3/pb->gnostic-8        	      64	  19036357 ns/op	14967267 B/op	  170123 allocs/op
BenchmarkFastConversionV3/gnostic->yaml
BenchmarkFastConversionV3/gnostic->yaml-8      	      31	  44807695 ns/op	37846702 B/op	  388852 allocs/op
BenchmarkFastConversionV3/yaml->kube
BenchmarkFastConversionV3/yaml->kube-8         	      14	  87296806 ns/op	37919867 B/op	  733867 allocs/op
```

In total a conversion from

PB -> Gnostic -> YAML -> Kube-OpenAPIv3 was approx 151ms