### PR TITLE
Remove deprecated ioutil

### DIFF
--- a/cmd/openapi2smd/openapi2smd.go
+++ b/cmd/openapi2smd/openapi2smd.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -33,7 +33,7 @@ func main() {
 		log.Fatal("this program takes input on stdin and writes output to stdout.")
 	}
 
-	input, err := ioutil.ReadAll(os.Stdin)
+	input, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatalf("error reading stdin: %v", err)
 	}

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -19,7 +19,7 @@ package aggregator
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -1970,7 +1970,7 @@ definitions:
 
 func loadTestData() ([]*spec.Swagger, *spec.Swagger) {
 	loadSpec := func(fileName string) *spec.Swagger {
-		bs, err := ioutil.ReadFile(filepath.Join("../../test/integration/testdata/aggregator", fileName))
+		bs, err := os.ReadFile(filepath.Join("../../test/integration/testdata/aggregator", fileName))
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/generators/api_linter.go
+++ b/pkg/generators/api_linter.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 
@@ -64,7 +63,7 @@ func (a apiViolationFile) VerifyFile(f *generator.File, path string) error {
 	path = a.unmangledPath
 
 	formatted := f.Body.Bytes()
-	existing, err := ioutil.ReadFile(path)
+	existing, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("unable to read file %q for comparison: %v", path, err)
 	}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -2,9 +2,10 @@ package handler
 
 import (
 	json "encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
@@ -85,7 +86,7 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 			t.Errorf("Accept: %v: Unexpected response status code, want: %v, got: %v", tc.acceptHeader, tc.respStatus, resp.StatusCode)
 		}
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("Accept: %v: Unexpected error in reading response body: %v", tc.acceptHeader, err)
 		}
@@ -96,7 +97,7 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 }
 
 func TestToProtoBinary(t *testing.T) {
-	bs, err := ioutil.ReadFile("../../test/integration/testdata/aggregator/openapi.json")
+	bs, err := os.ReadFile("../../test/integration/testdata/aggregator/openapi.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/handler3/handler_test.go
+++ b/pkg/handler3/handler_test.go
@@ -18,7 +18,7 @@ package handler3
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -208,7 +208,7 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 		}
 
 		if tc.respStatus == 304 {
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("Accept: %v: Unexpected error in reading response body: %v", tc.acceptHeader, err)
 			}
@@ -225,7 +225,7 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 			t.Errorf("Expect ETag %s, got %s", strconv.Quote(tc.expectedETag), gotETag)
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("Accept: %v: Unexpected error in reading response body: %v", tc.acceptHeader, err)
 		}
@@ -374,7 +374,7 @@ func TestCacheBusting(t *testing.T) {
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("Accept: %v: Unexpected error in reading response body: %v", tc.acceptHeader, err)
 		}

--- a/pkg/openapiconv/convert_test.go
+++ b/pkg/openapiconv/convert_test.go
@@ -18,7 +18,7 @@ package openapiconv
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -41,7 +41,7 @@ func TestConvert(t *testing.T) {
 
 	for _, tc := range tcs {
 
-		spec2JSON, err := ioutil.ReadFile(filepath.Join("testdata_generated_from_k8s/v2_" + tc.groupVersion + ".json"))
+		spec2JSON, err := os.ReadFile(filepath.Join("testdata_generated_from_k8s/v2_" + tc.groupVersion + ".json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +66,7 @@ func TestConvert(t *testing.T) {
 			t.Errorf("Expected OpenAPI V2 to be untouched before and after conversion")
 		}
 
-		spec3JSON, err := ioutil.ReadFile(filepath.Join("testdata_generated_from_k8s/v3_" + tc.groupVersion + ".json"))
+		spec3JSON, err := os.ReadFile(filepath.Join("testdata_generated_from_k8s/v3_" + tc.groupVersion + ".json"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/schemaconv/smd_test.go
+++ b/pkg/schemaconv/smd_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package schemaconv
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -83,7 +83,7 @@ func testToSchema(t *testing.T, openAPIPath, expectedNewSchemaPath string) {
 		t.Fatal(err)
 	}
 
-	expect, err := ioutil.ReadFile(expectedNewSchemaPath)
+	expect, err := os.ReadFile(expectedNewSchemaPath)
 	if err != nil {
 		t.Fatalf("Unable to read golden data file %q: %v", expectedNewSchemaPath, err)
 	}

--- a/pkg/util/proto/testing/openapi.go
+++ b/pkg/util/proto/testing/openapi.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -42,7 +41,7 @@ func (f *Fake) OpenAPISchema() (*openapi_v2.Document, error) {
 			f.err = err
 			return
 		}
-		spec, err := ioutil.ReadFile(f.Path)
+		spec, err := os.ReadFile(f.Path)
 		if err != nil {
 			f.err = err
 			return

--- a/pkg/util/proto/testing/openapi_v3.go
+++ b/pkg/util/proto/testing/openapi_v3.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -47,7 +46,7 @@ func (f *FakeV3) OpenAPIV3Schema(groupVersion string) (*openapi_v3.Document, err
 	if err != nil {
 		return nil, err
 	}
-	spec, err := ioutil.ReadFile(filepath.Join(f.Path, groupVersion+".json"))
+	spec, err := os.ReadFile(filepath.Join(f.Path, groupVersion+".json"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/validation/validate/debug_test.go
+++ b/pkg/validation/validate/debug_test.go
@@ -15,7 +15,6 @@
 package validate
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -28,7 +27,7 @@ var (
 )
 
 func TestDebug(t *testing.T) {
-	tmpFile, _ := ioutil.TempFile("", "debug-test")
+	tmpFile, _ := os.CreateTemp("", "debug-test")
 	tmpName := tmpFile.Name()
 	defer func() {
 		Debug = false

--- a/pkg/validation/validate/jsonschema_test.go
+++ b/pkg/validation/validate/jsonschema_test.go
@@ -16,7 +16,6 @@ package validate
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -113,7 +112,7 @@ func TestJSONSchemaSuite(t *testing.T) {
 		}
 	}()
 
-	files, err := ioutil.ReadDir(jsonSchemaFixturesPath)
+	files, err := os.ReadDir(jsonSchemaFixturesPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,14 +130,14 @@ func TestJSONSchemaSuite(t *testing.T) {
 				return
 			}
 			t.Log("Running " + specName)
-			b, _ := ioutil.ReadFile(filepath.Join(jsonSchemaFixturesPath, fileName))
+			b, _ := os.ReadFile(filepath.Join(jsonSchemaFixturesPath, fileName))
 			doTestSchemaSuite(t, b)
 		})
 	}
 }
 
 func TestSchemaFixtures(t *testing.T) {
-	files, err := ioutil.ReadDir(schemaFixturesPath)
+	files, err := os.ReadDir(schemaFixturesPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +151,7 @@ func TestSchemaFixtures(t *testing.T) {
 			t.Parallel()
 			specName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
 			t.Log("Running " + specName)
-			b, _ := ioutil.ReadFile(filepath.Join(schemaFixturesPath, fileName))
+			b, _ := os.ReadFile(filepath.Join(schemaFixturesPath, fileName))
 			doTestSchemaSuite(t, b)
 		})
 	}
@@ -160,7 +159,7 @@ func TestSchemaFixtures(t *testing.T) {
 
 func TestOptionalJSONSchemaSuite(t *testing.T) {
 	jsonOptionalSchemaFixturesPath := filepath.Join(jsonSchemaFixturesPath, "optional")
-	files, err := ioutil.ReadDir(jsonOptionalSchemaFixturesPath)
+	files, err := os.ReadDir(jsonOptionalSchemaFixturesPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +177,7 @@ func TestOptionalJSONSchemaSuite(t *testing.T) {
 				return
 			}
 			t.Log("Running [optional] " + specName)
-			b, _ := ioutil.ReadFile(filepath.Join(jsonOptionalSchemaFixturesPath, fileName))
+			b, _ := os.ReadFile(filepath.Join(jsonOptionalSchemaFixturesPath, fileName))
 			doTestSchemaSuite(t, b)
 		})
 	}
@@ -187,7 +186,7 @@ func TestOptionalJSONSchemaSuite(t *testing.T) {
 // Further testing with all formats recognized by strfmt
 func TestFormat_JSONSchemaExtended(t *testing.T) {
 	jsonFormatSchemaFixturesPath := filepath.Join(formatFixturesPath)
-	files, err := ioutil.ReadDir(jsonFormatSchemaFixturesPath)
+	files, err := os.ReadDir(jsonFormatSchemaFixturesPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +204,7 @@ func TestFormat_JSONSchemaExtended(t *testing.T) {
 				return
 			}
 			t.Log("Running [extended formats] " + specName)
-			b, _ := ioutil.ReadFile(filepath.Join(jsonFormatSchemaFixturesPath, fileName))
+			b, _ := os.ReadFile(filepath.Join(jsonFormatSchemaFixturesPath, fileName))
 			doTestSchemaSuite(t, b)
 		})
 	}
@@ -219,7 +218,7 @@ func doTestSchemaSuite(t *testing.T, doc []byte) {
 
 	for _, testDescription := range testDescriptions {
 		b, _ := testDescription.Schema.MarshalJSON()
-		tmpFile, err := ioutil.TempFile(os.TempDir(), "validate-test")
+		tmpFile, err := os.CreateTemp(os.TempDir(), "validate-test")
 		assert.NoError(t, err)
 		_, _ = tmpFile.Write(b)
 		tmpFile.Close()

--- a/test/integration/builder/main.go
+++ b/test/integration/builder/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -63,7 +62,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("json marshal error: %s", err.Error())
 	}
-	err = ioutil.WriteFile(swaggerFilename, specBytes, 0644)
+	err = os.WriteFile(swaggerFilename, specBytes, 0644)
 	if err != nil {
 		log.Fatalf("stdout write error: %s", err.Error())
 	}

--- a/test/integration/builder3/main.go
+++ b/test/integration/builder3/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -67,7 +66,7 @@ func main() {
 		log.Fatalf("OpenAPI v3 validation error: %s", err.Error())
 	}
 
-	err = ioutil.WriteFile(swaggerFilename, specBytes, 0644)
+	err = os.WriteFile(swaggerFilename, specBytes, 0644)
 	if err != nil {
 		log.Fatalf("stdout write error: %s", err.Error())
 	}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +74,7 @@ var _ = BeforeSuite(func() {
 	workingDirectory = abs
 
 	// Create a temporary directory for generated swagger files.
-	tempDir, terr = ioutil.TempDir("./", "openapi")
+	tempDir, terr = os.MkdirTemp("./", "openapi")
 	Expect(terr).ShouldNot(HaveOccurred())
 
 	// Build the OpenAPI code generator.


### PR DESCRIPTION
Remove deprecated ioutil package from kube-openapi

Related to https://github.com/kubernetes/kubernetes/issues/100367