### PR TITLE
add vendor extensions to marshal openapi v2 spec.Header

### DIFF
--- a/pkg/validation/spec/header.go
+++ b/pkg/validation/spec/header.go
@@ -53,7 +53,11 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return swag.ConcatJSON(b1, b2, b3), nil
+	b4, err := json.Marshal(h.VendorExtensible)
+	if err != nil {
+		return nil, err
+	}
+	return swag.ConcatJSON(b1, b2, b3, b4), nil
 }
 
 // UnmarshalJSON unmarshals this header from JSON


### PR DESCRIPTION
I noticed while fuzzing a type converter to gnostic that the `spec.Header` type does not include its `x-` vendor extensions when marshaled to JSON (they were already being properly unmarshaled from JSON). This PR adds that functionality.