### PR TITLE
Trim leading newlines in Descriptions

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -603,7 +603,8 @@ func (g openAPITypeWriter) generateDescription(CommentLines []string) {
 		}
 	}
 
-	postDoc := strings.TrimRight(buffer.String(), "\n")
+	postDoc := strings.TrimLeft(buffer.String(), "\n")
+	postDoc = strings.TrimRight(postDoc, "\n")
 	postDoc = strings.Replace(postDoc, "\\\"", "\"", -1) // replace user's \" to "
 	postDoc = strings.Replace(postDoc, "\"", "\\\"", -1) // Escape "
 	postDoc = strings.Replace(postDoc, "\n", "\\n", -1)

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -568,7 +568,7 @@ import "time"
 // Nested is used as embedded struct field
 type Nested struct {
   // A simple string
-  time.Duration 
+  time.Duration
 }
 
 // Blah demonstrate a struct with embedded struct field.
@@ -1590,6 +1590,7 @@ const EnumB EnumType = "b"
 type Blah struct {
   // Value is the value.
 	Value EnumType
+	NoCommentEnum EnumType
 }`)
 	if callErr != nil {
 		t.Fatal(callErr)
@@ -1613,8 +1614,16 @@ Type: []string{"string"},
 Format: "",
 Enum: []interface{}{"a", "b"}},
 },
+"NoCommentEnum": {
+SchemaProps: spec.SchemaProps{`+"\n"+
+		"Description: \"Possible enum values:\\n - `\\\"a\\\"` is a.\\n - `\\\"b\\\"` is b.\","+`
+Default: "",
+Type: []string{"string"},
+Format: "",
+Enum: []interface{}{"a", "b"}},
 },
-Required: []string{"Value"},
+},
+Required: []string{"Value","NoCommentEnum"},
 },
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{


### PR DESCRIPTION
Trim leading newlines in Descriptions. Improves the formatting when Enum types have no comments attached and any case where there are extra newlines at the beginning of descriptions.

Changes `"\n\nDescription: \"Possible enum values:...` to `"Description: \"Possible enum values:...`

/cc @apelisse 
/cc @jiahuif 