### PR TITLE
Cache busting

### DIFF
--- a/pkg/handler3/handler.go
+++ b/pkg/handler3/handler.go
@@ -23,7 +23,10 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"net/url"
+	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -49,9 +52,20 @@ const (
 	subTypeJSON     = "json"
 )
 
+// OpenAPIV3Discovery is the format of the Discovery document for OpenAPI V3
+// It maps Discovery paths to their corresponding URLs with a hash parameter included
+type OpenAPIV3Discovery struct {
+	Paths map[string]OpenAPIV3DiscoveryGroupVersion
+}
+
+// OpenAPIV3DiscoveryGroupVersion includes information about a group version and URL
+// for accessing the OpenAPI. The URL includes a hash parameter to support client side caching
+type OpenAPIV3DiscoveryGroupVersion struct {
+	URL string
+}
+
 // OpenAPIService is the service responsible for serving OpenAPI spec. It has
 // the ability to safely change the spec while serving it.
-// OpenAPI V3 currently does not use the lazy marshaling strategy that OpenAPI V2 is using
 type OpenAPIService struct {
 	// rwMutex protects All members of this service.
 	rwMutex      sync.RWMutex
@@ -66,6 +80,7 @@ type OpenAPIV3Group struct {
 
 	pbCache   handler.HandlerCache
 	jsonCache handler.HandlerCache
+	etagCache handler.HandlerCache
 }
 
 func init() {
@@ -75,7 +90,18 @@ func init() {
 }
 
 func computeETag(data []byte) string {
-	return fmt.Sprintf("\"%X\"", sha512.Sum512(data))
+	if data == nil {
+		return ""
+	}
+	return fmt.Sprintf("%X", sha512.Sum512(data))
+}
+
+func constructURL(gvString, etag string) string {
+	u := url.URL{Path: path.Join("/openapi/v3", gvString)}
+	query := url.Values{}
+	query.Set("hash", etag)
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 // NewOpenAPIService builds an OpenAPIService starting with the given spec.
@@ -96,10 +122,17 @@ func (o *OpenAPIService) getGroupBytes() ([]byte, error) {
 	}
 
 	sort.Strings(keys)
-	group := make(map[string][]string)
-	group["Paths"] = keys
-
-	j, err := json.Marshal(group)
+	discovery := &OpenAPIV3Discovery{Paths: make(map[string]OpenAPIV3DiscoveryGroupVersion)}
+	for gvString, groupVersion := range o.v3Schema {
+		etagBytes, err := groupVersion.etagCache.Get()
+		if err != nil {
+			return nil, err
+		}
+		discovery.Paths[gvString] = OpenAPIV3DiscoveryGroupVersion{
+			URL: constructURL(gvString, string(etagBytes)),
+		}
+	}
+	j, err := json.Marshal(discovery)
 	if err != nil {
 		return nil, err
 	}
@@ -114,11 +147,19 @@ func (o *OpenAPIService) getSingleGroupBytes(getType string, group string) ([]by
 		return nil, "", time.Now(), fmt.Errorf("Cannot find CRD group %s", group)
 	}
 	if getType == subTypeJSON {
-		specBytes, etag, err := v.jsonCache.Get()
-		return specBytes, etag, v.lastModified, err
+		specBytes, err := v.jsonCache.Get()
+		if err != nil {
+			return nil, "", v.lastModified, err
+		}
+		etagBytes, err := v.etagCache.Get()
+		return specBytes, string(etagBytes), v.lastModified, err
 	} else if getType == subTypeProtobuf {
-		specPb, etag, err := v.pbCache.Get()
-		return specPb, etag, v.lastModified, err
+		specPb, err := v.pbCache.Get()
+		if err != nil {
+			return nil, "", v.lastModified, err
+		}
+		etagBytes, err := v.etagCache.Get()
+		return specPb, string(etagBytes), v.lastModified, err
 	}
 	return nil, "", time.Now(), fmt.Errorf("Invalid accept clause %s", getType)
 }
@@ -127,15 +168,10 @@ func (o *OpenAPIService) UpdateGroupVersion(group string, openapi *spec3.OpenAPI
 	o.rwMutex.Lock()
 	defer o.rwMutex.Unlock()
 
-	specBytes, err := json.Marshal(openapi)
-	if err != nil {
-		return err
-	}
-
 	if _, ok := o.v3Schema[group]; !ok {
 		o.v3Schema[group] = &OpenAPIV3Group{}
 	}
-	return o.v3Schema[group].UpdateSpec(specBytes)
+	return o.v3Schema[group].UpdateSpec(openapi)
 }
 
 func (o *OpenAPIService) DeleteGroupVersion(group string) {
@@ -192,7 +228,26 @@ func (o *OpenAPIService) HandleGroupVersion(w http.ResponseWriter, r *http.Reque
 			if err != nil {
 				return
 			}
-			w.Header().Set("Etag", etag)
+			// ETag must be enclosed in double quotes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+			w.Header().Set("Etag", strconv.Quote(etag))
+
+			if hash := r.URL.Query().Get("hash"); hash != "" {
+				if hash != etag {
+					u := constructURL(group, etag)
+					http.Redirect(w, r, u, 301)
+					return
+				}
+				// The Vary header is required because the Accept header can
+				// change the contents returned. This prevents clients from caching
+				// protobuf as JSON and vice versa.
+				w.Header().Set("Vary", "Accept")
+
+				// Only set these headers when a hash is given.
+				w.Header().Set("Cache-Control", "public, immutable")
+				// Set the Expires directive to the maximum value of one year from the request,
+				// effectively indicating that the cache never expires.
+				w.Header().Set("Expires", time.Now().AddDate(1, 0, 0).Format(time.RFC1123))
+			}
 			http.ServeContent(w, r, "", lastModified, bytes.NewReader(data))
 			return
 		}
@@ -207,16 +262,28 @@ func (o *OpenAPIService) RegisterOpenAPIV3VersionedService(servePath string, han
 	return nil
 }
 
-func (o *OpenAPIV3Group) UpdateSpec(specBytes []byte) (err error) {
+func (o *OpenAPIV3Group) UpdateSpec(openapi *spec3.OpenAPI) (err error) {
 	o.rwMutex.Lock()
 	defer o.rwMutex.Unlock()
 
-	o.pbCache = o.pbCache.New(func() ([]byte, error) {
-		return ToV3ProtoBinary(specBytes)
-	})
-
 	o.jsonCache = o.jsonCache.New(func() ([]byte, error) {
-		return specBytes, nil
+		return json.Marshal(openapi)
+	})
+	o.pbCache = o.pbCache.New(func() ([]byte, error) {
+		json, err := o.jsonCache.Get()
+		if err != nil {
+			return nil, err
+		}
+		return ToV3ProtoBinary(json)
+	})
+	// TODO: This forces a json marshal of corresponding group-versions.
+	// We should look to replace this with a faster hashing mechanism.
+	o.etagCache = o.etagCache.New(func() ([]byte, error) {
+		json, err := o.jsonCache.Get()
+		if err != nil {
+			return nil, err
+		}
+		return []byte(computeETag(json)), nil
 	})
 	o.lastModified = time.Now()
 	return nil

--- a/pkg/handler3/handler_test.go
+++ b/pkg/handler3/handler_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+   Copyright 2021 The Kubernetes Authors.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 package handler3
@@ -23,12 +23,12 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"encoding/json"
+
 	"k8s.io/kube-openapi/pkg/spec3"
 )
-
-var returnedGroupVersionListJSON = []byte(`{"Paths":["apis/apps/v1"]}`)
 
 var returnedOpenAPI = []byte(`{
   "openapi": "3.0",
@@ -45,6 +45,9 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 		t.Errorf("%v", err)
 	}
 	compactOpenAPI := buffer.Bytes()
+	var hash = computeETag(compactOpenAPI)
+
+	var returnedGroupVersionListJSON = []byte(`{"Paths":{"apis/apps/v1":{"URL":"/openapi/v3/apis/apps/v1?hash=` + hash + `"}}}`)
 
 	json.Unmarshal(compactOpenAPI, &s)
 
@@ -54,7 +57,6 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 	}
 
 	returnedPb, err := ToV3ProtoBinary(compactOpenAPI)
-	_ = returnedPb
 
 	if err != nil {
 		t.Fatalf("Unexpected error in preparing returnedPb: %v", err)
@@ -110,6 +112,155 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 		if resp.StatusCode != tc.respStatus {
 			t.Errorf("Accept: %v: Unexpected response status code, want: %v, got: %v", tc.acceptHeader, tc.respStatus, resp.StatusCode)
 		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Accept: %v: Unexpected error in reading response body: %v", tc.acceptHeader, err)
+		}
+		if !reflect.DeepEqual(body, tc.respBody) {
+			t.Errorf("Accept: %v: Response body mismatches, \nwant: %s, \ngot:  %s", tc.acceptHeader, string(tc.respBody), string(body))
+		}
+	}
+}
+
+func TestCacheBusting(t *testing.T) {
+	var s *spec3.OpenAPI
+	buffer := new(bytes.Buffer)
+	if err := json.Compact(buffer, returnedOpenAPI); err != nil {
+		t.Errorf("%v", err)
+	}
+	compactOpenAPI := buffer.Bytes()
+	var hash = computeETag(compactOpenAPI)
+
+	json.Unmarshal(compactOpenAPI, &s)
+
+	returnedJSON, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Unexpected error in preparing returnedJSON: %v", err)
+	}
+
+	returnedPb, err := ToV3ProtoBinary(compactOpenAPI)
+
+	if err != nil {
+		t.Fatalf("Unexpected error in preparing returnedPb: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	o, err := NewOpenAPIService(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux.Handle("/openapi/v3", http.HandlerFunc(o.HandleDiscovery))
+	mux.Handle("/openapi/v3/apis/apps/v1", http.HandlerFunc(o.HandleGroupVersion))
+
+	o.UpdateGroupVersion("apis/apps/v1", s)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	client := server.Client()
+
+	tcs := []struct {
+		acceptHeader string
+		respStatus   int
+		urlPath      string
+		respBody     []byte
+		expectedHash string
+		cacheControl string
+	}{
+		// Correct hash should yield the proper expiry and Cache Control headers
+		{"application/json",
+			200,
+			"openapi/v3/apis/apps/v1?hash=" + hash,
+			returnedJSON,
+			hash,
+			"public, immutable",
+		},
+		{"application/com.github.proto-openapi.spec.v3@v1.0+protobuf",
+			200,
+			"openapi/v3/apis/apps/v1?hash=" + hash,
+			returnedPb,
+			hash,
+			"public, immutable",
+		},
+		// Incorrect hash should redirect to the page with the correct hash
+		{"application/json",
+			200,
+			"openapi/v3/apis/apps/v1?hash=OUTDATEDHASH",
+			returnedJSON,
+			hash,
+			"public, immutable",
+		},
+		{"application/com.github.proto-openapi.spec.v3@v1.0+protobuf",
+			200,
+			"openapi/v3/apis/apps/v1?hash=OUTDATEDHASH",
+			returnedPb,
+			hash,
+			"public, immutable",
+		},
+		// No hash should not return Cache Control information
+		{"application/json",
+			200,
+			"openapi/v3/apis/apps/v1",
+			returnedJSON,
+			"",
+			"",
+		},
+		{"application/com.github.proto-openapi.spec.v3@v1.0+protobuf",
+			200,
+			"openapi/v3/apis/apps/v1",
+			returnedPb,
+			"",
+			"",
+		},
+	}
+
+	for _, tc := range tcs {
+		req, err := http.NewRequest("GET", server.URL+"/"+tc.urlPath, nil)
+		if err != nil {
+			t.Errorf("Accept: %v: Unexpected error in creating new request: %v", tc.acceptHeader, err)
+		}
+
+		req.Header.Add("Accept", tc.acceptHeader)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Errorf("Accept: %v: Unexpected error in serving HTTP request: %v", tc.acceptHeader, err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Errorf("Accept: Unexpected response status code, want: %v, got: %v", 200, resp.StatusCode)
+		}
+
+		if cacheControl := resp.Header.Get("Cache-Control"); cacheControl != tc.cacheControl {
+			t.Errorf("Expected Cache Control %v, got %v", tc.cacheControl, cacheControl)
+		}
+
+		if tc.expectedHash != "" {
+			if hash := resp.Request.URL.Query().Get("hash"); hash != tc.expectedHash {
+				t.Errorf("Expected Hash: %s, got %s", tc.expectedHash, hash)
+			}
+
+			expires := resp.Header.Get("Expires")
+			parsedTime, err := time.Parse(time.RFC1123, expires)
+			if err != nil {
+				t.Errorf("Could not parse cache expiry %v", expires)
+			}
+
+			difference := parsedTime.Sub(time.Now()).Hours()
+			if difference <= 0 {
+				t.Errorf("Expected cache expiry to be in the future")
+			}
+		} else {
+			hash := resp.Request.URL.Query()["hash"]
+			if len(hash) != 0 {
+				t.Errorf("Expect no redirect and empty hash if the hash is not provide")
+			}
+			expires := resp.Header.Get("Expires")
+			if expires != "" {
+				t.Errorf("Expected an empty Expiry if hash is not provided,  got %v", expires)
+			}
+		}
+
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/internal/handler/handler_cache.go
+++ b/pkg/internal/handler/handler_cache.go
@@ -17,31 +17,22 @@ limitations under the License.
 package handler
 
 import (
-	"crypto/sha512"
-	"fmt"
 	"sync"
 )
 
-func computeETag(data []byte) string {
-	if data == nil {
-		return ""
-	}
-	return fmt.Sprintf("\"%X\"", sha512.Sum512(data))
-}
-
-// HandlerCache represents an OpenAPI v2/v3 marshaling cache.
+// HandlerCache represents a lazy cache for generating a byte array
+// It is used to lazily marshal OpenAPI v2/v3 and lazily generate the ETag
 type HandlerCache struct {
 	BuildCache func() ([]byte, error)
 	once       sync.Once
 	bytes      []byte
-	etag       string
 	err        error
 }
 
 // Get either returns the cached value or calls BuildCache() once before caching and returning
 // its results. If BuildCache returns an error, the last valid value for the cache (from prior
 // calls to New()) is used instead if possible.
-func (c *HandlerCache) Get() ([]byte, string, error) {
+func (c *HandlerCache) Get() ([]byte, error) {
 	c.once.Do(func() {
 		bytes, err := c.BuildCache()
 		// if there is an error updating the cache, there can be situations where
@@ -51,10 +42,9 @@ func (c *HandlerCache) Get() ([]byte, string, error) {
 		if c.err == nil {
 			// don't override previous spec if we had an error
 			c.bytes = bytes
-			c.etag = computeETag(c.bytes)
 		}
 	})
-	return c.bytes, c.etag, c.err
+	return c.bytes, c.err
 }
 
 // New creates a new HandlerCache for situations where a cache refresh is needed.
@@ -62,7 +52,6 @@ func (c *HandlerCache) Get() ([]byte, string, error) {
 func (c *HandlerCache) New(cacheBuilder func() ([]byte, error)) HandlerCache {
 	return HandlerCache{
 		bytes:      c.bytes,
-		etag:       c.etag,
 		BuildCache: cacheBuilder,
 	}
 }

--- a/pkg/internal/handler/handler_cache_test.go
+++ b/pkg/internal/handler/handler_cache_test.go
@@ -32,7 +32,7 @@ func TestCache(t *testing.T) {
 			return expectedBytes, nil
 		},
 	}
-	bytes, _, _ := cacheObj.Get()
+	bytes, _ := cacheObj.Get()
 	if string(bytes) != string(expectedBytes) {
 		t.Fatalf("got value of %q from cache (expected %q)", bytes, expectedBytes)
 	}
@@ -48,7 +48,7 @@ func TestCacheError(t *testing.T) {
 			return nil, errors.New("cache error")
 		},
 	}
-	_, _, err := cacheObj.Get()
+	_, err := cacheObj.Get()
 	if err == nil {
 		t.Fatalf("expected non-nil err from cache.Get()")
 	}
@@ -61,7 +61,7 @@ func TestCacheRefresh(t *testing.T) {
 	})
 	// make multiple calls to Get() to ensure errors are preserved across subsequent calls
 	for i := 0; i < 4; i++ {
-		value, _, err := cacheObj.Get()
+		value, err := cacheObj.Get()
 		if value != nil {
 			t.Fatalf("expected nil bytes (got %s)", value)
 		}
@@ -75,21 +75,17 @@ func TestCacheRefresh(t *testing.T) {
 		return lastGoodVal, nil
 	})
 	// call Get() once, so lastGoodVal is cached
-	_, lastGoodEtag, _ := cacheObj.Get()
+	cacheObj.Get()
 	for i := 0; i < 4; i++ {
 		cacheObj = cacheObj.New(func() ([]byte, error) {
 			return nil, errors.New("check that c.bytes is preserved across New() calls")
 		})
-		value, newEtag, err := cacheObj.Get()
+		value, err := cacheObj.Get()
 		if err == nil {
 			t.Fatalf("expected non-nil err from cache.Get()")
 		}
 		if string(value) != string(lastGoodVal) {
 			t.Fatalf("expected previous value for cache to be returned (got %s, expected %s)", value, lastGoodVal)
-		}
-		// check that etags carry over between calls to cache.New()
-		if lastGoodEtag != newEtag {
-			t.Fatalf("expected etags to match (got %s, expected %s", newEtag, lastGoodEtag)
 		}
 	}
 	// check that if we successfully renew the cache the old last known value is flushed
@@ -97,7 +93,7 @@ func TestCacheRefresh(t *testing.T) {
 	cacheObj = cacheObj.New(func() ([]byte, error) {
 		return newVal, nil
 	})
-	value, _, err := cacheObj.Get()
+	value, err := cacheObj.Get()
 	if err != nil {
 		t.Fatalf("expected nil err from cache.Get()")
 	}


### PR DESCRIPTION
Support Cache Busting in kube-openapi.

Also fix a bug where lazy marshaling wasn't performed on OpenAPI V3.