### PR TITLE
Add gofmt to CI and upgrade to go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.x' ]
+        go: [ '1.19', '1.18', '1.x' ]
         gostable: [true]
         include:
         - go: '1.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         cd ${GITHUB_WORKSPACE}/src/k8s.io/kube-openapi/
         go mod tidy && git diff --exit-code
         go build ./cmd/... ./pkg/...
+    - name: Format
+      run: |
+        diff=$(gofmt -s -d .)
+        if [[ -n "${diff}" ]]; then echo "${diff}"; exit 1; fi
     - name: Test
       run: |
         cd ${GITHUB_WORKSPACE}/src/k8s.io/kube-openapi/

--- a/pkg/builder3/openapi_test.go
+++ b/pkg/builder3/openapi_test.go
@@ -99,18 +99,16 @@ func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 		},
 		"reference-nullable": {
 			SchemaProps: spec.SchemaProps{
-				Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+				Ref:      spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
 				Nullable: true,
 			},
 		},
 		"reference-default": {
 			SchemaProps: spec.SchemaProps{
-				Ref: spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
+				Ref:     spec.MustCreateRef("/components/schemas/builder3.TestOutput"),
 				Default: map[string]interface{}{},
 			},
 		},
-
-
 	}
 	schema.Extensions = spec.Extensions{"x-test": "test"}
 	def := openapi.EmbedOpenAPIDefinitionIntoV2Extension(openapi.OpenAPIDefinition{
@@ -316,7 +314,7 @@ func getTestRequestBody() *spec3.RequestBody {
 	ret := &spec3.RequestBody{
 		RequestBodyProps: spec3.RequestBodyProps{
 			Content: map[string]*spec3.MediaType{
-				restful.MIME_JSON: &spec3.MediaType{
+				restful.MIME_JSON: {
 					MediaTypeProps: spec3.MediaTypeProps{
 						Schema: getRefSchema("#/components/schemas/builder3.TestInput"),
 					},

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -246,38 +246,42 @@ var schemaTypeFormatMap = map[string]typeInfo{
 // the spec does not need to be simple type,format) or can even return a simple type,format (e.g. IntOrString). For simple
 // type formats, the benefit of adding OpenAPIDefinitionGetter interface is to keep both type and property documentation.
 // Example:
-// type Sample struct {
-//      ...
-//      // port of the server
-//      port IntOrString
-//      ...
-// }
+//
+//	type Sample struct {
+//	     ...
+//	     // port of the server
+//	     port IntOrString
+//	     ...
+//	}
+//
 // // IntOrString documentation...
 // type IntOrString { ... }
 //
 // Adding IntOrString to this function:
-// "port" : {
-//           format:      "string",
-//           type:        "int-or-string",
-//           Description: "port of the server"
-// }
+//
+//	"port" : {
+//	          format:      "string",
+//	          type:        "int-or-string",
+//	          Description: "port of the server"
+//	}
 //
 // Implement OpenAPIDefinitionGetter for IntOrString:
 //
-// "port" : {
-//           $Ref:    "#/definitions/IntOrString"
-//           Description: "port of the server"
-// }
+//	"port" : {
+//	          $Ref:    "#/definitions/IntOrString"
+//	          Description: "port of the server"
+//	}
+//
 // ...
 // definitions:
-// {
-//           "IntOrString": {
-//                     format:      "string",
-//                     type:        "int-or-string",
-//                     Description: "IntOrString documentation..."    // new
-//           }
-// }
 //
+//	{
+//	          "IntOrString": {
+//	                    format:      "string",
+//	                    type:        "int-or-string",
+//	                    Description: "IntOrString documentation..."    // new
+//	          }
+//	}
 func OpenAPITypeFormat(typeName string) (string, string) {
 	mapped, ok := schemaTypeFormatMap[typeName]
 	if !ok {

--- a/pkg/common/restfuladapter/adapter.go
+++ b/pkg/common/restfuladapter/adapter.go
@@ -13,4 +13,3 @@ func AdaptWebServices(webServices []*restful.WebService) []common.RouteContainer
 	}
 	return containers
 }
-

--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -78,8 +78,8 @@ func (et *enumType) ValueStrings() []string {
 // DescriptionLines returns a description of the enum in this format:
 //
 // Possible enum values:
-//  - `"value1"` description 1
-//  - `"value2"` description 2
+//   - `"value1"` description 1
+//   - `"value2"` description 2
 func (et *enumType) DescriptionLines() []string {
 	var lines []string
 	for _, value := range et.Values {
@@ -132,7 +132,7 @@ func (et *enumType) appendValue(value *enumValue) {
 
 // Description returns the description line for the enumValue
 // with the format:
-//  - `"FooValue"` is the Foo value
+//   - `"FooValue"` is the Foo value
 func (ev *enumValue) Description() string {
 	comment := strings.TrimSpace(ev.Comment)
 	// The comment should starts with the type name, trim it first.

--- a/pkg/generators/rules/idl_tag_test.go
+++ b/pkg/generators/rules/idl_tag_test.go
@@ -26,7 +26,7 @@ func TestListTypeMissing(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Containers",
 						Type: &types.Type{
 							Kind: types.Slice,
@@ -41,7 +41,7 @@ func TestListTypeMissing(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Containers",
 						Type: &types.Type{
 							Kind: types.Slice,
@@ -58,14 +58,14 @@ func TestListTypeMissing(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Items",
 						Type: &types.Type{
 							Kind: types.Slice,
 						},
 						CommentLines: []string{"+listType=map"},
 					},
-					types.Member{
+					{
 						Name:     "ListMeta",
 						Embedded: true,
 						Type: &types.Type{
@@ -82,13 +82,13 @@ func TestListTypeMissing(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Items",
 						Type: &types.Type{
 							Kind: types.Slice,
 						},
 					},
-					types.Member{
+					{
 						Name:     "ListMeta",
 						Embedded: true,
 						Type: &types.Type{
@@ -105,7 +105,7 @@ func TestListTypeMissing(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Items",
 						Type: &types.Type{
 							Kind: types.Slice,

--- a/pkg/generators/rules/names_match.go
+++ b/pkg/generators/rules/names_match.go
@@ -56,24 +56,29 @@ Go field names must be CamelCase. JSON field names must be camelCase. Other than
 initial letter, the two should almost always match. No underscores nor dashes in either.
 This rule verifies the convention "Other than capitalization of the initial letter, the two should almost always match."
 Examples (also in unit test):
-    Go name      | JSON name    | match
-                   podSpec        false
-    PodSpec        podSpec        true
-    PodSpec        PodSpec        false
-    podSpec        podSpec        false
-    PodSpec        spec           false
-    Spec           podSpec        false
-    JSONSpec       jsonSpec       true
-    JSONSpec       jsonspec       false
-    HTTPJSONSpec   httpJSONSpec   true
+
+	Go name      | JSON name    | match
+	               podSpec        false
+	PodSpec        podSpec        true
+	PodSpec        PodSpec        false
+	podSpec        podSpec        false
+	PodSpec        spec           false
+	Spec           podSpec        false
+	JSONSpec       jsonSpec       true
+	JSONSpec       jsonspec       false
+	HTTPJSONSpec   httpJSONSpec   true
+
 NOTE: this validator cannot tell two sequential all-capital words from one word, therefore the case below
 is also considered matched.
-    HTTPJSONSpec   httpjsonSpec   true
+
+	HTTPJSONSpec   httpjsonSpec   true
+
 NOTE: JSON names in jsonNameBlacklist should skip evaluation
-                                  true
-    podSpec                       true
-    podSpec        -              true
-    podSpec        metadata       true
+
+	                              true
+	podSpec                       true
+	podSpec        -              true
+	podSpec        metadata       true
 */
 type NamesMatch struct{}
 
@@ -114,14 +119,15 @@ func (n *NamesMatch) Validate(t *types.Type) ([]string, error) {
 
 // namesMatch evaluates if goName and jsonName match the API rule
 // TODO: Use an off-the-shelf CamelCase solution instead of implementing this logic. The following existing
-//       packages have been tried out:
-//		github.com/markbates/inflect
-//		github.com/segmentio/go-camelcase
-//		github.com/iancoleman/strcase
-//		github.com/fatih/camelcase
-//	 Please see https://github.com/kubernetes/kube-openapi/pull/83#issuecomment-400842314 for more details
-//	 about why they don't satisfy our need. What we need can be a function that detects an acronym at the
-//	 beginning of a string.
+//
+//	      packages have been tried out:
+//			github.com/markbates/inflect
+//			github.com/segmentio/go-camelcase
+//			github.com/iancoleman/strcase
+//			github.com/fatih/camelcase
+//		 Please see https://github.com/kubernetes/kube-openapi/pull/83#issuecomment-400842314 for more details
+//		 about why they don't satisfy our need. What we need can be a function that detects an acronym at the
+//		 beginning of a string.
 func namesMatch(goName, jsonName string) bool {
 	if jsonNameBlacklist.Has(jsonName) {
 		return true

--- a/pkg/generators/rules/names_match_test.go
+++ b/pkg/generators/rules/names_match_test.go
@@ -39,7 +39,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"podSpec"`,
 					},
@@ -53,7 +53,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"podSpec,omitempty"`,
 					},
@@ -67,7 +67,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"podSpec,omitempty" protobuf:"bytes,1,opt,name=podSpec"`,
 					},
@@ -81,7 +81,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "",
 						Tags: `json:"podSpec"`,
 					},
@@ -95,7 +95,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"PodSpec"`,
 					},
@@ -109,7 +109,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "podSpec",
 						Tags: `json:"podSpec"`,
 					},
@@ -123,7 +123,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"spec"`,
 					},
@@ -137,7 +137,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Spec",
 						Tags: `json:"podSpec"`,
 					},
@@ -151,7 +151,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "JSONSpec",
 						Tags: `json:"jsonSpec"`,
 					},
@@ -165,7 +165,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "JSONSpec",
 						Tags: `json:"jsonspec"`,
 					},
@@ -179,7 +179,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "HTTPJSONSpec",
 						Tags: `json:"httpJSONSpec"`,
 					},
@@ -195,7 +195,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "HTTPJSONSpec",
 						Tags: `json:"httpjsonSpec"`,
 					},
@@ -209,7 +209,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "podSpec",
 						Tags: `json:"-"`,
 					},
@@ -223,7 +223,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"-,"`,
 					},
@@ -238,7 +238,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "",
 						Tags: `json:""`,
 					},
@@ -252,7 +252,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "podSpec",
 						Tags: `json:""`,
 					},
@@ -266,7 +266,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "podSpec",
 						Tags: `json:"metadata"`,
 					},
@@ -286,7 +286,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `podSpec`,
 					},
@@ -301,7 +301,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "S",
 						Tags: `json:"s"`,
 					},
@@ -316,7 +316,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Pod-Spec",
 						Tags: `json:"pod-Spec"`,
 					},
@@ -330,7 +330,7 @@ func TestNamesMatch(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "Pod_Spec",
 						Tags: `json:"pod_Spec"`,
 					},

--- a/pkg/generators/rules/omitempty_match_case_test.go
+++ b/pkg/generators/rules/omitempty_match_case_test.go
@@ -37,7 +37,7 @@ func TestOmitEmptyMatchCase(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"podSpec"`,
 					},
@@ -50,7 +50,7 @@ func TestOmitEmptyMatchCase(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"-,inline"`,
 					},
@@ -63,7 +63,7 @@ func TestOmitEmptyMatchCase(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "OmitEmpty",
 						Tags: `json:"omitEmpty,inline"`,
 					},
@@ -76,7 +76,7 @@ func TestOmitEmptyMatchCase(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"podSpec,omitempty"`,
 					},
@@ -89,7 +89,7 @@ func TestOmitEmptyMatchCase(t *testing.T) {
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
-					types.Member{
+					{
 						Name: "PodSpec",
 						Tags: `json:"podSpec,omitEmpty"`,
 					},

--- a/pkg/handler/default_pruning_test.go
+++ b/pkg/handler/default_pruning_test.go
@@ -31,16 +31,16 @@ func TestDefaultPruning(t *testing.T) {
 		"foo": spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Default: 0,
-				AllOf:   []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
-				AnyOf:   []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
-				OneOf:   []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
+				AllOf:   []spec.Schema{{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
+				AnyOf:   []spec.Schema{{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
+				OneOf:   []spec.Schema{{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
 				Not:     &spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}},
 				Properties: map[string]spec.Schema{
-					"foo": spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}},
+					"foo": {SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}},
 				},
 				AdditionalProperties: &spec.SchemaOrBool{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
 				PatternProperties: map[string]spec.Schema{
-					"foo": spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}},
+					"foo": {SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}},
 				},
 				Dependencies: spec.Dependencies{
 					"foo": spec.SchemaOrStringArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Default: "default-string", Title: "Field"}}},
@@ -61,16 +61,16 @@ func TestDefaultPruning(t *testing.T) {
 	wanted := spec.Definitions{
 		"foo": spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				AllOf: []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}}},
-				AnyOf: []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}}},
-				OneOf: []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}}},
+				AllOf: []spec.Schema{{SchemaProps: spec.SchemaProps{Title: "Field"}}},
+				AnyOf: []spec.Schema{{SchemaProps: spec.SchemaProps{Title: "Field"}}},
+				OneOf: []spec.Schema{{SchemaProps: spec.SchemaProps{Title: "Field"}}},
 				Not:   &spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}},
 				Properties: map[string]spec.Schema{
-					"foo": spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}},
+					"foo": {SchemaProps: spec.SchemaProps{Title: "Field"}},
 				},
 				AdditionalProperties: &spec.SchemaOrBool{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}}},
 				PatternProperties: map[string]spec.Schema{
-					"foo": spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}},
+					"foo": {SchemaProps: spec.SchemaProps{Title: "Field"}},
 				},
 				Dependencies: spec.Dependencies{
 					"foo": spec.SchemaOrStringArray{Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Title: "Field"}}},

--- a/pkg/idl/doc.go
+++ b/pkg/idl/doc.go
@@ -26,21 +26,24 @@ package idl
 // This tag MUST only be used on lists, or the generation step will
 // fail.
 //
-// Atomic
+// # Atomic
 //
 // Example:
-//  +listType=atomic
+//
+//	+listType=atomic
 //
 // Atomic lists will be entirely replaced when updated. This tag may be
 // used on any type of list (struct, scalar, ...).
 //
 // Using this tag will generate the following OpenAPI extension:
-//  "x-kubernetes-list-type": "atomic"
 //
-// Map
+//	"x-kubernetes-list-type": "atomic"
+//
+// # Map
 //
 // Example:
-//  +listType=map
+//
+//	+listType=map
 //
 // These lists are like maps in that their elements have a non-index key
 // used to identify them. Order is preserved upon merge. Using the map
@@ -48,18 +51,21 @@ package idl
 // the generation step.
 //
 // Using this tag will generate the following OpenAPI extension:
-//  "x-kubernetes-list-type": "map"
 //
-// Set
+//	"x-kubernetes-list-type": "map"
+//
+// # Set
 //
 // Example:
-//  +listType=set
+//
+//	+listType=set
 //
 // Sets are lists that must not have multiple times the same value. Each
 // value must be a scalar (or another atomic type).
 //
 // Using this tag will generate the following OpenAPI extension:
-//  "x-kubernetes-list-type": "set"
+//
+//	"x-kubernetes-list-type": "set"
 type ListType string
 
 // ListMapKey annotates map lists by specifying the key used as the index of the map.
@@ -72,10 +78,12 @@ type ListType string
 // An example of how this can be used is shown in the ListType (map) example.
 //
 // Example:
-//  +listMapKey=name
+//
+//	+listMapKey=name
 //
 // Using this tag will generate the following OpenAPI extension:
-//  "x-kubernetes-list-map-key": "name"
+//
+//	"x-kubernetes-list-map-key": "name"
 type ListMapKey string
 
 // MapType annotates a map to further describe its topology. It may
@@ -90,16 +98,18 @@ type ListMapKey string
 //
 // This tag MUST only be used on maps, or the generation step will fail.
 //
-// Atomic
+// # Atomic
 //
 // Example:
-//  +mapType=atomic
+//
+//	+mapType=atomic
 //
 // Atomic maps will be entirely replaced when updated. This tag may be
 // used on any map.
 //
 // Using this tag will generate the following OpenAPI extension:
-//  "x-kubernetes-map-type": "atomic"
+//
+//	"x-kubernetes-map-type": "atomic"
 type MapType string
 
 // OpenAPIGen needs to be described.
@@ -109,12 +119,14 @@ type OpenAPIGen string
 // By default, fields will be marked as required if not otherwise specified.
 //
 // Example:
+//
 //	+optional
 //
 // Additionally, the json struct tag directive "omitempty" can be used to imply
 // the same.
 //
 // Example:
+//
 //	OptionalField `json:"optionalField,omitempty"`
 type Optional string
 
@@ -136,16 +148,18 @@ type PatchStrategy string
 //
 // This tag MUST only be used on structs, or the generation step will fail.
 //
-// Atomic
+// # Atomic
 //
 // Example:
-//  +structType=atomic
+//
+//	+structType=atomic
 //
 // Atomic structs will be entirely replaced when updated. This tag may be
 // used on any struct.
 //
 // Using this tag will generate the following OpenAPI extension:
-//  "x-kubernetes-map-type": "atomic"
+//
+//	"x-kubernetes-map-type": "atomic"
 type StructType string
 
 // Union is TBD.

--- a/pkg/internal/third_party/go-json-experiment/json/diff_test.go
+++ b/pkg/internal/third_party/go-json-experiment/json/diff_test.go
@@ -43,6 +43,7 @@ var jsonPackages = []struct {
 // snake_case, camelCase, or kebab-case.
 //
 // Related issue:
+//
 //	https://go.dev/issue/14750
 func TestCaseSensitivity(t *testing.T) {
 	type Fields struct {
@@ -125,6 +126,7 @@ func TestCaseSensitivity(t *testing.T) {
 // but now defined in terms of the JSON type system in v2.
 //
 // Related issues:
+//
 //	https://go.dev/issue/11939
 //	https://go.dev/issue/22480
 //	https://go.dev/issue/29310
@@ -284,6 +286,7 @@ func addr[T any](v T) *T {
 // is removed in v2 because this behavior was surprising and inconsistent in v1.
 //
 // Related issues:
+//
 //	https://go.dev/issue/15624
 //	https://go.dev/issue/20651
 //	https://go.dev/issue/22177
@@ -468,6 +471,7 @@ func TestStringOption(t *testing.T) {
 // The non-zero values of those types always marshal as JSON strings.
 //
 // Related issues:
+//
 //	https://go.dev/issue/27589
 //	https://go.dev/issue/37711
 func TestNilSlicesAndMaps(t *testing.T) {
@@ -610,6 +614,7 @@ func (v *CallCheck) UnmarshalJSON([]byte) error {
 // Unfortunately, it cannot be changed without breaking existing usages.
 //
 // Related issues:
+//
 //	https://go.dev/issue/27722
 //	https://go.dev/issue/33993
 //	https://go.dev/issue/42508
@@ -694,6 +699,7 @@ func TestPointerReceiver(t *testing.T) {
 //	(*json.RawValue)(&b).Canonicalize()
 //
 // Related issue:
+//
 //	https://go.dev/issue/7872
 //	https://go.dev/issue/33714
 func TestMapDeterminism(t *testing.T) {
@@ -833,6 +839,7 @@ func TestInvalidUTF8(t *testing.T) {
 // See https://labs.bishopfox.com/tech-blog/an-exploration-of-json-interoperability-vulnerabilities
 //
 // Related issue:
+//
 //	https://go.dev/issue/48298
 func TestDuplicateNames(t *testing.T) {
 	for _, json := range jsonPackages {
@@ -862,6 +869,7 @@ func TestDuplicateNames(t *testing.T) {
 // when Unmarshaling into a empty value.
 //
 // Related issues:
+//
 //	https://go.dev/issue/22177
 //	https://go.dev/issue/33835
 func TestMergeNull(t *testing.T) {
@@ -937,6 +945,7 @@ func TestMergeNull(t *testing.T) {
 // In v2, merging follows behavior based on RFC 7396.
 //
 // Related issues:
+//
 //	https://go.dev/issue/21092
 //	https://go.dev/issue/26946
 //	https://go.dev/issue/27172
@@ -1028,6 +1037,7 @@ func TestMergeComposite(t *testing.T) {
 //	}
 //
 // Related issue:
+//
 //	https://go.dev/issue/10275
 func TestTimeDurations(t *testing.T) {
 	for _, json := range jsonPackages {
@@ -1168,6 +1178,7 @@ func TestEmptyStructs(t *testing.T) {
 // explicitly mark such fields as being ignored with `json:"-"`.
 //
 // Related issues:
+//
 //	https://go.dev/issue/21353
 //	https://go.dev/issue/21357
 //	https://go.dev/issue/24153

--- a/pkg/internal/third_party/go-json-experiment/json/doc.go
+++ b/pkg/internal/third_party/go-json-experiment/json/doc.go
@@ -8,8 +8,7 @@
 // primitive data types such as booleans, strings, and numbers,
 // in addition to structured data types such as objects and arrays.
 //
-//
-// Terminology
+// # Terminology
 //
 // This package uses the terms "encode" and "decode" for syntactic functionality
 // that is concerned with processing JSON based on its grammar, and
@@ -32,8 +31,7 @@
 //
 // See RFC 8259 for more information.
 //
-//
-// Specifications
+// # Specifications
 //
 // Relevant specifications include RFC 4627, RFC 7159, RFC 7493, RFC 8259,
 // and RFC 8785. Each RFC is generally a stricter subset of another RFC.
@@ -60,8 +58,7 @@
 // In particular, it makes specific choices about behavior that RFC 8259
 // leaves as undefined in order to ensure greater interoperability.
 //
-//
-// JSON Representation of Go structs
+// # JSON Representation of Go structs
 //
 // A Go struct is naturally represented as a JSON object,
 // where each Go struct field corresponds with a JSON object member.

--- a/pkg/spec3/component_test.go
+++ b/pkg/spec3/component_test.go
@@ -37,7 +37,7 @@ func TestSchemasJSONSerialization(t *testing.T) {
 			name: "scenario1: smoke test serialization of spec3.Components.Schemas",
 			target: spec3.Components{
 				Schemas: map[string]*spec.Schema{
-					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
+					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MutatingWebhook describes an admission webhook and the resources and operations it applies to.",
 							Type:        []string{"object"},
@@ -143,7 +143,7 @@ func TestSchemasJSONSerialization(t *testing.T) {
 			name: "scenario2: schema can be defined as a ref, see: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject",
 			target: spec3.Components{
 				Schemas: map[string]*spec.Schema{
-					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": &spec.Schema{
+					"io.k8s.api.admissionregistration.v1beta1.MutatingWebhook": {
 						SchemaProps: spec.SchemaProps{
 							Ref: spec.MustCreateRef("k8s.io/api/admissionregistration/v1beta1.WebhookClientConfig"),
 						},

--- a/pkg/spec3/encoding_test.go
+++ b/pkg/spec3/encoding_test.go
@@ -38,7 +38,7 @@ func TestEncodingJSONSerialization(t *testing.T) {
 				EncodingProps: spec3.EncodingProps{
 					ContentType: "image/png",
 					Headers: map[string]*spec3.Header{
-						"X-Rate-Limit-Limit": &spec3.Header{
+						"X-Rate-Limit-Limit": {
 							HeaderProps: spec3.HeaderProps{
 								Description: "The number of allowed requests in the current period",
 								Schema: &spec.Schema{

--- a/pkg/spec3/example.go
+++ b/pkg/spec3/example.go
@@ -19,8 +19,8 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Example https://swagger.io/specification/#example-object

--- a/pkg/spec3/example_test.go
+++ b/pkg/spec3/example_test.go
@@ -35,7 +35,7 @@ func TestExampleJSONSerialization(t *testing.T) {
 			target: &spec3.Example{
 				ExampleProps: spec3.ExampleProps{
 					Summary: "An example",
-					Value: map[string]string{"foo": "bar"},
+					Value:   map[string]string{"foo": "bar"},
 				},
 			},
 			expectedOutput: `{"summary":"An example","value":{"foo":"bar"}}`,

--- a/pkg/spec3/external_documentation.go
+++ b/pkg/spec3/external_documentation.go
@@ -18,8 +18,8 @@ package spec3
 
 import (
 	"encoding/json"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 type ExternalDocumentation struct {

--- a/pkg/spec3/external_documentation_test.go
+++ b/pkg/spec3/external_documentation_test.go
@@ -36,7 +36,7 @@ func TestExternalDocumentationJSONSerialization(t *testing.T) {
 			target: &spec3.ExternalDocumentation{
 				ExternalDocumentationProps: spec3.ExternalDocumentationProps{
 					Description: "Find more info here",
-					URL: "https://example.com",
+					URL:         "https://example.com",
 				},
 			},
 			expectedOutput: `{"description":"Find more info here","url":"https://example.com"}`,

--- a/pkg/spec3/media_type.go
+++ b/pkg/spec3/media_type.go
@@ -56,7 +56,7 @@ func (m *MediaType) UnmarshalJSON(data []byte) error {
 // MediaTypeProps a struct that allows you to specify content format, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#mediaTypeObject
 type MediaTypeProps struct {
 	// Schema holds the schema defining the type used for the media type
-	Schema    *spec.Schema `json:"schema,omitempty"`
+	Schema *spec.Schema `json:"schema,omitempty"`
 	// Example of the media type
 	Example interface{} `json:"example,omitempty"`
 	// Examples of the media type. Each example object should match the media type and specific schema if present

--- a/pkg/spec3/media_type_test.go
+++ b/pkg/spec3/media_type_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func TestMediaTypeJSONSerialization(t *testing.T) {

--- a/pkg/spec3/operation.go
+++ b/pkg/spec3/operation.go
@@ -19,8 +19,8 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Operation describes a single API operation on a path, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject

--- a/pkg/spec3/operation_test.go
+++ b/pkg/spec3/operation_test.go
@@ -39,7 +39,7 @@ func TestOperationJSONSerialization(t *testing.T) {
 					Summary:     "Updates a pet in the store with form data",
 					OperationId: "updatePetWithForm",
 					Parameters: []*spec3.Parameter{
-						&spec3.Parameter{
+						{
 							ParameterProps: spec3.ParameterProps{
 								Name:        "petId",
 								In:          "path",
@@ -56,19 +56,19 @@ func TestOperationJSONSerialization(t *testing.T) {
 					RequestBody: &spec3.RequestBody{
 						RequestBodyProps: spec3.RequestBodyProps{
 							Content: map[string]*spec3.MediaType{
-								"application/x-www-form-urlencoded": &spec3.MediaType{
+								"application/x-www-form-urlencoded": {
 									MediaTypeProps: spec3.MediaTypeProps{
 										Schema: &spec.Schema{
 											SchemaProps: spec.SchemaProps{
 												Type: []string{"object"},
 												Properties: map[string]spec.Schema{
-													"name": spec.Schema{
+													"name": {
 														SchemaProps: spec.SchemaProps{
 															Description: "Updated name of the pet",
 															Type:        []string{"string"},
 														},
 													},
-													"status": spec.Schema{
+													"status": {
 														SchemaProps: spec.SchemaProps{
 															Description: "Updated status of the pet",
 															Type:        []string{"string"},
@@ -85,12 +85,12 @@ func TestOperationJSONSerialization(t *testing.T) {
 					Responses: &spec3.Responses{
 						ResponsesProps: spec3.ResponsesProps{
 							StatusCodeResponses: map[int]*spec3.Response{
-								200: &spec3.Response{
+								200: {
 									ResponseProps: spec3.ResponseProps{
 										Description: "Pet updated.",
 										Content: map[string]*spec3.MediaType{
-											"application/json": &spec3.MediaType{},
-											"application/xml": &spec3.MediaType{},
+											"application/json": {},
+											"application/xml":  {},
 										},
 									},
 								},

--- a/pkg/spec3/parameter_test.go
+++ b/pkg/spec3/parameter_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func TestParameterJSONSerialization(t *testing.T) {
@@ -35,13 +35,13 @@ func TestParameterJSONSerialization(t *testing.T) {
 			name: "header parameter",
 			target: &spec3.Parameter{
 				ParameterProps: spec3.ParameterProps{
-					Name: "token",
-					In: "header",
+					Name:        "token",
+					In:          "header",
 					Description: "token to be passed as a header",
-					Required: true,
+					Required:    true,
 					Schema: &spec.Schema{
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"integer"},
+							Type:   []string{"integer"},
 							Format: "int64",
 						},
 					},
@@ -54,10 +54,10 @@ func TestParameterJSONSerialization(t *testing.T) {
 			name: "path parameter",
 			target: &spec3.Parameter{
 				ParameterProps: spec3.ParameterProps{
-					Name: "username",
-					In: "path",
+					Name:        "username",
+					In:          "path",
 					Description: "username to fetch",
-					Required: true,
+					Required:    true,
 					Schema: &spec.Schema{
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"string"},
@@ -67,7 +67,6 @@ func TestParameterJSONSerialization(t *testing.T) {
 			},
 			expectedOutput: `{"name":"username","in":"path","description":"username to fetch","required":true,"schema":{"type":"string"}}`,
 		},
-
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/spec3/path.go
+++ b/pkg/spec3/path.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Paths describes the available paths and operations for the API, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathsObject

--- a/pkg/spec3/path_test.go
+++ b/pkg/spec3/path_test.go
@@ -43,11 +43,11 @@ func TestPathJSONSerialization(t *testing.T) {
 							Responses: &spec3.Responses{
 								ResponsesProps: spec3.ResponsesProps{
 									StatusCodeResponses: map[int]*spec3.Response{
-										200: &spec3.Response{
+										200: {
 											ResponseProps: spec3.ResponseProps{
 												Description: "Pet response",
 												Content: map[string]*spec3.MediaType{
-													"*/*": &spec3.MediaType{
+													"*/*": {
 														MediaTypeProps: spec3.MediaTypeProps{
 															Schema: &spec.Schema{
 																SchemaProps: spec.SchemaProps{
@@ -72,7 +72,7 @@ func TestPathJSONSerialization(t *testing.T) {
 						},
 					},
 					Parameters: []*spec3.Parameter{
-						&spec3.Parameter{
+						{
 							ParameterProps: spec3.ParameterProps{
 								Name:        "id",
 								In:          "path",

--- a/pkg/spec3/request_body.go
+++ b/pkg/spec3/request_body.go
@@ -19,8 +19,8 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // RequestBody describes a single request body, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#requestBodyObject

--- a/pkg/spec3/request_body_test.go
+++ b/pkg/spec3/request_body_test.go
@@ -37,7 +37,7 @@ func TestRequestBodyJSONSerialization(t *testing.T) {
 				RequestBodyProps: spec3.RequestBodyProps{
 					Description: "user to add to the system",
 					Content: map[string]*spec3.MediaType{
-						"application/json": &spec3.MediaType{
+						"application/json": {
 							MediaTypeProps: spec3.MediaTypeProps{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{

--- a/pkg/spec3/response.go
+++ b/pkg/spec3/response.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // Responses holds the list of possible responses as they are returned from executing this operation
@@ -148,7 +148,6 @@ type ResponseProps struct {
 	// Links is a map of operations links that can be followed from the response
 	Links map[string]*Link `json:"links,omitempty"`
 }
-
 
 // Link represents a possible design-time link for a response, more at https://swagger.io/specification/#link-object
 type Link struct {

--- a/pkg/spec3/response_test.go
+++ b/pkg/spec3/response_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func TestResponseJSONSerialization(t *testing.T) {
@@ -37,7 +37,7 @@ func TestResponseJSONSerialization(t *testing.T) {
 			target: &spec3.Response{
 				ResponseProps: spec3.ResponseProps{
 					Content: map[string]*spec3.MediaType{
-						"text/plain": &spec3.MediaType{
+						"text/plain": {
 							MediaTypeProps: spec3.MediaTypeProps{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{

--- a/pkg/spec3/security_requirement.go
+++ b/pkg/spec3/security_requirement.go
@@ -19,8 +19,8 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // SecurityRequirementProps describes the required security schemes to execute an operation, more at https://swagger.io/specification/#security-requirement-object

--- a/pkg/spec3/security_requirement_test.go
+++ b/pkg/spec3/security_requirement_test.go
@@ -35,7 +35,7 @@ func TestSecurityRequirementJSONSerialization(t *testing.T) {
 			name: "Non-OAuth2 Security Requirement",
 			target: &spec3.SecurityRequirement{
 				SecurityRequirementProps: map[string][]string{
-					"api_key": []string{},
+					"api_key": {},
 				},
 			},
 			expectedOutput: `{"api_key":[]}`,
@@ -44,7 +44,7 @@ func TestSecurityRequirementJSONSerialization(t *testing.T) {
 			name: "OAuth2 Security Requirement",
 			target: &spec3.SecurityRequirement{
 				SecurityRequirementProps: map[string][]string{
-					"petstore_auth": []string{
+					"petstore_auth": {
 						"write_pets",
 						"read:pets",
 					},

--- a/pkg/spec3/security_scheme.go
+++ b/pkg/spec3/security_scheme.go
@@ -19,8 +19,8 @@ package spec3
 import (
 	"encoding/json"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 // SecurityScheme defines reusable Security Scheme Object, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject

--- a/pkg/spec3/security_scheme_test.go
+++ b/pkg/spec3/security_scheme_test.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	"k8s.io/kube-openapi/pkg/spec3"
 )
@@ -64,7 +64,7 @@ func TestSecuritySchemaJSONSerialization(t *testing.T) {
 				SecuritySchemeProps: spec3.SecuritySchemeProps{
 					Type: "oauth2",
 					Flows: map[string]*spec3.OAuthFlow{
-						"implicit": &spec3.OAuthFlow{
+						"implicit": {
 							OAuthFlowProps: spec3.OAuthFlowProps{
 								AuthorizationUrl: "https://example.com/api/oauth/dialog",
 								Scopes: map[string]string{

--- a/pkg/spec3/server.go
+++ b/pkg/spec3/server.go
@@ -18,9 +18,8 @@ package spec3
 
 import (
 	"encoding/json"
-	"k8s.io/kube-openapi/pkg/validation/spec"
 	"github.com/go-openapi/swag"
-
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 type Server struct {

--- a/pkg/spec3/server_test.go
+++ b/pkg/spec3/server_test.go
@@ -35,7 +35,7 @@ func TestServerJSONSerialization(t *testing.T) {
 			name: "basic",
 			target: &spec3.Server{
 				ServerProps: spec3.ServerProps{
-					URL: "https://development.gigantic-server.com/v1",
+					URL:         "https://development.gigantic-server.com/v1",
 					Description: "Development server",
 				},
 			},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -30,6 +30,7 @@ import (
 // in GetCanonicalTypeName means Go type names with full package path.
 //
 // Examples of REST friendly OpenAPI name:
+//
 //	Input:  k8s.io/api/core/v1.Pod
 //	Output: io.k8s.api.core.v1.Pod
 //
@@ -45,6 +46,7 @@ func ToCanonicalName(name string) string {
 // ToRESTFriendlyName converts Golang package/type canonical name into REST friendly OpenAPI name.
 //
 // Examples of REST friendly OpenAPI name:
+//
 //	Input:  k8s.io/api/core/v1.Pod
 //	Output: io.k8s.api.core.v1.Pod
 //
@@ -71,18 +73,21 @@ func ToRESTFriendlyName(name string) string {
 // OpenAPI canonical names are Go type names with full package path, for uniquely indentifying
 // a model / Go type. If a Go type is vendored from another package, only the path after "/vendor/"
 // should be used. For custom resource definition (CRD), the canonical name is expected to be
-//     group/version.kind
+//
+//	group/version.kind
 //
 // Examples of canonical name:
-//     Go type: k8s.io/kubernetes/pkg/apis/core.Pod
-//     CRD:     csi.storage.k8s.io/v1alpha1.CSINodeInfo
+//
+//	Go type: k8s.io/kubernetes/pkg/apis/core.Pod
+//	CRD:     csi.storage.k8s.io/v1alpha1.CSINodeInfo
 //
 // Example for vendored Go type:
-//     Original full path:  k8s.io/kubernetes/vendor/k8s.io/api/core/v1.Pod
-//     Canonical name:      k8s.io/api/core/v1.Pod
 //
-//     Original full path:  vendor/k8s.io/api/core/v1.Pod
-//     Canonical name:      k8s.io/api/core/v1.Pod
+//	Original full path:  k8s.io/kubernetes/vendor/k8s.io/api/core/v1.Pod
+//	Canonical name:      k8s.io/api/core/v1.Pod
+//
+//	Original full path:  vendor/k8s.io/api/core/v1.Pod
+//	Canonical name:      k8s.io/api/core/v1.Pod
 type OpenAPICanonicalTypeNamer interface {
 	OpenAPICanonicalTypeName() string
 }

--- a/pkg/validation/errors/doc.go
+++ b/pkg/validation/errors/doc.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 /*
-
 Package errors provides an Error interface and several concrete types
 implementing this interface to manage API errors and JSON-schema validation
 errors.
@@ -23,6 +22,5 @@ it defines.
 
 It is used throughout the various go-openapi toolkit libraries
 (https://github.com/go-openapi).
-
 */
 package errors

--- a/pkg/validation/spec/paths_test.go
+++ b/pkg/validation/spec/paths_test.go
@@ -65,7 +65,7 @@ func TestPathsRoundtrip(t *testing.T) {
 					"x-framework": "swagger-go",
 				}},
 				map[string]PathItem{
-					"/this-is-a-path": PathItem{Refable: Refable{MustCreateRef("/components/a/path/item")}},
+					"/this-is-a-path": {Refable: Refable{MustCreateRef("/components/a/path/item")}},
 				},
 			},
 		}, {

--- a/test/integration/builder/main.go
+++ b/test/integration/builder/main.go
@@ -43,7 +43,7 @@ func main() {
 	// from GetOpenAPIDefinitions. Anonymous function returning empty
 	// Ref is not used.
 	var defNames []string
-	for name, _ := range generated.GetOpenAPIDefinitions(func(name string) spec.Ref {
+	for name := range generated.GetOpenAPIDefinitions(func(name string) spec.Ref {
 		return spec.Ref{}
 	}) {
 		defNames = append(defNames, name)

--- a/test/integration/openapiconv/convert_test.go
+++ b/test/integration/openapiconv/convert_test.go
@@ -35,7 +35,7 @@ func TestConvertGolden(t *testing.T) {
 	// from GetOpenAPIDefinitions. Anonymous function returning empty
 	// Ref is not used.
 	var defNames []string
-	for name, _ := range generated.GetOpenAPIDefinitions(func(name string) spec.Ref {
+	for name := range generated.GetOpenAPIDefinitions(func(name string) spec.Ref {
 		return spec.Ref{}
 	}) {
 		defNames = append(defNames, name)

--- a/test/integration/testdata/enumtype/enum.go
+++ b/test/integration/testdata/enumtype/enum.go
@@ -21,5 +21,5 @@ type FruitsBasket struct {
 	Content FruitType `json:"content"`
 
 	// +default=0
-	Count  int `json:"count"`
+	Count int `json:"count"`
 }

--- a/test/integration/testutil/testutil.go
+++ b/test/integration/testutil/testutil.go
@@ -39,7 +39,7 @@ func CreateOpenAPIBuilderConfig() *common.Config {
 			},
 		},
 		ResponseDefinitions: map[string]spec.Response{
-			"NotFound": spec.Response{
+			"NotFound": {
 				ResponseProps: spec.ResponseProps{
 					Description: "Entity not found.",
 				},


### PR DESCRIPTION
Add gofmt to CI and upgrade to go 1.19

The diff code was partially copied from ./hack/verify-gofmt.sh from k/k.

This code also updated some of the files in `internal/third_party`, should those be ignored?