### PR TITLE
Wrap Refs with AllOf

### DIFF
--- a/pkg/builder3/openapi_test.go
+++ b/pkg/builder3/openapi_test.go
@@ -89,6 +89,28 @@ func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 				},
 			},
 		},
+		"reference-extension": {
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: map[string]interface{}{"extension": "value"},
+			},
+			SchemaProps: spec.SchemaProps{
+				Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+			},
+		},
+		"reference-nullable": {
+			SchemaProps: spec.SchemaProps{
+				Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+				Nullable: true,
+			},
+		},
+		"reference-default": {
+			SchemaProps: spec.SchemaProps{
+				Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+				Default: map[string]interface{}{},
+			},
+		},
+
+
 	}
 	schema.Extensions = spec.Extensions{"x-test": "test"}
 	def := openapi.EmbedOpenAPIDefinitionIntoV2Extension(openapi.OpenAPIDefinition{
@@ -336,6 +358,38 @@ func getTestInputDefinition() *spec.Schema {
 								},
 							},
 						},
+					},
+				},
+				"reference-extension": {
+					VendorExtensible: spec.VendorExtensible{
+						Extensions: map[string]interface{}{"extension": "value"},
+					},
+					SchemaProps: spec.SchemaProps{
+						AllOf: []spec.Schema{{
+							SchemaProps: spec.SchemaProps{
+								Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+							},
+						}},
+					},
+				},
+				"reference-nullable": {
+					SchemaProps: spec.SchemaProps{
+						Nullable: true,
+						AllOf: []spec.Schema{{
+							SchemaProps: spec.SchemaProps{
+								Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+							},
+						}},
+					},
+				},
+				"reference-default": {
+					SchemaProps: spec.SchemaProps{
+						AllOf: []spec.Schema{{
+							SchemaProps: spec.SchemaProps{
+								Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+							},
+						}},
+						Default: map[string]interface{}{},
 					},
 				},
 			},

--- a/test/integration/testdata/golden.v3.json
+++ b/test/integration/testdata/golden.v3.json
@@ -514,14 +514,22 @@
       },
       "OtherSub": {
        "default": {},
-       "$ref": "#/components/schemas/defaults.SubStruct"
+       "allOf": [
+        {
+         "$ref": "#/components/schemas/defaults.SubStruct"
+        }
+       ]
       },
       "Sub": {
        "default": {
         "i": 5,
         "s": "foo"
        },
-       "$ref": "#/components/schemas/defaults.SubStruct"
+       "allOf": [
+        {
+         "$ref": "#/components/schemas/defaults.SubStruct"
+        }
+       ]
       }
      }
     },
@@ -688,7 +696,11 @@
        "type": "array",
        "items": {
         "default": {},
-        "$ref": "#/components/schemas/listtype.Item"
+        "allOf": [
+         {
+          "$ref": "#/components/schemas/listtype.Item"
+         }
+        ]
        },
        "x-kubernetes-list-map-keys": [
         "port"
@@ -754,8 +766,12 @@
      "properties": {
       "Field": {
        "default": {},
-       "x-kubernetes-map-type": "atomic",
-       "$ref": "#/components/schemas/structtype.ContainedStruct"
+       "allOf": [
+        {
+         "$ref": "#/components/schemas/structtype.ContainedStruct"
+        }
+       ],
+       "x-kubernetes-map-type": "atomic"
       },
       "OtherField": {
        "type": "integer",
@@ -790,8 +806,12 @@
      "properties": {
       "Field": {
        "default": {},
-       "x-kubernetes-map-type": "granular",
-       "$ref": "#/components/schemas/structtype.ContainedStruct"
+       "allOf": [
+        {
+         "$ref": "#/components/schemas/structtype.ContainedStruct"
+        }
+       ],
+       "x-kubernetes-map-type": "granular"
       },
       "OtherField": {
        "type": "integer",


### PR DESCRIPTION
Refs should not have sibling elements other than description: https://github.com/kubernetes/kubernetes/issues/106387. Wrap Refs in AllOf to preserve gnostic round trip.