### PR TITLE
Remove mime AddExtensionsType

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
-	"mime"
 	"net/http"
 	"strconv"
 	"sync"
@@ -39,15 +38,6 @@ import (
 	"k8s.io/kube-openapi/pkg/common/restfuladapter"
 	"k8s.io/kube-openapi/pkg/internal/handler"
 	"k8s.io/kube-openapi/pkg/validation/spec"
-)
-
-const (
-	jsonExt = ".json"
-
-	mimeJson = "application/json"
-	// TODO(mehdy): change @68f4ded to a version tag when gnostic add version tags.
-	mimePb   = "application/com.github.googleapis.gnostic.OpenAPIv2@68f4ded+protobuf"
-	mimePbGz = "application/x-gzip"
 )
 
 func computeETag(data []byte) string {
@@ -68,12 +58,6 @@ type OpenAPIService struct {
 	jsonCache  handler.HandlerCache
 	protoCache handler.HandlerCache
 	etagCache  handler.HandlerCache
-}
-
-func init() {
-	mime.AddExtensionType(".json", mimeJson)
-	mime.AddExtensionType(".pb-v1", mimePb)
-	mime.AddExtensionType(".gz", mimePbGz)
 }
 
 // NewOpenAPIService builds an OpenAPIService starting with the given spec.

--- a/pkg/handler3/handler.go
+++ b/pkg/handler3/handler.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
-	"mime"
 	"net/http"
 	"net/url"
 	"path"
@@ -41,13 +40,6 @@ import (
 )
 
 const (
-	jsonExt = ".json"
-
-	mimeJson = "application/json"
-	// TODO(mehdy): change @68f4ded to a version tag when gnostic add version tags.
-	mimePb   = "application/com.github.googleapis.gnostic.OpenAPIv3@68f4ded+protobuf"
-	mimePbGz = "application/x-gzip"
-
 	subTypeProtobuf = "com.github.proto-openapi.spec.v3@v1.0+protobuf"
 	subTypeJSON     = "json"
 )
@@ -82,12 +74,6 @@ type OpenAPIV3Group struct {
 	pbCache   handler.HandlerCache
 	jsonCache handler.HandlerCache
 	etagCache handler.HandlerCache
-}
-
-func init() {
-	mime.AddExtensionType(".json", mimeJson)
-	mime.AddExtensionType(".pb-v1", mimePb)
-	mime.AddExtensionType(".gz", mimePbGz)
 }
 
 func computeETag(data []byte) string {


### PR DESCRIPTION
I was going through test coverage and noticed this block being unused/untested. It looks to be unused based on the mime documentation (https://cs.opensource.google/go/go/+/go1.19.3:src/mime/type.go;l=167), the items added by `mime.AddExtensionsType` are only used if the items are fetched via `mime.ExtensionsByType` which is not seen in this repo or k/k. The other usage of AddExtensionsType is in k/k https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/discovery/discovery_client_test.go#L487 and seems like a no-op since the values added are never retrieved.

I think we can remove this but I'm not 100% sure and would like to get some feedback.

/cc @apelisse 
/cc @liggitt 