### PR TITLE
Return valid field in Validation struct

### DIFF
--- a/pkg/validation/errors/headers.go
+++ b/pkg/validation/errors/headers.go
@@ -20,6 +20,7 @@ type Validation struct {
 	Name    string
 	In      string
 	Value   interface{}
+	Valid   interface{}
 	message string
 	Values  []interface{}
 }

--- a/pkg/validation/errors/schema.go
+++ b/pkg/validation/errors/schema.go
@@ -156,31 +156,33 @@ func PropertyNotAllowed(name, in, key string) *Validation {
 }
 
 // TooFewProperties an error for an object with too few properties
-func TooFewProperties(name, in string, n int64) *Validation {
-	msg := fmt.Sprintf(tooFewProperties, name, in, n)
+func TooFewProperties(name, in string, minProperties int64) *Validation {
+	msg := fmt.Sprintf(tooFewProperties, name, in, minProperties)
 	if in == "" {
-		msg = fmt.Sprintf(tooFewPropertiesNoIn, name, n)
+		msg = fmt.Sprintf(tooFewPropertiesNoIn, name, minProperties)
 	}
 	return &Validation{
 		code:    TooFewPropertiesCode,
 		Name:    name,
 		In:      in,
-		Value:   n,
+		Value:   minProperties,
+		Valid:   minProperties,
 		message: msg,
 	}
 }
 
 // TooManyProperties an error for an object with too many properties
-func TooManyProperties(name, in string, n int64) *Validation {
-	msg := fmt.Sprintf(tooManyProperties, name, in, n)
+func TooManyProperties(name, in string, maxProperties int64) *Validation {
+	msg := fmt.Sprintf(tooManyProperties, name, in, maxProperties)
 	if in == "" {
-		msg = fmt.Sprintf(tooManyPropertiesNoIn, name, n)
+		msg = fmt.Sprintf(tooManyPropertiesNoIn, name, maxProperties)
 	}
 	return &Validation{
 		code:    TooManyPropertiesCode,
 		Name:    name,
 		In:      in,
-		Value:   n,
+		Value:   maxProperties,
+		Valid:   maxProperties,
 		message: msg,
 	}
 }
@@ -279,6 +281,7 @@ func TooManyItems(name, in string, max int64, value interface{}) *Validation {
 		Name:    name,
 		In:      in,
 		Value:   value,
+		Valid:   max,
 		message: msg,
 	}
 }
@@ -294,6 +297,7 @@ func TooFewItems(name, in string, min int64, value interface{}) *Validation {
 		Name:    name,
 		In:      in,
 		Value:   value,
+		Valid:   min,
 		message: msg,
 	}
 }
@@ -513,6 +517,7 @@ func TooLong(name, in string, max int64, value interface{}) *Validation {
 		Name:    name,
 		In:      in,
 		Value:   value,
+		Valid:   max,
 		message: msg,
 	}
 }
@@ -531,6 +536,7 @@ func TooShort(name, in string, min int64, value interface{}) *Validation {
 		Name:    name,
 		In:      in,
 		Value:   value,
+		Valid:   min,
 		message: msg,
 	}
 }

--- a/pkg/validation/errors/schema.go
+++ b/pkg/validation/errors/schema.go
@@ -156,7 +156,7 @@ func PropertyNotAllowed(name, in, key string) *Validation {
 }
 
 // TooFewProperties an error for an object with too few properties
-func TooFewProperties(name, in string, minProperties int64) *Validation {
+func TooFewProperties(name, in string, minProperties, size int64) *Validation {
 	msg := fmt.Sprintf(tooFewProperties, name, in, minProperties)
 	if in == "" {
 		msg = fmt.Sprintf(tooFewPropertiesNoIn, name, minProperties)
@@ -165,14 +165,14 @@ func TooFewProperties(name, in string, minProperties int64) *Validation {
 		code:    TooFewPropertiesCode,
 		Name:    name,
 		In:      in,
-		Value:   minProperties,
+		Value:   size,
 		Valid:   minProperties,
 		message: msg,
 	}
 }
 
 // TooManyProperties an error for an object with too many properties
-func TooManyProperties(name, in string, maxProperties int64) *Validation {
+func TooManyProperties(name, in string, maxProperties, size int64) *Validation {
 	msg := fmt.Sprintf(tooManyProperties, name, in, maxProperties)
 	if in == "" {
 		msg = fmt.Sprintf(tooManyPropertiesNoIn, name, maxProperties)
@@ -181,7 +181,7 @@ func TooManyProperties(name, in string, maxProperties int64) *Validation {
 		code:    TooManyPropertiesCode,
 		Name:    name,
 		In:      in,
-		Value:   maxProperties,
+		Value:   size,
 		Valid:   maxProperties,
 		message: msg,
 	}

--- a/pkg/validation/errors/schema_test.go
+++ b/pkg/validation/errors/schema_test.go
@@ -363,27 +363,27 @@ func TestSchemaErrors(t *testing.T) {
 	//unallowedPropertyNoIn     = "%s.%s is a forbidden property"
 	assert.Equal(t, "path.key is a forbidden property", err.Error())
 
-	//func TooManyProperties(name, in string, n int64) *Validation {
-	err = TooManyProperties("path", "body", 10)
+	//func TooManyProperties(name, in string, n， size int64) *Validation {
+	err = TooManyProperties("path", "body", 10, 20)
 	assert.Error(t, err)
 	assert.EqualValues(t, TooManyPropertiesCode, err.Code())
 	//tooManyProperties         = "%s in %s should have at most %d properties"
 	assert.Equal(t, "path in body should have at most 10 properties", err.Error())
 
-	err = TooManyProperties("path", "", 10)
+	err = TooManyProperties("path", "", 10, 20)
 	assert.Error(t, err)
 	assert.EqualValues(t, TooManyPropertiesCode, err.Code())
 	//tooManyPropertiesNoIn     = "%s should have at most %d properties"
 	assert.Equal(t, "path should have at most 10 properties", err.Error())
 
-	err = TooFewProperties("path", "body", 10)
+	err = TooFewProperties("path", "body", 10, 1)
 	// func TooFewProperties(name, in string, n int64) *Validation {
 	assert.Error(t, err)
 	assert.EqualValues(t, TooFewPropertiesCode, err.Code())
 	//tooFewProperties          = "%s in %s should have at least %d properties"
 	assert.Equal(t, "path in body should have at least 10 properties", err.Error())
 
-	err = TooFewProperties("path", "", 10)
+	err = TooFewProperties("path", "", 10, 1)
 	// func TooFewProperties(name, in string, n int64) *Validation {
 	assert.Error(t, err)
 	assert.EqualValues(t, TooFewPropertiesCode, err.Code())

--- a/pkg/validation/validate/object_validator.go
+++ b/pkg/validation/validate/object_validator.go
@@ -56,10 +56,10 @@ func (o *objectValidator) Validate(data interface{}) *Result {
 	numKeys := int64(len(val))
 
 	if o.MinProperties != nil && numKeys < *o.MinProperties {
-		return errorHelp.sErr(errors.TooFewProperties(o.Path, o.In, *o.MinProperties))
+		return errorHelp.sErr(errors.TooFewProperties(o.Path, o.In, *o.MinProperties, numKeys))
 	}
 	if o.MaxProperties != nil && numKeys > *o.MaxProperties {
-		return errorHelp.sErr(errors.TooManyProperties(o.Path, o.In, *o.MaxProperties))
+		return errorHelp.sErr(errors.TooManyProperties(o.Path, o.In, *o.MaxProperties, numKeys))
 	}
 
 	res := new(Result)


### PR DESCRIPTION
Due to inconsistent in returned err value field, add `valid` for Kubernetes to better handle err.
TooFewProperties/TooManyProperties didn't align well with other err but it might make sense since we don't want return large object back especially when it is rarely used.

Close #296 