### PR TITLE
Add direct conversion from Gnostic v2 types to spec.Swagger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/tools v0.1.5 // indirect
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,9 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=

--- a/pkg/validation/spec/gnostic.go
+++ b/pkg/validation/spec/gnostic.go
@@ -1,0 +1,1515 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/go-openapi/jsonreference"
+	openapi_v2 "github.com/google/gnostic/openapiv2"
+)
+
+// Interfaces
+type GnosticCommonValidations interface {
+	GetMaximum() float64
+	GetExclusiveMaximum() bool
+	GetMinimum() float64
+	GetExclusiveMinimum() bool
+	GetMaxLength() int64
+	GetMinLength() int64
+	GetPattern() string
+	GetMaxItems() int64
+	GetMinItems() int64
+	GetUniqueItems() bool
+	GetMultipleOf() float64
+	GetEnum() []*openapi_v2.Any
+}
+
+func (k *CommonValidations) FromGnostic(g GnosticCommonValidations) error {
+	if g == nil {
+		return nil
+	}
+
+	max := g.GetMaximum()
+	if max != 0 {
+		k.Maximum = &max
+	}
+
+	k.ExclusiveMaximum = g.GetExclusiveMaximum()
+
+	min := g.GetMinimum()
+	if min != 0 {
+		k.Minimum = &min
+	}
+
+	k.ExclusiveMinimum = g.GetExclusiveMinimum()
+
+	maxLen := g.GetMaxLength()
+	if maxLen != 0 {
+		k.MaxLength = &maxLen
+	}
+
+	minLen := g.GetMinLength()
+	if minLen != 0 {
+		k.MinLength = &minLen
+	}
+
+	k.Pattern = g.GetPattern()
+
+	maxItems := g.GetMaxItems()
+	if maxItems != 0 {
+		k.MaxItems = &maxItems
+	}
+
+	minItems := g.GetMinItems()
+	if minItems != 0 {
+		k.MinItems = &minItems
+	}
+
+	k.UniqueItems = g.GetUniqueItems()
+
+	multOf := g.GetMultipleOf()
+	if multOf != 0 {
+		k.MultipleOf = &multOf
+	}
+
+	enums := g.GetEnum()
+
+	if enums != nil {
+		k.Enum = make([]interface{}, len(enums))
+		for i, v := range enums {
+			if v == nil {
+				continue
+			}
+
+			var convert interface{}
+			if err := v.ToRawInfo().Decode(&convert); err != nil {
+				return err
+			} else {
+				k.Enum[i] = convert
+			}
+		}
+	}
+
+	return nil
+}
+
+type GnosticSimpleSchema interface {
+	GetType() string
+	GetFormat() string
+	GetItems() *openapi_v2.PrimitivesItems
+	GetCollectionFormat() string
+	GetDefault() *openapi_v2.Any
+}
+
+func (k *SimpleSchema) FromGnostic(g GnosticSimpleSchema) error {
+	if g == nil {
+		return nil
+	}
+
+	k.Type = g.GetType()
+	k.Format = g.GetFormat()
+	k.CollectionFormat = g.GetCollectionFormat()
+
+	items := g.GetItems()
+	if items != nil {
+		k.Items = &Items{}
+		if err := k.Items.FromGnostic(items); err != nil {
+			return err
+		}
+	}
+
+	def := g.GetDefault()
+	if def != nil {
+		var convert interface{}
+		if err := def.ToRawInfo().Decode(&convert); err != nil {
+			return err
+		} else {
+			k.Default = convert
+		}
+	}
+
+	return nil
+}
+
+func (k *Items) FromGnostic(g *openapi_v2.PrimitivesItems) error {
+	if g == nil {
+		return nil
+	}
+
+	if err := k.SimpleSchema.FromGnostic(g); err != nil {
+		return err
+	}
+
+	if err := k.CommonValidations.FromGnostic(g); err != nil {
+		return err
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *VendorExtensible) FromGnostic(g []*openapi_v2.NamedAny) error {
+	if len(g) == 0 {
+		return nil
+	}
+
+	k.Extensions = make(Extensions, len(g))
+	for _, v := range g {
+		if v == nil {
+			continue
+		}
+
+		if v.Value == nil {
+			k.Extensions[v.Name] = nil
+			continue
+		}
+
+		var iface interface{}
+		if err := v.Value.ToRawInfo().Decode(&iface); err != nil {
+			return err
+		} else {
+			k.Extensions[v.Name] = iface
+		}
+	}
+	return nil
+}
+
+func (k *Refable) FromGnostic(g string) error {
+	return k.Ref.FromGnostic(g)
+}
+
+func (k *Ref) FromGnostic(g string) error {
+	if g == "" {
+		return nil
+	}
+
+	ref, err := jsonreference.New(g)
+	if err != nil {
+		return err
+	}
+
+	*k = Ref{
+		Ref: ref,
+	}
+
+	return nil
+}
+
+// Converts a gnostic v2 Document to a kube-openapi Swagger Document
+//
+// Caveats:
+//
+// - gnostic v2 documents treats zero as unspecified for numerical fields of
+//CommonValidations fields such as Maximum, Minimum, MaximumItems, etc.
+//There will always be data loss if one of the values of these fields is set to zero.
+//
+// Returns:
+//
+// - `ok`: `false` if a value was present in the gnostic document which cannot be
+// roundtripped into kube-openapi types. In these instances, `ok` is set to
+// `false` and the value is skipped.
+//
+// - `err`: an unexpected error occurred in the conversion from the gnostic type
+// to kube-openapi type.
+func (k *Swagger) FromGnostic(g *openapi_v2.Document) (ok bool, err error) {
+	ok = true
+	if g == nil {
+		return true, nil
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+
+	if nok, err := k.SwaggerProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *SwaggerProps) FromGnostic(g *openapi_v2.Document) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	// openapi_v2.Document does not support "ID" field, so it will not be
+	// included
+	k.Consumes = g.Consumes
+	k.Produces = g.Produces
+	k.Schemes = g.Schemes
+	k.Swagger = g.Swagger
+
+	if g.Info != nil {
+		k.Info = &Info{}
+		if nok, err := k.Info.FromGnostic(g.Info); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	k.Host = g.Host
+	k.BasePath = g.BasePath
+
+	if g.Paths != nil {
+		k.Paths = &Paths{}
+		if nok, err := k.Paths.FromGnostic(g.Paths); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Definitions != nil {
+		k.Definitions = make(Definitions, len(g.Definitions.AdditionalProperties))
+		for _, v := range g.Definitions.AdditionalProperties {
+			if v == nil {
+				continue
+			}
+			converted := Schema{}
+			if nok, err := converted.FromGnostic(v.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+			k.Definitions[v.Name] = converted
+
+		}
+	}
+
+	if g.Parameters != nil {
+		k.Parameters = make(
+			map[string]Parameter,
+			len(g.Parameters.AdditionalProperties))
+		for _, v := range g.Parameters.AdditionalProperties {
+			if v == nil {
+				continue
+			}
+			p := Parameter{}
+			if nok, err := p.FromGnostic(v.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			k.Parameters[v.Name] = p
+		}
+	}
+
+	if g.Responses != nil {
+		k.Responses = make(
+			map[string]Response,
+			len(g.Responses.AdditionalProperties))
+
+		for _, v := range g.Responses.AdditionalProperties {
+			if v == nil {
+				continue
+			}
+			p := Response{}
+			if nok, err := p.FromGnostic(v.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			k.Responses[v.Name] = p
+		}
+	}
+
+	if g.SecurityDefinitions != nil {
+		k.SecurityDefinitions = make(SecurityDefinitions)
+		if err := k.SecurityDefinitions.FromGnostic(g.SecurityDefinitions); err != nil {
+			return false, err
+		}
+	}
+
+	if g.Security != nil {
+		k.Security = make([]map[string][]string, len(g.Security))
+		for i, v := range g.Security {
+			if v == nil || v.AdditionalProperties == nil {
+				continue
+			}
+
+			k.Security[i] = make(map[string][]string, len(v.AdditionalProperties))
+			converted := k.Security[i]
+			for _, p := range v.AdditionalProperties {
+				if p == nil {
+					continue
+				}
+				if p.Value != nil {
+					converted[p.Name] = p.Value.Value
+				} else {
+					converted[p.Name] = nil
+				}
+			}
+		}
+	}
+
+	if g.Tags != nil {
+		k.Tags = make([]Tag, len(g.Tags))
+		for i, v := range g.Tags {
+			if v == nil {
+				continue
+			} else if nok, err := k.Tags[i].FromGnostic(v); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		}
+	}
+
+	if g.ExternalDocs != nil {
+		k.ExternalDocs = &ExternalDocumentation{}
+		if nok, err := k.ExternalDocs.FromGnostic(g.ExternalDocs); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	return ok, nil
+}
+
+// Info
+
+func (k *Info) FromGnostic(g *openapi_v2.Info) (ok bool, err error) {
+	ok = true
+	if g == nil {
+		return true, nil
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+
+	if nok, err := k.InfoProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *InfoProps) FromGnostic(g *openapi_v2.Info) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	k.Description = g.Description
+	k.Title = g.Title
+	k.TermsOfService = g.TermsOfService
+
+	if g.Contact != nil {
+		k.Contact = &ContactInfo{}
+
+		if nok, err := k.Contact.FromGnostic(g.Contact); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.License != nil {
+		k.License = &License{}
+		if nok, err := k.License.FromGnostic(g.License); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	k.Version = g.Version
+	return ok, nil
+}
+
+func (k *License) FromGnostic(g *openapi_v2.License) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	k.Name = g.Name
+	k.URL = g.Url
+
+	// License does not embed to VendorExtensible!
+	// data loss from g.VendorExtension
+	if len(g.VendorExtension) != 0 {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *ContactInfo) FromGnostic(g *openapi_v2.Contact) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	k.Name = g.Name
+	k.URL = g.Url
+	k.Email = g.Email
+
+	// ContactInfo does not embed to VendorExtensible!
+	// data loss from g.VendorExtension
+	if len(g.VendorExtension) != 0 {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+// Paths
+
+func (k *Paths) FromGnostic(g *openapi_v2.Paths) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	if g.Path != nil {
+		k.Paths = make(map[string]PathItem, len(g.Path))
+		for _, v := range g.Path {
+			if v == nil {
+				continue
+			}
+
+			converted := PathItem{}
+			if nok, err := converted.FromGnostic(v.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			k.Paths[v.Name] = converted
+		}
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+func (k *PathItem) FromGnostic(g *openapi_v2.PathItem) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+
+	if nok, err := k.PathItemProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	if err := k.Refable.FromGnostic(g.XRef); err != nil {
+		return false, err
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+func (k *PathItemProps) FromGnostic(g *openapi_v2.PathItem) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	if g.Get != nil {
+		k.Get = &Operation{}
+		if nok, err := k.Get.FromGnostic(g.Get); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Put != nil {
+		k.Put = &Operation{}
+		if nok, err := k.Put.FromGnostic(g.Put); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Post != nil {
+		k.Post = &Operation{}
+		if nok, err := k.Post.FromGnostic(g.Post); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Delete != nil {
+		k.Delete = &Operation{}
+		if nok, err := k.Delete.FromGnostic(g.Delete); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Options != nil {
+		k.Options = &Operation{}
+		if nok, err := k.Options.FromGnostic(g.Options); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Head != nil {
+		k.Head = &Operation{}
+		if nok, err := k.Head.FromGnostic(g.Head); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Patch != nil {
+		k.Patch = &Operation{}
+		if nok, err := k.Patch.FromGnostic(g.Patch); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Parameters != nil {
+		k.Parameters = make([]Parameter, len(g.Parameters))
+		for i, v := range g.Parameters {
+			if v == nil {
+				continue
+			} else if nok, err := k.Parameters[i].FromGnosticParametersItem(v); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		}
+	}
+
+	return ok, nil
+}
+
+func (k *Operation) FromGnostic(g *openapi_v2.Operation) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+
+	if nok, err := k.OperationProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *OperationProps) FromGnostic(g *openapi_v2.Operation) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	k.Description = g.Description
+	k.Consumes = g.Consumes
+	k.Produces = g.Produces
+	k.Schemes = g.Schemes
+	k.Tags = g.Tags
+	k.Summary = g.Summary
+
+	if g.ExternalDocs != nil {
+		k.ExternalDocs = &ExternalDocumentation{}
+		if nok, err := k.ExternalDocs.FromGnostic(g.ExternalDocs); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	k.ID = g.OperationId
+	k.Deprecated = g.Deprecated
+
+	if g.Security != nil {
+		k.Security = make([]map[string][]string, len(g.Security))
+		for i, v := range g.Security {
+			if v == nil || v.AdditionalProperties == nil {
+				continue
+			}
+
+			k.Security[i] = make(map[string][]string, len(v.AdditionalProperties))
+			converted := k.Security[i]
+			for _, p := range v.AdditionalProperties {
+				if p == nil {
+					continue
+				}
+
+				if p.Value != nil {
+					converted[p.Name] = p.Value.Value
+				} else {
+					converted[p.Name] = nil
+				}
+			}
+		}
+	}
+
+	if g.Parameters != nil {
+		k.Parameters = make([]Parameter, len(g.Parameters))
+		for i, v := range g.Parameters {
+			if v == nil {
+				continue
+			} else if nok, err := k.Parameters[i].FromGnosticParametersItem(v); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		}
+	}
+
+	if g.Responses != nil {
+		k.Responses = &Responses{}
+		if nok, err := k.Responses.FromGnostic(g.Responses); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	return ok, nil
+}
+
+// Responses
+
+func (k *Responses) FromGnostic(g *openapi_v2.Responses) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+
+	if nok, err := k.ResponsesProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *ResponsesProps) FromGnostic(g *openapi_v2.Responses) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	} else if g.ResponseCode == nil {
+		return ok, nil
+	}
+
+	ok = true
+	for _, v := range g.ResponseCode {
+		if v == nil {
+			continue
+		}
+		if v.Name == "default" {
+			k.Default = &Response{}
+			if nok, err := k.Default.FromGnosticResponseValue(v.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		} else if nk, err := strconv.Atoi(v.Name); err != nil {
+			// This should actually never fail, unless gnostic struct was
+			// manually/purposefully tampered with at runtime.
+			// Gnostic's ParseDocument validates that all StatusCodeResponses
+			// 	keys adhere to the following regex ^([0-9]{3})$|^(default)$
+			ok = false
+		} else {
+			if k.StatusCodeResponses == nil {
+				k.StatusCodeResponses = map[int]Response{}
+			}
+
+			res := Response{}
+			if nok, err := res.FromGnosticResponseValue(v.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+			k.StatusCodeResponses[nk] = res
+		}
+	}
+
+	return ok, nil
+}
+
+func (k *Response) FromGnostic(g *openapi_v2.Response) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	// Refable case handled in FromGnosticResponseValue
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+
+	if nok, err := k.ResponseProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *Response) FromGnosticResponseValue(g *openapi_v2.ResponseValue) (ok bool, err error) {
+	ok = true
+	if ref := g.GetJsonReference(); ref != nil {
+		k.Description = ref.Description
+
+		if err := k.Refable.FromGnostic(ref.XRef); err != nil {
+			return false, err
+		}
+	} else if nok, err := k.FromGnostic(g.GetResponse()); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+func (k *ResponseProps) FromGnostic(g *openapi_v2.Response) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	k.Description = g.Description
+
+	if g.Schema != nil {
+		k.Schema = &Schema{}
+		if nok, err := k.Schema.FromGnosticSchemaItem(g.Schema); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Headers != nil {
+		k.Headers = make(map[string]Header, len(g.Headers.AdditionalProperties))
+		for _, v := range g.Headers.AdditionalProperties {
+			if v == nil {
+				continue
+			}
+
+			converted := Header{}
+			if err := converted.FromGnostic(v.GetValue()); err != nil {
+				return false, err
+			}
+
+			k.Headers[v.Name] = converted
+		}
+	}
+
+	if g.Examples != nil {
+		k.Examples = make(map[string]interface{}, len(g.Examples.AdditionalProperties))
+		for _, v := range g.Examples.AdditionalProperties {
+			if v == nil {
+				continue
+			} else if v.Value == nil {
+				k.Examples[v.Name] = nil
+				continue
+			}
+
+			var iface interface{}
+			if err := v.Value.ToRawInfo().Decode(&iface); err != nil {
+				return false, err
+			} else {
+				k.Examples[v.Name] = iface
+			}
+		}
+	}
+
+	return ok, nil
+}
+
+// Header
+
+func (k *Header) FromGnostic(g *openapi_v2.Header) (err error) {
+	if g == nil {
+		return nil
+	}
+
+	if err := k.CommonValidations.FromGnostic(g); err != nil {
+		return err
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return err
+	}
+
+	if err := k.SimpleSchema.FromGnostic(g); err != nil {
+		return err
+	}
+
+	if err := k.HeaderProps.FromGnostic(g); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *HeaderProps) FromGnostic(g *openapi_v2.Header) error {
+	if g == nil {
+		return nil
+	}
+
+	// All other fields of openapi_v2.Header are handled by
+	// the embeded fields, commonvalidations, etc.
+	k.Description = g.Description
+	return nil
+}
+
+// Parameters
+
+func (k *Parameter) FromGnostic(g *openapi_v2.Parameter) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	switch p := g.Oneof.(type) {
+	case *openapi_v2.Parameter_BodyParameter:
+		if nok, err := k.ParamProps.FromGnostic(p.BodyParameter); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+
+		if err := k.VendorExtensible.FromGnostic(p.BodyParameter.GetVendorExtension()); err != nil {
+			return false, err
+		}
+
+		return ok, nil
+	case *openapi_v2.Parameter_NonBodyParameter:
+		switch nb := g.GetNonBodyParameter().Oneof.(type) {
+		case *openapi_v2.NonBodyParameter_HeaderParameterSubSchema:
+			if nok, err := k.ParamProps.FromGnostic(nb.HeaderParameterSubSchema); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			if err := k.SimpleSchema.FromGnostic(nb.HeaderParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.CommonValidations.FromGnostic(nb.HeaderParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.VendorExtensible.FromGnostic(nb.HeaderParameterSubSchema.GetVendorExtension()); err != nil {
+				return false, err
+			}
+
+			return ok, nil
+		case *openapi_v2.NonBodyParameter_FormDataParameterSubSchema:
+			if nok, err := k.ParamProps.FromGnostic(nb.FormDataParameterSubSchema); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			if err := k.SimpleSchema.FromGnostic(nb.FormDataParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.CommonValidations.FromGnostic(nb.FormDataParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.VendorExtensible.FromGnostic(nb.FormDataParameterSubSchema.GetVendorExtension()); err != nil {
+				return false, err
+			}
+
+			return ok, nil
+		case *openapi_v2.NonBodyParameter_QueryParameterSubSchema:
+			if nok, err := k.ParamProps.FromGnostic(nb.QueryParameterSubSchema); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			if err := k.SimpleSchema.FromGnostic(nb.QueryParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.CommonValidations.FromGnostic(nb.QueryParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.VendorExtensible.FromGnostic(nb.QueryParameterSubSchema.GetVendorExtension()); err != nil {
+				return false, err
+			}
+
+			return ok, nil
+		case *openapi_v2.NonBodyParameter_PathParameterSubSchema:
+			if nok, err := k.ParamProps.FromGnostic(nb.PathParameterSubSchema); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			if err := k.SimpleSchema.FromGnostic(nb.PathParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.CommonValidations.FromGnostic(nb.PathParameterSubSchema); err != nil {
+				return false, err
+			}
+
+			if err := k.VendorExtensible.FromGnostic(nb.PathParameterSubSchema.GetVendorExtension()); err != nil {
+				return false, err
+			}
+
+			return ok, nil
+		default:
+			return false, errors.New("unrecognized nonbody type for Parameter")
+		}
+	default:
+		return false, errors.New("unrecognized type for Parameter")
+	}
+}
+
+type GnosticCommonParamProps interface {
+	GetName() string
+	GetRequired() bool
+	GetIn() string
+	GetDescription() string
+}
+
+type GnosticCommonParamPropsBodyParameter interface {
+	GetSchema() *openapi_v2.Schema
+}
+
+type GnosticCommonParamPropsFormData interface {
+	GetAllowEmptyValue() bool
+}
+
+func (k *ParamProps) FromGnostic(g GnosticCommonParamProps) (ok bool, err error) {
+	ok = true
+	k.Description = g.GetDescription()
+	k.In = g.GetIn()
+	k.Name = g.GetName()
+	k.Required = g.GetRequired()
+
+	if formDataParameter, success := g.(GnosticCommonParamPropsFormData); success {
+		k.AllowEmptyValue = formDataParameter.GetAllowEmptyValue()
+	}
+
+	if bodyParameter, success := g.(GnosticCommonParamPropsBodyParameter); success {
+		if bodyParameter.GetSchema() != nil {
+			k.Schema = &Schema{}
+			if nok, err := k.Schema.FromGnostic(bodyParameter.GetSchema()); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		}
+	}
+
+	return ok, nil
+}
+
+// PB types use a different structure than we do for "refable". For PB, there is
+// a wrappign oneof type that could be a ref or the type
+func (k *Parameter) FromGnosticParametersItem(g *openapi_v2.ParametersItem) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+	if ref := g.GetJsonReference(); ref != nil {
+		k.Description = ref.Description
+
+		if err := k.Refable.FromGnostic(ref.XRef); err != nil {
+			return false, err
+		}
+	} else if nok, err := k.FromGnostic(g.GetParameter()); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	return ok, nil
+}
+
+// Schema
+
+func (k *Schema) FromGnostic(g *openapi_v2.Schema) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+
+	// SwaggerSchemaProps
+	k.Discriminator = g.Discriminator
+	k.ReadOnly = g.ReadOnly
+	k.Description = g.Description
+	if g.ExternalDocs != nil {
+		k.ExternalDocs = &ExternalDocumentation{}
+		if nok, err := k.ExternalDocs.FromGnostic(g.ExternalDocs); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Example != nil {
+		if err := g.Example.ToRawInfo().Decode(&k.Example); err != nil {
+			return false, err
+		}
+	}
+
+	// SchemaProps
+	if err := k.Ref.FromGnostic(g.XRef); err != nil {
+		return false, err
+	}
+	k.Type = g.Type.GetValue()
+	k.Format = g.GetFormat()
+	k.Title = g.GetTitle()
+
+	// These below fields are not available in gnostic types, so will never
+	// be populated. This means roundtrips which make use of these
+	//	(non-official, kube-only) fields will lose information.
+	//
+	// Schema.ID is not available in official spec
+	// Schema.$schema
+	// Schema.Nullable - in openapiv3, not v2
+	// Schema.AnyOf - in openapiv3, not v2
+	// Schema.OneOf - in openapiv3, not v2
+	// Schema.Not - in openapiv3, not v2
+	// Schema.PatternProperties - in openapiv3, not v2
+	// Schema.Dependencies - in openapiv3, not v2
+	// Schema.AdditionalItems
+	// Schema.Definitions - not part of spec
+	// Schema.ExtraProps - gnostic parser rejects any keys it does not recognize
+
+	if g.GetDefault() != nil {
+		if err := g.GetDefault().ToRawInfo().Decode(&k.Default); err != nil {
+			return false, err
+		}
+	}
+
+	// These conditionals (!= 0) follow gnostic's logic for ToRawInfo
+	// The keys in gnostic source are only included if nonzero.
+
+	if g.Maximum != 0.0 {
+		k.Maximum = &g.Maximum
+	}
+
+	if g.Minimum != 0.0 {
+		k.Minimum = &g.Minimum
+	}
+
+	k.ExclusiveMaximum = g.ExclusiveMaximum
+	k.ExclusiveMinimum = g.ExclusiveMinimum
+
+	if g.MaxLength != 0 {
+		k.MaxLength = &g.MaxLength
+	}
+
+	if g.MinLength != 0 {
+		k.MinLength = &g.MinLength
+	}
+
+	k.Pattern = g.GetPattern()
+
+	if g.MaxItems != 0 {
+		k.MaxItems = &g.MaxItems
+	}
+
+	if g.MinItems != 0 {
+		k.MinItems = &g.MinItems
+	}
+	k.UniqueItems = g.UniqueItems
+
+	if g.MultipleOf != 0 {
+		k.MultipleOf = &g.MultipleOf
+	}
+
+	for _, v := range g.GetEnum() {
+		if v == nil {
+			continue
+		}
+
+		var convert interface{}
+		if err := v.ToRawInfo().Decode(&convert); err != nil {
+			return false, err
+		}
+		k.Enum = append(k.Enum, convert)
+	}
+
+	if g.MaxProperties != 0 {
+		k.MaxProperties = &g.MaxProperties
+	}
+
+	if g.MinProperties != 0 {
+		k.MinProperties = &g.MinProperties
+	}
+
+	k.Required = g.Required
+
+	if g.GetItems() != nil {
+		k.Items = &SchemaOrArray{}
+		for _, v := range g.Items.GetSchema() {
+			if v == nil {
+				continue
+			}
+
+			schema := Schema{}
+			if nok, err := schema.FromGnostic(v); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+			k.Items.Schemas = append(k.Items.Schemas, schema)
+		}
+
+		if len(k.Items.Schemas) == 1 {
+			k.Items.Schema = &k.Items.Schemas[0]
+			k.Items.Schemas = nil
+		}
+	}
+
+	for i, v := range g.GetAllOf() {
+		if v == nil {
+			continue
+		}
+
+		k.AllOf = append(k.AllOf, Schema{})
+		if nok, err := k.AllOf[i].FromGnostic(v); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	if g.Properties != nil {
+		k.Properties = make(map[string]Schema)
+		for _, namedSchema := range g.Properties.AdditionalProperties {
+			if namedSchema == nil {
+				continue
+			}
+			val := &Schema{}
+			if nok, err := val.FromGnostic(namedSchema.Value); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+
+			k.Properties[namedSchema.Name] = *val
+		}
+	}
+
+	if g.AdditionalProperties != nil {
+		k.AdditionalProperties = &SchemaOrBool{}
+		if g.AdditionalProperties.GetSchema() == nil {
+			k.AdditionalProperties.Allows = g.AdditionalProperties.GetBoolean()
+		} else {
+			k.AdditionalProperties.Schema = &Schema{}
+			if nok, err := k.AdditionalProperties.Schema.FromGnostic(g.AdditionalProperties.GetSchema()); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		}
+	}
+
+	return ok, nil
+}
+
+func (k *Schema) FromGnosticSchemaItem(g *openapi_v2.SchemaItem) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+
+	switch p := g.Oneof.(type) {
+	case *openapi_v2.SchemaItem_FileSchema:
+		fileSchema := p.FileSchema
+
+		if err := k.VendorExtensible.FromGnostic(fileSchema.VendorExtension); err != nil {
+			return false, err
+		}
+
+		k.Format = fileSchema.Format
+		k.Title = fileSchema.Title
+		k.Description = fileSchema.Description
+		k.Required = fileSchema.Required
+		k.Type = []string{fileSchema.Type}
+		k.ReadOnly = fileSchema.ReadOnly
+
+		if fileSchema.ExternalDocs != nil {
+			k.ExternalDocs = &ExternalDocumentation{}
+			if nok, err := k.ExternalDocs.FromGnostic(fileSchema.ExternalDocs); err != nil {
+				return false, err
+			} else if !nok {
+				ok = false
+			}
+		}
+
+		if fileSchema.Example != nil {
+			if err := fileSchema.Example.ToRawInfo().Decode(&k.Example); err != nil {
+				return false, err
+			}
+		}
+
+		if fileSchema.Default != nil {
+			if err := fileSchema.Default.ToRawInfo().Decode(&k.Default); err != nil {
+				return false, err
+			}
+		}
+
+	case *openapi_v2.SchemaItem_Schema:
+		schema := p.Schema
+
+		if nok, err := k.FromGnostic(schema); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	default:
+		return false, errors.New("unrecognized type for SchemaItem")
+	}
+
+	return ok, nil
+}
+
+// SecurityDefinitions
+
+func (k SecurityDefinitions) FromGnostic(g *openapi_v2.SecurityDefinitions) error {
+	for _, v := range g.GetAdditionalProperties() {
+		if v == nil {
+			continue
+		}
+		secScheme := &SecurityScheme{}
+		if err := secScheme.FromGnostic(v.Value); err != nil {
+			return err
+		}
+		k[v.Name] = secScheme
+	}
+
+	return nil
+}
+
+type GnosticCommonSecurityDefinition interface {
+	GetType() string
+	GetDescription() string
+}
+
+func (k *SecuritySchemeProps) FromGnostic(g GnosticCommonSecurityDefinition) error {
+	k.Type = g.GetType()
+	k.Description = g.GetDescription()
+
+	if hasName, success := g.(interface{ GetName() string }); success {
+		k.Name = hasName.GetName()
+	}
+
+	if hasIn, success := g.(interface{ GetIn() string }); success {
+		k.In = hasIn.GetIn()
+	}
+
+	if hasFlow, success := g.(interface{ GetFlow() string }); success {
+		k.Flow = hasFlow.GetFlow()
+	}
+
+	if hasAuthURL, success := g.(interface{ GetAuthorizationUrl() string }); success {
+		k.AuthorizationURL = hasAuthURL.GetAuthorizationUrl()
+	}
+
+	if hasTokenURL, success := g.(interface{ GetTokenUrl() string }); success {
+		k.TokenURL = hasTokenURL.GetTokenUrl()
+	}
+
+	if hasScopes, success := g.(interface {
+		GetScopes() *openapi_v2.Oauth2Scopes
+	}); success {
+		scopes := hasScopes.GetScopes()
+		if scopes != nil {
+			k.Scopes = make(map[string]string, len(scopes.AdditionalProperties))
+			for _, v := range scopes.AdditionalProperties {
+				if v == nil {
+					continue
+				}
+
+				k.Scopes[v.Name] = v.Value
+			}
+		}
+	}
+
+	return nil
+}
+
+func (k *SecurityScheme) FromGnostic(g *openapi_v2.SecurityDefinitionsItem) error {
+	if g == nil {
+		return nil
+	}
+
+	switch s := g.Oneof.(type) {
+	case *openapi_v2.SecurityDefinitionsItem_ApiKeySecurity:
+		if err := k.SecuritySchemeProps.FromGnostic(s.ApiKeySecurity); err != nil {
+			return err
+		}
+		if err := k.VendorExtensible.FromGnostic(s.ApiKeySecurity.VendorExtension); err != nil {
+			return err
+		}
+		return nil
+	case *openapi_v2.SecurityDefinitionsItem_BasicAuthenticationSecurity:
+		if err := k.SecuritySchemeProps.FromGnostic(s.BasicAuthenticationSecurity); err != nil {
+			return err
+		}
+		if err := k.VendorExtensible.FromGnostic(s.BasicAuthenticationSecurity.VendorExtension); err != nil {
+			return err
+		}
+		return nil
+	case *openapi_v2.SecurityDefinitionsItem_Oauth2AccessCodeSecurity:
+		if err := k.SecuritySchemeProps.FromGnostic(s.Oauth2AccessCodeSecurity); err != nil {
+			return err
+		}
+		if err := k.VendorExtensible.FromGnostic(s.Oauth2AccessCodeSecurity.VendorExtension); err != nil {
+			return err
+		}
+		return nil
+	case *openapi_v2.SecurityDefinitionsItem_Oauth2ApplicationSecurity:
+		if err := k.SecuritySchemeProps.FromGnostic(s.Oauth2ApplicationSecurity); err != nil {
+			return err
+		}
+		if err := k.VendorExtensible.FromGnostic(s.Oauth2ApplicationSecurity.VendorExtension); err != nil {
+			return err
+		}
+		return nil
+	case *openapi_v2.SecurityDefinitionsItem_Oauth2ImplicitSecurity:
+		if err := k.SecuritySchemeProps.FromGnostic(s.Oauth2ImplicitSecurity); err != nil {
+			return err
+		}
+		if err := k.VendorExtensible.FromGnostic(s.Oauth2ImplicitSecurity.VendorExtension); err != nil {
+			return err
+		}
+		return nil
+	case *openapi_v2.SecurityDefinitionsItem_Oauth2PasswordSecurity:
+		if err := k.SecuritySchemeProps.FromGnostic(s.Oauth2PasswordSecurity); err != nil {
+			return err
+		}
+		if err := k.VendorExtensible.FromGnostic(s.Oauth2PasswordSecurity.VendorExtension); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("unrecognized SecurityDefinitionsItem")
+	}
+}
+
+// Tag
+
+func (k *Tag) FromGnostic(g *openapi_v2.Tag) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+
+	ok = true
+
+	if nok, err := k.TagProps.FromGnostic(g); err != nil {
+		return false, err
+	} else if !nok {
+		ok = false
+	}
+
+	if err := k.VendorExtensible.FromGnostic(g.VendorExtension); err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+func (k *TagProps) FromGnostic(g *openapi_v2.Tag) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	k.Description = g.Description
+	k.Name = g.Name
+
+	if g.ExternalDocs != nil {
+		k.ExternalDocs = &ExternalDocumentation{}
+		if nok, err := k.ExternalDocs.FromGnostic(g.ExternalDocs); err != nil {
+			return false, err
+		} else if !nok {
+			ok = false
+		}
+	}
+
+	return ok, nil
+}
+
+// ExternalDocumentation
+
+func (k *ExternalDocumentation) FromGnostic(g *openapi_v2.ExternalDocs) (ok bool, err error) {
+	if g == nil {
+		return true, nil
+	}
+	ok = true
+	k.Description = g.Description
+	k.URL = g.Url
+
+	// data loss! g.VendorExtension
+	if len(g.VendorExtension) != 0 {
+		ok = false
+	}
+
+	return ok, nil
+}

--- a/pkg/validation/spec/gnostic_test.go
+++ b/pkg/validation/spec/gnostic_test.go
@@ -1,0 +1,1073 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec_test
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/jsonreference"
+	"github.com/google/gnostic/compiler"
+	openapi_v2 "github.com/google/gnostic/openapiv2"
+	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
+	. "k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+var SpecV2DiffOptions = []cmp.Option{
+	// cmp.Diff panics on Ref since jsonreference.Ref uses unexported fields
+	cmp.Comparer(func(a Ref, b Ref) bool {
+		return a.String() == b.String()
+	}),
+}
+
+func gnosticCommonTest(t testing.TB, fuzzer *fuzz.Fuzzer) {
+	fuzzer.Funcs(
+		func(v *Responses, c fuzz.Continue) {
+			c.FuzzNoCustom(v)
+			if v.Default != nil {
+				// Check if we hit maxDepth and left an incomplete value
+				if v.Default.Description == "" {
+					v.Default = nil
+					v.StatusCodeResponses = nil
+				}
+			}
+
+			// conversion has no way to discern empty statusCodeResponses from
+			// nil, since "default" is always included in the map.
+			// So avoid empty responses list
+			if len(v.StatusCodeResponses) == 0 {
+				v.StatusCodeResponses = nil
+			}
+		},
+		func(v *Operation, c fuzz.Continue) {
+			c.FuzzNoCustom(v)
+
+			if v != nil {
+				// force non-nil
+				v.Responses = &Responses{}
+				c.Fuzz(v.Responses)
+
+				v.Schemes = nil
+				if c.RandBool() {
+					v.Schemes = append(v.Schemes, "http")
+				}
+
+				if c.RandBool() {
+					v.Schemes = append(v.Schemes, "https")
+				}
+
+				if c.RandBool() {
+					v.Schemes = append(v.Schemes, "ws")
+				}
+
+				if c.RandBool() {
+					v.Schemes = append(v.Schemes, "wss")
+				}
+
+				// Gnostic unconditionally makes security values non-null
+				// So do not fuzz null values into the array.
+				for i, val := range v.Security {
+					if val == nil {
+						v.Security[i] = make(map[string][]string)
+					}
+
+					for k, v := range val {
+						if v == nil {
+							val[k] = make([]string, 0)
+						}
+					}
+				}
+			}
+		},
+		func(v map[int]Response, c fuzz.Continue) {
+			n := 0
+			c.Fuzz(&n)
+			if n == 0 {
+				// Test that fuzzer is not at maxDepth so we do not
+				// end up with empty elements
+				return
+			}
+
+			// Prevent negative numbers
+			num := c.Intn(4)
+			for i := 0; i < num+2; i++ {
+				val := Response{}
+				c.Fuzz(&val)
+
+				val.Description = c.RandString() + "x"
+				v[100*(i+1)+c.Intn(100)] = val
+			}
+		},
+		func(v map[string]PathItem, c fuzz.Continue) {
+			n := 0
+			c.Fuzz(&n)
+			if n == 0 {
+				// Test that fuzzer is not at maxDepth so we do not
+				// end up with empty elements
+				return
+			}
+
+			num := c.Intn(5)
+			for i := 0; i < num+2; i++ {
+				val := PathItem{}
+				c.Fuzz(&val)
+
+				// Ref params are only allowed in certain locations, so
+				// possibly add a few to PathItems
+				numRefsToAdd := c.Intn(5)
+				for i := 0; i < numRefsToAdd; i++ {
+					theRef := Parameter{}
+					c.Fuzz(&theRef.Refable)
+
+					val.Parameters = append(val.Parameters, theRef)
+				}
+
+				v["/"+c.RandString()] = val
+			}
+		},
+		func(v *SchemaOrArray, c fuzz.Continue) {
+			*v = SchemaOrArray{}
+			// gnostic parser just doesn't support more
+			// than one Schema here
+			v.Schema = &Schema{}
+			c.Fuzz(&v.Schema)
+
+		},
+		func(v *SchemaOrBool, c fuzz.Continue) {
+			*v = SchemaOrBool{}
+
+			if c.RandBool() {
+				v.Allows = c.RandBool()
+			} else {
+				v.Schema = &Schema{}
+				c.Fuzz(&v.Schema)
+			}
+		},
+		func(v map[string]Response, c fuzz.Continue) {
+			n := 0
+			c.Fuzz(&n)
+			if n == 0 {
+				// Test that fuzzer is not at maxDepth so we do not
+				// end up with empty elements
+				return
+			}
+
+			// Response definitions are not allowed to
+			// be refs
+			for i := 0; i < c.Intn(5)+1; i++ {
+				resp := &Response{}
+
+				c.Fuzz(resp)
+				resp.Ref = Ref{}
+				resp.Description = c.RandString() + "x"
+
+				// Response refs are not vendor extensible by gnostic
+				resp.VendorExtensible.Extensions = nil
+				v[c.RandString()+"x"] = *resp
+			}
+		},
+		func(v *Header, c fuzz.Continue) {
+			if v != nil {
+				c.FuzzNoCustom(v)
+
+				// descendant Items of Header may not be refs
+				cur := v.Items
+				for cur != nil {
+					cur.Ref = Ref{}
+					cur = cur.Items
+				}
+			}
+		},
+		func(v *Ref, c fuzz.Continue) {
+			*v = Ref{}
+			v.Ref, _ = jsonreference.New("http://asd.com/" + c.RandString())
+		},
+		func(v *Response, c fuzz.Continue) {
+			*v = Response{}
+			if c.RandBool() {
+				v.Ref = Ref{}
+				v.Ref.Ref, _ = jsonreference.New("http://asd.com/" + c.RandString())
+			} else {
+				c.Fuzz(&v.VendorExtensible)
+				c.Fuzz(&v.Schema)
+				c.Fuzz(&v.ResponseProps)
+
+				v.Headers = nil
+				v.Ref = Ref{}
+
+				n := 0
+				c.Fuzz(&n)
+				if n != 0 {
+					// Test that fuzzer is not at maxDepth so we do not
+					// end up with empty elements
+					num := c.Intn(4)
+					for i := 0; i < num; i++ {
+						if v.Headers == nil {
+							v.Headers = make(map[string]Header)
+						}
+						hdr := Header{}
+						c.Fuzz(&hdr)
+						if hdr.Type == "" {
+							// hit maxDepth, just abort trying to make haders
+							v.Headers = nil
+							break
+						}
+						v.Headers[c.RandString()+"x"] = hdr
+					}
+				} else {
+					v.Headers = nil
+				}
+			}
+
+			v.Description = c.RandString() + "x"
+
+			// Gnostic parses empty as nil, so to keep avoid putting empty
+			if len(v.Headers) == 0 {
+				v.Headers = nil
+			}
+		},
+		func(v **Info, c fuzz.Continue) {
+			// Info is never nil
+			*v = &Info{}
+			c.FuzzNoCustom(*v)
+
+			(*v).Title = c.RandString() + "x"
+		},
+		func(v *Extensions, c fuzz.Continue) {
+			// gnostic parser only picks up x- vendor extensions
+			numChildren := c.Intn(5)
+			for i := 0; i < numChildren; i++ {
+				if *v == nil {
+					*v = Extensions{}
+				}
+				(*v)["x-"+c.RandString()] = c.RandString()
+			}
+		},
+		func(v *Swagger, c fuzz.Continue) {
+			c.FuzzNoCustom(v)
+
+			if v.Paths == nil {
+				// Force paths non-nil since it does not have omitempty in json tag.
+				// This means a perfect roundtrip (via json) is impossible,
+				// since we can't tell the difference between empty/unspecified paths
+				v.Paths = &Paths{}
+				c.Fuzz(v.Paths)
+			}
+
+			v.Swagger = "2.0"
+
+			// Gnostic support serializing ID at all
+			// unavoidable data loss
+			v.ID = ""
+
+			v.Schemes = nil
+			if c.RandUint64()%2 == 1 {
+				v.Schemes = append(v.Schemes, "http")
+			}
+
+			if c.RandUint64()%2 == 1 {
+				v.Schemes = append(v.Schemes, "https")
+			}
+
+			if c.RandUint64()%2 == 1 {
+				v.Schemes = append(v.Schemes, "ws")
+			}
+
+			if c.RandUint64()%2 == 1 {
+				v.Schemes = append(v.Schemes, "wss")
+			}
+
+			// Gnostic unconditionally makes security values non-null
+			// So do not fuzz null values into the array.
+			for i, val := range v.Security {
+				if val == nil {
+					v.Security[i] = make(map[string][]string)
+				}
+
+				for k, v := range val {
+					if v == nil {
+						val[k] = make([]string, 0)
+					}
+				}
+			}
+		},
+		func(v *SecurityScheme, c fuzz.Continue) {
+			v.Description = c.RandString() + "x"
+			c.Fuzz(&v.VendorExtensible)
+
+			switch c.Intn(3) {
+			case 0:
+				v.Type = "basic"
+			case 1:
+				v.Type = "apiKey"
+				switch c.Intn(2) {
+				case 0:
+					v.In = "header"
+				case 1:
+					v.In = "query"
+				default:
+					panic("unreachable")
+				}
+				v.Name = "x" + c.RandString()
+			case 2:
+				v.Type = "oauth2"
+
+				switch c.Intn(4) {
+				case 0:
+					v.Flow = "accessCode"
+					v.TokenURL = "https://" + c.RandString()
+					v.AuthorizationURL = "https://" + c.RandString()
+				case 1:
+					v.Flow = "application"
+					v.TokenURL = "https://" + c.RandString()
+				case 2:
+					v.Flow = "implicit"
+					v.AuthorizationURL = "https://" + c.RandString()
+				case 3:
+					v.Flow = "password"
+					v.TokenURL = "https://" + c.RandString()
+				default:
+					panic("unreachable")
+				}
+				c.Fuzz(&v.Scopes)
+			default:
+				panic("unreachable")
+			}
+		},
+		func(v *interface{}, c fuzz.Continue) {
+			*v = c.RandString() + "x"
+		},
+		func(v *string, c fuzz.Continue) {
+			*v = c.RandString() + "x"
+		},
+		func(v *ExternalDocumentation, c fuzz.Continue) {
+			v.Description = c.RandString() + "x"
+			v.URL = c.RandString() + "x"
+		},
+		func(v *SimpleSchema, c fuzz.Continue) {
+			c.FuzzNoCustom(v)
+
+			switch c.Intn(5) {
+			case 0:
+				v.Type = "string"
+			case 1:
+				v.Type = "number"
+			case 2:
+				v.Type = "boolean"
+			case 3:
+				v.Type = "integer"
+			case 4:
+				v.Type = "array"
+			default:
+				panic("unreachable")
+			}
+
+			switch c.Intn(5) {
+			case 0:
+				v.CollectionFormat = "csv"
+			case 1:
+				v.CollectionFormat = "ssv"
+			case 2:
+				v.CollectionFormat = "tsv"
+			case 3:
+				v.CollectionFormat = "pipes"
+			case 4:
+				v.CollectionFormat = ""
+			default:
+				panic("unreachable")
+			}
+
+			// None of the types which include SimpleSchema in our definitions
+			// actually support "example" in the official spec
+			v.Example = nil
+
+			// unsupported by openapi
+			v.Nullable = false
+		},
+		func(v *int64, c fuzz.Continue) {
+			c.Fuzz(v)
+
+			// Gnostic does not differentiate between 0 and non-specified
+			// so avoid using 0 for fuzzer
+			if *v == 0 {
+				*v = 1
+			}
+		},
+		func(v *float64, c fuzz.Continue) {
+			c.Fuzz(v)
+
+			// Gnostic does not differentiate between 0 and non-specified
+			// so avoid using 0 for fuzzer
+			if *v == 0.0 {
+				*v = 1.0
+			}
+		},
+		func(v *Parameter, c fuzz.Continue) {
+			if v == nil {
+				return
+			}
+			c.Fuzz(&v.VendorExtensible)
+			if c.RandBool() {
+				// body param
+				v.Description = c.RandString() + "x"
+				v.Name = c.RandString() + "x"
+				v.In = "body"
+				c.Fuzz(&v.Description)
+				c.Fuzz(&v.Required)
+
+				v.Schema = &Schema{}
+				c.Fuzz(&v.Schema)
+
+			} else {
+				c.Fuzz(&v.SimpleSchema)
+				c.Fuzz(&v.CommonValidations)
+				v.AllowEmptyValue = false
+				v.Description = c.RandString() + "x"
+				v.Name = c.RandString() + "x"
+
+				switch c.Intn(4) {
+				case 0:
+					// Header param
+					v.In = "header"
+				case 1:
+					// Form data param
+					v.In = "formData"
+					v.AllowEmptyValue = c.RandBool()
+				case 2:
+					// Query param
+					v.In = "query"
+					v.AllowEmptyValue = c.RandBool()
+				case 3:
+					// Path param
+					v.In = "path"
+					v.Required = true
+				default:
+					panic("unreachable")
+				}
+
+				// descendant Items of Parameter may not be refs
+				cur := v.Items
+				for cur != nil {
+					cur.Ref = Ref{}
+					cur = cur.Items
+				}
+			}
+		},
+		func(v *Schema, c fuzz.Continue) {
+			if c.RandBool() {
+				// file schema
+				c.Fuzz(&v.Default)
+				c.Fuzz(&v.Description)
+				c.Fuzz(&v.Example)
+				c.Fuzz(&v.ExternalDocs)
+
+				c.Fuzz(&v.Format)
+				c.Fuzz(&v.ReadOnly)
+				c.Fuzz(&v.Required)
+				c.Fuzz(&v.Title)
+				v.Type = StringOrArray{"file"}
+
+			} else {
+				// normal schema
+				c.Fuzz(&v.SchemaProps)
+				c.Fuzz(&v.SwaggerSchemaProps)
+				c.Fuzz(&v.VendorExtensible)
+				// c.Fuzz(&v.ExtraProps)
+				// ExtraProps will not roundtrip - gnostic throws out
+				// unrecognized keys
+			}
+
+			// Not supported by official openapi v2 spec
+			// and stripped by k8s apiserver
+			v.ID = ""
+			v.AnyOf = nil
+			v.OneOf = nil
+			v.Not = nil
+			v.Nullable = false
+			v.AdditionalItems = nil
+			v.Schema = ""
+			v.PatternProperties = nil
+			v.Definitions = nil
+			v.Dependencies = nil
+		},
+	)
+
+	expected := Swagger{}
+	fuzzer.Fuzz(&expected)
+
+	// Convert to gnostic via JSON to compare
+	jsonBytes, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	t.Log("Specimen", string(jsonBytes))
+
+	gnosticSpec, err := openapi_v2.ParseDocument(jsonBytes)
+	require.NoError(t, err)
+
+	actual := Swagger{}
+	ok, err := actual.FromGnostic(gnosticSpec)
+	require.NoError(t, err)
+	require.True(t, ok)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatal(cmp.Diff(expected, actual, SpecV2DiffOptions...))
+	}
+
+	newJsonBytes, err := json.Marshal(actual)
+	require.NoError(t, err)
+	if !reflect.DeepEqual(jsonBytes, newJsonBytes) {
+		t.Fatal(cmp.Diff(string(jsonBytes), string(newJsonBytes), SpecV2DiffOptions...))
+	}
+}
+
+func TestGnosticConversionSmallDeterministic(t *testing.T) {
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(15).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallDeterministic2(t *testing.T) {
+	// A failed case of TestGnosticConversionSmallRandom
+	// which failed during development/testing loop
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(1646770841).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallDeterministic3(t *testing.T) {
+	// A failed case of TestGnosticConversionSmallRandom
+	// which failed during development/testing loop
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(1646772024).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallDeterministic4(t *testing.T) {
+	// A failed case of TestGnosticConversionSmallRandom
+	// which failed during development/testing loop
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(1646791953).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallDeterministic5(t *testing.T) {
+	// A failed case of TestGnosticConversionSmallRandom
+	// which failed during development/testing loop
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(1646940131).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallDeterministic6(t *testing.T) {
+	// A failed case of TestGnosticConversionSmallRandom
+	// which failed during development/testing loop
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(1646941926).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallDeterministic7(t *testing.T) {
+	// A failed case of TestGnosticConversionSmallRandom
+	// which failed during development/testing loop
+	// This case did not convert nil/empty array within OperationProps.Security
+	// correctly
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(1647297721085690000).
+			NilChance(0.8).
+			MaxDepth(10).
+			NumElements(1, 2),
+	)
+}
+
+func TestGnosticConversionSmallRandom(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Log("Using seed: ", seed)
+	fuzzer := fuzz.
+		NewWithSeed(seed).
+		NilChance(0.8).
+		MaxDepth(10).
+		NumElements(1, 2)
+
+	for i := 0; i <= 50; i++ {
+		gnosticCommonTest(
+			t,
+			fuzzer,
+		)
+	}
+}
+
+func TestGnosticConversionMediumDeterministic(t *testing.T) {
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(15).
+			NilChance(0.4).
+			MaxDepth(12).
+			NumElements(3, 5),
+	)
+}
+
+func TestGnosticConversionLargeDeterministic(t *testing.T) {
+	gnosticCommonTest(
+		t,
+		fuzz.
+			NewWithSeed(15).
+			NilChance(0.1).
+			MaxDepth(15).
+			NumElements(3, 5),
+	)
+}
+
+func TestGnosticConversionLargeRandom(t *testing.T) {
+	var seed int64 = time.Now().UnixNano()
+	t.Log("Using seed: ", seed)
+	fuzzer := fuzz.
+		NewWithSeed(seed).
+		NilChance(0).
+		MaxDepth(15).
+		NumElements(3, 5)
+
+	for i := 0; i < 5; i++ {
+		gnosticCommonTest(
+			t,
+			fuzzer,
+		)
+	}
+}
+
+func BenchmarkGnosticConversion(b *testing.B) {
+	// Download kube-openapi swagger json
+	swagFile, err := os.Open("../../schemaconv/testdata/swagger.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer swagFile.Close()
+
+	originalJSON, err := io.ReadAll(swagFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Parse into kube-openapi types
+	var result *Swagger
+	b.Run("json->swagger", func(b2 *testing.B) {
+		for i := 0; i < b2.N; i++ {
+			if err := json.Unmarshal(originalJSON, &result); err != nil {
+				b2.Fatal(err)
+			}
+		}
+	})
+
+	// Convert to JSON
+	var encodedJSON []byte
+	b.Run("swagger->json", func(b2 *testing.B) {
+		for i := 0; i < b2.N; i++ {
+			encodedJSON, err = json.Marshal(result)
+			if err != nil {
+				b2.Fatal(err)
+			}
+		}
+	})
+
+	// Convert to gnostic
+	var originalGnostic *openapi_v2.Document
+	b.Run("json->gnostic", func(b2 *testing.B) {
+		for i := 0; i < b2.N; i++ {
+			originalGnostic, err = openapi_v2.ParseDocument(encodedJSON)
+			if err != nil {
+				b2.Fatal(err)
+			}
+		}
+	})
+
+	// Convert to PB
+	var encodedProto []byte
+	b.Run("gnostic->pb", func(b2 *testing.B) {
+		for i := 0; i < b2.N; i++ {
+			encodedProto, err = proto.Marshal(originalGnostic)
+			if err != nil {
+				b2.Fatal(err)
+			}
+		}
+	})
+
+	// Convert to gnostic
+	var backToGnostic openapi_v2.Document
+	b.Run("pb->gnostic", func(b2 *testing.B) {
+		for i := 0; i < b2.N; i++ {
+			if err := proto.Unmarshal(encodedProto, &backToGnostic); err != nil {
+				b2.Fatal(err)
+			}
+		}
+	})
+
+	for i := 0; i < b.N; i++ {
+		b.Run("gnostic->kube", func(b2 *testing.B) {
+			for i := 0; i < b2.N; i++ {
+				decodedSwagger := &Swagger{}
+				if ok, err := decodedSwagger.FromGnostic(&backToGnostic); err != nil {
+					b2.Fatal(err)
+				} else if !ok {
+					b2.Fatal("conversion lost data")
+				}
+			}
+		})
+	}
+}
+
+// Ensure all variants of SecurityDefinition are being exercised by tests
+func TestSecurityDefinitionVariants(t *testing.T) {
+	type TestPattern struct {
+		Name    string
+		Pattern string
+	}
+
+	patterns := []TestPattern{
+		{
+			Name:    "Basic Authentication",
+			Pattern: `{"type": "basic", "description": "cool basic auth"}`,
+		},
+		{
+			Name:    "API Key Query",
+			Pattern: `{"type": "apiKey", "description": "cool api key auth", "in": "query", "name": "coolAuth"}`,
+		},
+		{
+			Name:    "API Key Header",
+			Pattern: `{"type": "apiKey", "description": "cool api key auth", "in": "header", "name": "coolAuth"}`,
+		},
+		{
+			Name:    "OAuth2 Implicit",
+			Pattern: `{"type": "oauth2", "flow": "implicit", "authorizationUrl": "https://google.com", "scopes": {"scope1": "a scope", "scope2": "a scope"}, "description": "cool oauth2 auth"}`,
+		},
+		{
+			Name:    "OAuth2 Password",
+			Pattern: `{"type": "oauth2", "flow": "password", "tokenUrl": "https://google.com", "scopes": {"scope1": "a scope", "scope2": "a scope"}, "description": "cool oauth2 auth"}`,
+		},
+		{
+			Name:    "OAuth2 Application",
+			Pattern: `{"type": "oauth2", "flow": "application", "tokenUrl": "https://google.com", "scopes": {"scope1": "a scope", "scope2": "a scope"}, "description": "cool oauth2 auth"}`,
+		},
+		{
+			Name:    "OAuth2 Access Code",
+			Pattern: `{"type": "oauth2", "flow": "accessCode", "authorizationUrl": "https://google.com", "tokenUrl": "https://google.com", "scopes": {"scope1": "a scope", "scope2": "a scope"}, "description": "cool oauth2 auth"}`,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.Name, func(t *testing.T) {
+			// Parse JSON into yaml
+			var nodes yaml.Node
+			if err := yaml.Unmarshal([]byte(p.Pattern), &nodes); err != nil {
+				t.Error(err)
+				return
+			} else if len(nodes.Content) != 1 {
+				t.Errorf("unexpected yaml parse result")
+				return
+			}
+
+			root := nodes.Content[0]
+
+			parsed, err := openapi_v2.NewSecurityDefinitionsItem(root, compiler.NewContextWithExtensions("$root", root, nil, nil))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			converted := SecurityScheme{}
+			if err := converted.FromGnostic(parsed); err != nil {
+				t.Error(err)
+				return
+			}
+
+			// Ensure that the same JSON parsed via kube-openapi gives the same
+			// result
+			var expected SecurityScheme
+			if err := json.Unmarshal([]byte(p.Pattern), &expected); err != nil {
+				t.Error(err)
+				return
+			} else if !reflect.DeepEqual(expected, converted) {
+				t.Errorf("expected equal values: %v", cmp.Diff(expected, converted, SpecV2DiffOptions...))
+				return
+			}
+		})
+	}
+}
+
+// Ensure all variants of Parameter are being exercised by tests
+func TestParamVariants(t *testing.T) {
+	type TestPattern struct {
+		Name    string
+		Pattern string
+	}
+
+	patterns := []TestPattern{
+		{
+			Name:    "Body Parameter",
+			Pattern: `{"in": "body", "name": "myBodyParam", "schema": {}}`,
+		},
+		{
+			Name:    "NonBody Header Parameter",
+			Pattern: `{"in": "header", "name": "myHeaderParam", "description": "a cool parameter", "type": "string", "collectionFormat": "pipes"}`,
+		},
+		{
+			Name:    "NonBody FormData Parameter",
+			Pattern: `{"in": "formData", "name": "myFormDataParam", "description": "a cool parameter", "type": "string", "collectionFormat": "pipes"}`,
+		},
+		{
+			Name:    "NonBody Query Parameter",
+			Pattern: `{"in": "query", "name": "myQueryParam", "description": "a cool parameter", "type": "string", "collectionFormat": "pipes"}`,
+		},
+		{
+			Name:    "NonBody Path Parameter",
+			Pattern: `{"required": true, "in": "path", "name": "myPathParam", "description": "a cool parameter", "type": "string", "collectionFormat": "pipes"}`,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.Name, func(t *testing.T) {
+			// Parse JSON into yaml
+			var nodes yaml.Node
+			if err := yaml.Unmarshal([]byte(p.Pattern), &nodes); err != nil {
+				t.Error(err)
+				return
+			} else if len(nodes.Content) != 1 {
+				t.Errorf("unexpected yaml parse result")
+				return
+			}
+
+			root := nodes.Content[0]
+
+			ctx := compiler.NewContextWithExtensions("$root", root, nil, nil)
+			parsed, err := openapi_v2.NewParameter(root, ctx)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			converted := Parameter{}
+			if ok, err := converted.FromGnostic(parsed); err != nil {
+				t.Error(err)
+				return
+			} else if !ok {
+				t.Errorf("expected no data loss while converting parameter: %v", p.Pattern)
+				return
+			}
+
+			// Ensure that the same JSON parsed via kube-openapi gives the same
+			// result
+			var expected Parameter
+			if err := json.Unmarshal([]byte(p.Pattern), &expected); err != nil {
+				t.Error(err)
+				return
+			} else if !reflect.DeepEqual(expected, converted) {
+				t.Errorf("expected equal values: %v", cmp.Diff(expected, converted, SpecV2DiffOptions...))
+				return
+			}
+		})
+	}
+}
+
+// Test that a few patterns of obvious data loss are detected
+func TestCommonDataLoss(t *testing.T) {
+	type TestPattern struct {
+		Name          string
+		BadInstance   string
+		FixedInstance string
+	}
+
+	patterns := []TestPattern{
+		{
+			Name:          "License with Vendor Extension",
+			BadInstance:   `{"swagger": "2.0", "info": {"title": "test", "version": "1.0", "license": {"name": "MIT", "x-hello": "ignored"}}, "paths": {}}`,
+			FixedInstance: `{"swagger": "2.0", "info": {"title": "test", "version": "1.0", "license": {"name": "MIT"}}, "paths": {}}`,
+		},
+		{
+			Name:          "Contact with Vendor Extension",
+			BadInstance:   `{"swagger": "2.0", "info": {"title": "test", "version": "1.0", "contact": {"name": "bill", "x-hello": "ignored"}}, "paths": {}}`,
+			FixedInstance: `{"swagger": "2.0", "info": {"title": "test", "version": "1.0", "contact": {"name": "bill"}}, "paths": {}}`,
+		},
+		{
+			Name:          "External Documentation with Vendor Extension",
+			BadInstance:   `{"swagger": "2.0", "info": {"title": "test", "version": "1.0", "contact": {"name": "bill", "x-hello": "ignored"}}, "paths": {}}`,
+			FixedInstance: `{"swagger": "2.0", "info": {"title": "test", "version": "1.0", "contact": {"name": "bill"}}, "paths": {}}`,
+		},
+	}
+
+	for _, v := range patterns {
+		t.Run(v.Name, func(t *testing.T) {
+			bad, err := openapi_v2.ParseDocument([]byte(v.BadInstance))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			fixed, err := openapi_v2.ParseDocument([]byte(v.FixedInstance))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			badConverted := Swagger{}
+			if ok, err := badConverted.FromGnostic(bad); err != nil {
+				t.Error(err)
+				return
+			} else if ok {
+				t.Errorf("expected test to have data loss")
+				return
+			}
+
+			fixedConverted := Swagger{}
+			if ok, err := fixedConverted.FromGnostic(fixed); err != nil {
+				t.Error(err)
+				return
+			} else if !ok {
+				t.Errorf("expected fixed test to not have data loss")
+				return
+			}
+
+			// Convert JSON directly into our kube-openapi type and check that
+			// it is exactly equal to the converted instance
+			fixedDirect := Swagger{}
+			if err := json.Unmarshal([]byte(v.FixedInstance), &fixedDirect); err != nil {
+				t.Error(err)
+				return
+			}
+
+			if !reflect.DeepEqual(fixedConverted, badConverted) {
+				t.Errorf("expected equal documents: %v", cmp.Diff(fixedConverted, badConverted, SpecV2DiffOptions...))
+				return
+			}
+
+			// Make sure that they were exactly the same, except for the data loss
+			//	by checking JSON encodes the some
+			badConvertedJSON, err := json.Marshal(badConverted)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			fixedConvertedJSON, err := json.Marshal(fixedConverted)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			fixedDirectJSON, err := json.Marshal(fixedDirect)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if !reflect.DeepEqual(badConvertedJSON, fixedConvertedJSON) {
+				t.Errorf("encoded json values for bad and fixed tests are not identical: %v", cmp.Diff(string(badConvertedJSON), string(fixedConvertedJSON)))
+			}
+
+			if !reflect.DeepEqual(fixedDirectJSON, fixedConvertedJSON) {
+				t.Errorf("encoded json values for fixed direct and fixed-from-gnostic tests are not identical: %v", cmp.Diff(string(fixedDirectJSON), string(fixedConvertedJSON)))
+			}
+		})
+	}
+}
+
+func TestBadStatusCode(t *testing.T) {
+	const testCase = `{"swagger": "2.0", "info": {"title": "test", "version": "1.0"}, "paths": {"/": {"get": {"responses" : { "default": { "$ref": "#/definitions/a" }, "200": { "$ref": "#/definitions/b" }}}}}}`
+	const dropped = `{"swagger": "2.0", "info": {"title": "test", "version": "1.0"}, "paths": {"/": {"get": {"responses" : { "200": { "$ref": "#/definitions/b" }}}}}}`
+	gnosticInstance, err := openapi_v2.ParseDocument([]byte(testCase))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	droppedGnosticInstance, err := openapi_v2.ParseDocument([]byte(dropped))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually poke an response code name which gnostic's json parser would not allow
+	gnosticInstance.Paths.Path[0].Value.Get.Responses.ResponseCode[0].Name = "bad"
+
+	badConverted := Swagger{}
+	droppedConverted := Swagger{}
+
+	if ok, err := badConverted.FromGnostic(gnosticInstance); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatalf("expected data loss converting an operation with a response code 'bad'")
+	}
+
+	if ok, err := droppedConverted.FromGnostic(droppedGnosticInstance); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatalf("expected no data loss converting a known good operation")
+	}
+
+	// Make sure that they were exactly the same, except for the data loss
+	//	by checking JSON encodes the some
+	badConvertedJSON, err := json.Marshal(badConverted)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	droppedConvertedJSON, err := json.Marshal(droppedConverted)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !reflect.DeepEqual(badConvertedJSON, droppedConvertedJSON) {
+		t.Errorf("encoded json values for bad and fixed tests are not identical: %v", cmp.Diff(string(badConvertedJSON), string(droppedConvertedJSON)))
+	}
+}


### PR DESCRIPTION
This PR continues conversation from https://github.com/kubernetes/kube-openapi/pull/279 and privately with @liggitt wherein we decided the best path to convert gnostic to kube-openapi was to write a direct conversion.

This PR adds a direct conversion from gnostic openapiv2 types to kube-openapi's spec.Swagger. Below are benchmark results from the same benchmark used in #279:

```
BenchmarkGnosticConversion/json->swagger
BenchmarkGnosticConversion/json->swagger-8                  2     537177100 ns/op    95737132 B/op    1381637 allocs/op
BenchmarkGnosticConversion/swagger->json
BenchmarkGnosticConversion/swagger->json-8                  9     125024798 ns/op    71075921 B/op     274071 allocs/op
BenchmarkGnosticConversion/json->gnostic
BenchmarkGnosticConversion/json->gnostic-8                  5     229392000 ns/op    81446859 B/op    1248395 allocs/op
BenchmarkGnosticConversion/gnostic->pb
BenchmarkGnosticConversion/gnostic->pb-8                  100      11095008 ns/op     2899968 B/op          1 allocs/op
BenchmarkGnosticConversion/gnostic->yaml
BenchmarkGnosticConversion/gnostic->yaml-8                 42      28717820 ns/op    32855169 B/op     264562 allocs/op

BenchmarkGnosticConversion/pb->gnostic
BenchmarkGnosticConversion/pb->gnostic-8                   97      13012220 ns/op     9480701 B/op     123829 allocs/op
BenchmarkGnosticConversion/gnostic->swagger
BenchmarkGnosticConversion/gnostic->swagger-8              50      25910391 ns/op    22287938 B/op     164414 allocs/op
```

pb->gnostic->swagger using this method takes ~39ms

this compares favorably to pb->gnostic->yaml->swagger from the last PR in ~97ms

which compared favorably to pb->gnostic->yaml->json->swagger, today's existing solution, which clocked this benchmark at ~628ms

Caveats:

* Fields like `Maximum`, `Minimum`, `MaxItems`, etc in gnostic are not implemented as pointers. This means the conversion has no way to differentiate between one of these being `0` vs being unused
* Kube-Openapi Swagger type has a number of fields added in OpenAPI v3, despite the fact it represents an OpenAPI v2 object. This fields cannot be populated by the unmarshaler since gnostic errors/ignores unrecognized keys. Thus, if one is roundtripping with gnostic via `kube->json->gnostic->kube`, those fields would be missing, since `json->gnostic` would ignore them.
* spec.SchemaOrArray in gnostic's implementation only scans for one element, so successive schemas are ignored
* A number of our kube-openapi Swagger types do not have `VendorExtensible` embedded even when OpenAPI spec permits "x-" extensions. This means any extensions used in gnostic for a few types are not carried over. This can be corrected in another PR
* Response.Description and Parameter.Description are missing from our type definitions despite being available in openapi v2, so the information is dropped when converted from gnostic. This can be corrected in another PR.

For the use case of kubernetes' swagger.json, most of these caveats do not apply:
* The Maximum/Minimum/etc. fields. May be an issue. I have not looked into whether in the OpenAPI spec these values being 0 means "unset" like gnostic treats them.
* The openapi v3 validation fields like anyOf, not, etc. are stripped from the kubernetes openapi v2 published description. (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/skeleton.go)
* Practical (and kubernetes') usages of Schema.Items (only usage of spec.SchemaOrArray) always have one element. This is because JSON schema spec does not specify it as an array in more recent versions. (`prefixItems` is used as the array version of old `Items`): http://json-schema.org/draft/2020-12/json-schema-core.html#items
* This is only a problem if the information existed in the first place. Since kubernetes use case is kube->gnostic->kube, there is no risk of losing fields that are available in gnostic but not in kube-openapi.
* MIssing fields can be added. But also see above point.

@natasha41575
/cc @apelisse