### PR TITLE
Fix wrong extension name in parse schema

### DIFF
--- a/pkg/util/proto/document_v3.go
+++ b/pkg/util/proto/document_v3.go
@@ -120,7 +120,7 @@ func (d *Definitions) ParseSchemaV3(s *openapi_v3.Schema, path *Path) (Schema, e
 	switch s.GetType() {
 	case object:
 		for _, extension := range s.GetSpecificationExtension() {
-			if extension.Name == "x-kuberentes-group-version-kind" {
+			if extension.Name == "x-kubernetes-group-version-kind" {
 				// Objects with x-kubernetes-group-version-kind are always top
 				// level types.
 				return d.parseV3Kind(s, path)
@@ -285,7 +285,7 @@ func parseV3Interface(def *yaml.Node) (interface{}, error) {
 
 func (d *Definitions) parseV3BaseSchema(s *openapi_v3.Schema, path *Path) (*BaseSchema, error) {
 	if s == nil {
-		return nil, fmt.Errorf("cannot initializae BaseSchema from nil")
+		return nil, fmt.Errorf("cannot initialize BaseSchema from nil")
 	}
 
 	def, err := parseV3Interface(s.GetDefault().ToRawInfo())


### PR DESCRIPTION
Fix wrong extension name in [document_v3.go](https://github.com/qingwave/kube-openapi/blob/f3cff1453715b47553c6543752d634081b0e9a38/pkg/util/proto/document_v3.go#L123)

cc  @alexzielenski @apelisse 