### PR TITLE
Optimize GetOpenAPIDefinitions to avoid generating the map for all definitions on every BuildOpenAPISpec invocation

### DIFF
--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -24,10 +24,10 @@ import (
 
 	restful "github.com/emicklei/go-restful"
 
+	builderutil "k8s.io/kube-openapi/pkg/builder3/util"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/common/restfuladapter"
 	"k8s.io/kube-openapi/pkg/spec3"
-	builderutil "k8s.io/kube-openapi/pkg/builder3/util"
 	"k8s.io/kube-openapi/pkg/util"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -226,10 +226,14 @@ func newOpenAPI(config *common.Config) openAPI {
 		}
 	}
 
-	o.definitions = o.config.GetDefinitions(func(name string) spec.Ref {
-		defName, _ := o.config.GetDefinitionName(name)
-		return spec.MustCreateRef("#/components/schemas/" + common.EscapeJsonPointer(defName))
-	})
+	if o.config.Definitions != nil {
+		o.definitions = o.config.Definitions
+	} else {
+		o.definitions = o.config.GetDefinitions(func(name string) spec.Ref {
+			defName, _ := o.config.GetDefinitionName(name)
+			return spec.MustCreateRef("#/components/schemas/" + common.EscapeJsonPointer(defName))
+		})
+	}
 
 	return o
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -94,6 +94,10 @@ type Config struct {
 	// or any of the models will result in spec generation failure.
 	GetDefinitions GetOpenAPIDefinitions
 
+	// Provides the definition for all models used by routes. One of GetDefinitions or Definitions must be defined to generate a spec.
+	// This takes precedent over the GetDefinitions function
+	Definitions map[string]OpenAPIDefinition
+
 	// GetOperationIDAndTags returns operation id and tags for a restful route. It is an optional function to customize operation IDs.
 	//
 	// Deprecated: GetOperationIDAndTagsFromRoute should be used instead. This cannot be specified if using the new Route
@@ -141,7 +145,12 @@ type OpenAPIV3Config struct {
 
 	// OpenAPIDefinitions should provide definition for all models used by routes. Failure to provide this map
 	// or any of the models will result in spec generation failure.
+	// One of GetDefinitions or Definitions must be defined to generate a spec.
 	GetDefinitions GetOpenAPIDefinitions
+
+	// Provides the definition for all models used by routes. One of GetDefinitions or Definitions must be defined to generate a spec.
+	// This takes precedent over the GetDefinitions function
+	Definitions map[string]OpenAPIDefinition
 
 	// GetOperationIDAndTags returns operation id and tags for a restful route. It is an optional function to customize operation IDs.
 	//
@@ -176,12 +185,13 @@ func ConvertConfigToV3(config *Config) *OpenAPIV3Config {
 		GetOperationIDAndTags:          config.GetOperationIDAndTags,
 		GetOperationIDAndTagsFromRoute: config.GetOperationIDAndTagsFromRoute,
 		GetDefinitionName:              config.GetDefinitionName,
+		Definitions:                    config.Definitions,
 		SecuritySchemes:                make(spec3.SecuritySchemes),
 		DefaultSecurity:                config.DefaultSecurity,
 		DefaultResponse:                openapiconv.ConvertResponse(config.DefaultResponse, []string{"application/json"}),
 
-		CommonResponses:                make(map[int]*spec3.Response),
-		ResponseDefinitions:            make(map[string]*spec3.Response),
+		CommonResponses:     make(map[int]*spec3.Response),
+		ResponseDefinitions: make(map[string]*spec3.Response),
 	}
 
 	if config.SecurityDefinitions != nil {


### PR DESCRIPTION
Optimize GetOpenAPIDefinitions to avoid generating the map for all definitions on every BuildOpenAPISpec invocation.

Use a pre-existing generated Definitions object if possible to avoid going through the generator process to generate the map of all Definitions.

Significantly reduces memory allocation footprint.

Please only look at latest commit. Branches off of https://github.com/kubernetes/kube-openapi/pull/292

This PR only optimizes for V3, but we can apply the optimization later for V2 as well. 

/assign @apelisse 