### PR TITLE
Improve format of generated enum lines

### DIFF
--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -81,6 +81,9 @@ func (et *enumType) ValueStrings() []string {
 //   - `"value1"` description 1
 //   - `"value2"` description 2
 func (et *enumType) DescriptionLines() []string {
+	if len(et.Values) == 0 {
+		return nil
+	}
 	var lines []string
 	for _, value := range et.Values {
 		lines = append(lines, value.Description())

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -686,7 +686,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 		g.generateSimpleProperty(typeString, format)
 		if enumType, isEnum := g.enumContext.EnumType(m.Type); isEnum {
 			// original type is an enum, add "Enum: " and the values
-			g.Do("Enum: []interface{}{$.$}", strings.Join(enumType.ValueStrings(), ", "))
+			g.Do("Enum: []interface{}{$.$},\n", strings.Join(enumType.ValueStrings(), ", "))
 		}
 		g.Do("},\n},\n", nil)
 		return nil

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1658,7 +1658,8 @@ SchemaProps: spec.SchemaProps{`+"\n"+
 Default: "",
 Type: []string{"string"},
 Format: "",
-Enum: []interface{}{"a", "b"}},
+Enum: []interface{}{"a", "b"},
+},
 },
 "NoCommentEnum": {
 SchemaProps: spec.SchemaProps{`+"\n"+
@@ -1666,14 +1667,16 @@ SchemaProps: spec.SchemaProps{`+"\n"+
 Default: "",
 Type: []string{"string"},
 Format: "",
-Enum: []interface{}{"a", "b"}},
+Enum: []interface{}{"a", "b"},
+},
 },
 "OptionalEnum": {
 SchemaProps: spec.SchemaProps{`+"\n"+
 		"Description: \"Possible enum values:\\n - `\\\"a\\\"` is a.\\n - `\\\"b\\\"` is b.\","+`
 Type: []string{"string"},
 Format: "",
-Enum: []interface{}{"a", "b"}},
+Enum: []interface{}{"a", "b"},
+},
 },
 },
 Required: []string{"Value","NoCommentEnum"},


### PR DESCRIPTION
Tweaks to improve formatting of generated enums.

Noticed when rebuilding generated go files in https://github.com/kubernetes/kubernetes/pull/114869

cc @apelisse 