### PR TITLE
Consistently find enum values from separate packages in openapi-gen.

### DIFF
--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -90,9 +90,9 @@ func parseEnums(c *generator.Context) enumMap {
 	// First, find the builtin "string" type
 	stringType := c.Universe.Type(types.Name{Name: "string"})
 
+	// find all enum types.
 	enumTypes := make(enumMap)
 	for _, p := range c.Universe {
-		// find all enum types.
 		for _, t := range p.Types {
 			if isEnumType(stringType, t) {
 				if _, ok := enumTypes[t.Name]; !ok {
@@ -102,7 +102,10 @@ func parseEnums(c *generator.Context) enumMap {
 				}
 			}
 		}
-		// find all enum values from constants, and try to match each with its type.
+	}
+
+	// find all enum values from constants, and try to match each with its type.
+	for _, p := range c.Universe {
 		for _, c := range p.Constants {
 			enumType := c.Underlying
 			if _, ok := enumTypes[enumType.Name]; ok {

--- a/pkg/generators/enum_test.go
+++ b/pkg/generators/enum_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/gengo/generator"
+	"k8s.io/gengo/types"
+)
+
+func TestParseEnums(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		universe types.Universe
+		expected map[string][]string
+	}{
+		{
+			name: "value in different package",
+			universe: types.Universe{
+				"foo": &types.Package{
+					Name: "foo",
+					Types: map[string]*types.Type{
+						"Foo": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "Foo",
+							},
+							Kind:         types.Alias,
+							Underlying:   types.String,
+							CommentLines: []string{"+enum"},
+						},
+					},
+				},
+				"bar": &types.Package{
+					Name: "bar",
+					Constants: map[string]*types.Type{
+						"Bar": {
+							Name: types.Name{
+								Package: "bar",
+								Name:    "Bar",
+							},
+							Kind: types.Alias,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"bar"}[0],
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				"foo.Foo": {"bar"},
+			},
+		},
+		{
+			name: "value in same package",
+			universe: types.Universe{
+				"foo": &types.Package{
+					Name: "foo",
+					Types: map[string]*types.Type{
+						"Foo": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "Foo",
+							},
+							Kind:         types.Alias,
+							Underlying:   types.String,
+							CommentLines: []string{"+enum"},
+						},
+					},
+					Constants: map[string]*types.Type{
+						"Bar": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "Bar",
+							},
+							Kind: types.Alias,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"bar"}[0],
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				"foo.Foo": {"bar"},
+			},
+		},
+		{
+			name: "values in same and different packages",
+			universe: types.Universe{
+				"foo": &types.Package{
+					Name: "foo",
+					Types: map[string]*types.Type{
+						"Foo": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "Foo",
+							},
+							Kind:         types.Alias,
+							Underlying:   types.String,
+							CommentLines: []string{"+enum"},
+						},
+					},
+					Constants: map[string]*types.Type{
+						"FooSame": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "FooSame",
+							},
+							Kind: types.Alias,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"same"}[0],
+						},
+					},
+				},
+				"bar": &types.Package{
+					Name: "bar",
+					Constants: map[string]*types.Type{
+						"FooDifferent": {
+							Name: types.Name{
+								Package: "bar",
+								Name:    "FooDifferent",
+							},
+							Kind: types.Alias,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"different"}[0],
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				"foo.Foo": {"different", "same"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enums := parseEnums(&generator.Context{Universe: tc.universe})
+
+			actual := make(map[string][]string)
+			for _, enum := range enums {
+				values := make([]string, len(enum.Values))
+				for i := range values {
+					values[i] = enum.Values[i].Value
+				}
+				sort.Strings(values)
+				actual[enum.Name.String()] = values
+			}
+
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Errorf("expected: %#v, got %#v", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When an enum value resides in a package other than the one containing the enum type, the output of openapi-gen varies depending on the order packages are processed.

Doing two passes -- first to discover all enum types, then to find all enum values -- makes openapi-gen always include values from all packages.

Fixes #321.