### PR TITLE
fix json unmarshal bug when extension used with Responses

### DIFF
--- a/pkg/validation/spec/responses.go
+++ b/pkg/validation/spec/responses.go
@@ -96,7 +96,9 @@ func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
 	}
 	if v, ok := res["default"]; ok {
 		value := Response{}
-		json.Unmarshal(v, &value)
+		if err := json.Unmarshal(v, &value); err != nil {
+			return err
+		}
 		r.Default = &value
 		delete(res, "default")
 	}

--- a/pkg/validation/spec/responses.go
+++ b/pkg/validation/spec/responses.go
@@ -92,7 +92,7 @@ func (r ResponsesProps) MarshalJSON() ([]byte, error) {
 func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
 	var res map[string]json.RawMessage
 	if err := json.Unmarshal(data, &res); err != nil {
-		return nil
+		return err
 	}
 	if v, ok := res["default"]; ok {
 		value := Response{}

--- a/pkg/validation/spec/responses.go
+++ b/pkg/validation/spec/responses.go
@@ -109,8 +109,7 @@ func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
 				r.StatusCodeResponses = map[int]Response{}
 			}
 			value := Response{}
-			err := json.Unmarshal(v, &value)
-			if err != nil {
+			if err := json.Unmarshal(v, &value); err != nil {
 				return err
 			}
 			r.StatusCodeResponses[nk] = value

--- a/pkg/validation/spec/responses.go
+++ b/pkg/validation/spec/responses.go
@@ -90,20 +90,28 @@ func (r ResponsesProps) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals responses from JSON
 func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
-	var res map[string]Response
+	var res map[string]json.RawMessage
 	if err := json.Unmarshal(data, &res); err != nil {
 		return nil
 	}
 	if v, ok := res["default"]; ok {
-		r.Default = &v
+		value := Response{}
+		json.Unmarshal(v, &value)
+		r.Default = &value
 		delete(res, "default")
 	}
 	for k, v := range res {
+		// Take all integral keys
 		if nk, err := strconv.Atoi(k); err == nil {
 			if r.StatusCodeResponses == nil {
 				r.StatusCodeResponses = map[int]Response{}
 			}
-			r.StatusCodeResponses[nk] = v
+			value := Response{}
+			err := json.Unmarshal(v, &value)
+			if err != nil {
+				return err
+			}
+			r.StatusCodeResponses[nk] = value
 		}
 	}
 	return nil

--- a/pkg/validation/spec/responses_test.go
+++ b/pkg/validation/spec/responses_test.go
@@ -148,6 +148,7 @@ func TestResponsesRoundtrip(t *testing.T) {
 
 			var decoded Responses
 			err = json.Unmarshal(jsonText, &decoded)
+			require.NoError(t, err)
 
 			if !reflect.DeepEqual(&test.Responses, &decoded) {
 				t.Fatal(cmp.Diff(&test.Responses, &decoded, cmpopts.IgnoreUnexported(jsonreference.Ref{})))

--- a/pkg/validation/spec/responses_test.go
+++ b/pkg/validation/spec/responses_test.go
@@ -1,0 +1,58 @@
+/*
+ Copyright 2022 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package spec
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+var specimen *Responses = &Responses{
+	VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{
+		"x-<vBŤç,ʡËdSS暙ɑɮ": string("鄲(兴ȑʦ衈覻鋕嚮峡jw逓:鮕虫F迢."),
+		"x-h":              string(""), "x-岡ʍ": string("Đɻ/nǌo鿻曑Œ TĀyĢ"),
+		"x-绅ƄȆ疩ã[魑銒;苎#砠zPȺ5Aù": string("閲ǉǠyư")},
+	},
+	ResponsesProps: ResponsesProps{
+		Default: &Response{
+			Refable:       Refable{Ref: MustCreateRef("Dog")},
+			ResponseProps: ResponseProps{Description: "梱bȿF)渽Ɲō-%x"},
+		},
+		StatusCodeResponses: map[int]Response{
+			200: {
+				Refable:       Refable{Ref: MustCreateRef("Cat")},
+				ResponseProps: ResponseProps{Description: "梱bȿF)渽Ɲō-%x"},
+			},
+		},
+	},
+}
+
+func TestResponsesRoundtrip(t *testing.T) {
+	jsonText, err := json.Marshal(specimen)
+	require.NoError(t, err)
+
+	var decoded Responses
+	err = json.Unmarshal(jsonText, &decoded)
+
+	if !reflect.DeepEqual(specimen, &decoded) {
+		t.Fatal(cmp.Diff(specimen, &decoded))
+	}
+}

--- a/pkg/validation/spec/responses_test.go
+++ b/pkg/validation/spec/responses_test.go
@@ -21,38 +21,159 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-openapi/jsonreference"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
-var specimen *Responses = &Responses{
-	VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{
-		"x-<vBŤç,ʡËdSS暙ɑɮ": string("鄲(兴ȑʦ衈覻鋕嚮峡jw逓:鮕虫F迢."),
-		"x-h":              string(""), "x-岡ʍ": string("Đɻ/nǌo鿻曑Œ TĀyĢ"),
-		"x-绅ƄȆ疩ã[魑銒;苎#砠zPȺ5Aù": string("閲ǉǠyư")},
-	},
-	ResponsesProps: ResponsesProps{
-		Default: &Response{
-			Refable:       Refable{Ref: MustCreateRef("Dog")},
-			ResponseProps: ResponseProps{Description: "梱bȿF)渽Ɲō-%x"},
-		},
-		StatusCodeResponses: map[int]Response{
-			200: {
-				Refable:       Refable{Ref: MustCreateRef("Cat")},
-				ResponseProps: ResponseProps{Description: "梱bȿF)渽Ɲō-%x"},
+func TestResponsesRoundtrip(t *testing.T) {
+	type testCase struct {
+		Name string
+		Responses
+	}
+
+	var cases []testCase = []testCase{
+		{
+			"Decode Ref Object",
+			Responses{
+				VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{
+					"x-<vBŤç,ʡËdSS暙ɑɮ":     "鄲兴ȑʦ衈覻鋕嚮峡jw逓:鮕虫F迢.",
+					"x-h":                  "",
+					"x-岡ʍ":                 "Đɻ/nǌo鿻曑Œ TĀyĢ",
+					"x-绅ƄȆ疩ã[魑銒;苎#砠zPȺ5Aù": "閲ǉǠyư"},
+				},
+				ResponsesProps: ResponsesProps{
+					Default: &Response{
+						ResponseProps: ResponseProps{Description: "梱bȿF)渽Ɲō-%x"},
+					},
+					StatusCodeResponses: map[int]Response{
+						200: {
+							Refable: Refable{Ref: MustCreateRef("Cat")},
+						},
+					},
+				},
 			},
 		},
-	},
+		{
+			"Default Full Object",
+			Responses{
+				VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{
+					"x-<vBŤç,ʡËdSS暙ɑɮ":     "鄲兴ȑʦ衈覻鋕嚮峡jw逓:鮕虫F迢.",
+					"x-h":                  "",
+					"x-岡ʍ":                 "Đɻ/nǌo鿻曑Œ TĀyĢ",
+					"x-绅ƄȆ疩ã[魑銒;苎#砠zPȺ5Aù": "閲ǉǠyư"},
+				},
+				ResponsesProps: ResponsesProps{
+					Default: &Response{
+						Refable: Refable{Ref: MustCreateRef("Dog")},
+					},
+					StatusCodeResponses: map[int]Response{
+						200: {
+							ResponseProps: ResponseProps{
+								Description: "梱bȿF)渽Ɲō-%x",
+								Headers: map[string]Header{
+									"a header": header,
+								},
+								Schema: &Schema{
+									VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{"x-framework": "go-swagger"}},
+									SchemaProps: SchemaProps{
+										Ref:              MustCreateRef("Cat"),
+										Type:             []string{"string"},
+										Format:           "date",
+										Description:      "the description of this schema",
+										Title:            "the title",
+										Default:          "blah",
+										Maximum:          float64Ptr(100),
+										ExclusiveMaximum: true,
+										ExclusiveMinimum: true,
+										Minimum:          float64Ptr(5),
+										MaxLength:        int64Ptr(100),
+										MinLength:        int64Ptr(5),
+										Pattern:          "\\w{1,5}\\w+",
+										MaxItems:         int64Ptr(100),
+										MinItems:         int64Ptr(5),
+										UniqueItems:      true,
+										MultipleOf:       float64Ptr(5),
+										Enum:             []interface{}{"hello", "world"},
+										MaxProperties:    int64Ptr(5),
+										MinProperties:    int64Ptr(1),
+										Required:         []string{"id", "name"},
+										Items:            &SchemaOrArray{Schema: &Schema{SchemaProps: SchemaProps{Type: []string{"string"}}}},
+										AllOf:            []Schema{{SchemaProps: SchemaProps{Type: []string{"string"}}}},
+										Properties: map[string]Schema{
+											"id":   {SchemaProps: SchemaProps{Type: []string{"integer"}, Format: "int64"}},
+											"name": {SchemaProps: SchemaProps{Type: []string{"string"}}},
+										},
+										AdditionalProperties: &SchemaOrBool{Allows: true, Schema: &Schema{SchemaProps: SchemaProps{
+											Type:   []string{"integer"},
+											Format: "int32",
+										}}},
+									},
+									SwaggerSchemaProps: SwaggerSchemaProps{
+										Discriminator: "not this",
+										ReadOnly:      true,
+										ExternalDocs: &ExternalDocumentation{
+											Description: "the documentation etc",
+											URL:         "http://readthedocs.org/swagger",
+										},
+										Example: []interface{}{
+											map[string]interface{}{
+												"id":   float64(1),
+												"name": "a book",
+											},
+											map[string]interface{}{
+												"id":   float64(2),
+												"name": "the thing",
+											},
+										},
+									},
+								},
+								Examples: map[string]interface{}{
+									"example1": "example text",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+
+			jsonText, err := json.Marshal(&test.Responses)
+			require.NoError(t, err)
+
+			var decoded Responses
+			err = json.Unmarshal(jsonText, &decoded)
+
+			if !reflect.DeepEqual(&test.Responses, &decoded) {
+				t.Fatal(cmp.Diff(&test.Responses, &decoded, cmpopts.IgnoreUnexported(jsonreference.Ref{})))
+			}
+		})
+	}
 }
 
-func TestResponsesRoundtrip(t *testing.T) {
-	jsonText, err := json.Marshal(specimen)
-	require.NoError(t, err)
+func TestResponsesDecodeErrors(t *testing.T) {
+	type testCase struct {
+		Name     string
+		JSONText string
+	}
 
-	var decoded Responses
-	err = json.Unmarshal(jsonText, &decoded)
+	var cases []testCase = []testCase{
+		{
+			"FailDecodeDefault",
+			`{"x-extension":"an extension","default":"wrong type object"}`,
+		},
+	}
 
-	if !reflect.DeepEqual(specimen, &decoded) {
-		t.Fatal(cmp.Diff(specimen, &decoded))
+	for _, v := range cases {
+		t.Run(v.Name, func(t *testing.T) {
+			deserialized := Responses{}
+			err := json.Unmarshal([]byte(v.JSONText), &deserialized)
+			require.Error(t, err, "expefcted an error")
+		})
 	}
 }


### PR DESCRIPTION
discovered while implementing https://github.com/kubernetes/kube-openapi/pull/319

spec allows vendor extensions, but if they are used the parsing would fail and leave both `Default` and `StatusCodeResponses` empty

code now decodes each response individually so vendor extensions can be filtered out