### PR TITLE
Revert content type change

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -178,9 +178,6 @@ func (o *OpenAPIService) RegisterOpenAPIVersionedService(servePath string, handl
 							return
 						}
 					}
-					contentType := accepts.Type + "/" + accepts.SubType
-					w.Header().Set("Content-Type", contentType)
-
 					// ETag must be enclosed in double quotes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
 					w.Header().Set("Etag", strconv.Quote(etag))
 					// ServeContent will take care of caching using eTag.

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -89,8 +89,8 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 			continue
 		}
 
-		if got := resp.Header.Get("Content-Type"); got != tc.expectedContentType {
-			t.Errorf("Content-Type: Unexpected content type, want: %v, got: %v", tc.expectedContentType, got)
+		if resp.Header.Get("Content-Type") != tc.expectedContentType {
+			t.Errorf("Content-Type: Unexpected content type, want: %v, got: %v", tc.expectedContentType, resp.Header.Get("Content-Type"))
 		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -51,23 +51,22 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 	client := server.Client()
 
 	tcs := []struct {
-		acceptHeader        string
-		respStatus          int
-		respBody            []byte
-		expectedContentType string
+		acceptHeader string
+		respStatus   int
+		respBody     []byte
 	}{
-		{"", 200, returnedJSON, "application/json"},
-		{"*/*", 200, returnedJSON, "application/json"},
-		{"application/*", 200, returnedJSON, "application/json"},
-		{"application/json", 200, returnedJSON, "application/json"},
-		{"test/test", 406, []byte{}, "application/json"},
-		{"application/test", 406, []byte{}, "application/json"},
-		{"application/test, */*", 200, returnedJSON, "application/json"},
-		{"application/test, application/json", 200, returnedJSON, "application/json"},
-		{"application/com.github.proto-openapi.spec.v2@v1.0+protobuf", 200, returnedPb, "application/com.github.proto-openapi.spec.v2@v1.0+protobuf"},
-		{"application/json, application/com.github.proto-openapi.spec.v2@v1.0+protobuf", 200, returnedJSON, "application/json"},
-		{"application/com.github.proto-openapi.spec.v2@v1.0+protobuf, application/json", 200, returnedPb, "application/com.github.proto-openapi.spec.v2@v1.0+protobuf"},
-		{"application/com.github.proto-openapi.spec.v2@v1.0+protobuf; q=0.5, application/json", 200, returnedJSON, "application/json"},
+		{"", 200, returnedJSON},
+		{"*/*", 200, returnedJSON},
+		{"application/*", 200, returnedJSON},
+		{"application/json", 200, returnedJSON},
+		{"test/test", 406, []byte{}},
+		{"application/test", 406, []byte{}},
+		{"application/test, */*", 200, returnedJSON},
+		{"application/test, application/json", 200, returnedJSON},
+		{"application/com.github.proto-openapi.spec.v2@v1.0+protobuf", 200, returnedPb},
+		{"application/json, application/com.github.proto-openapi.spec.v2@v1.0+protobuf", 200, returnedJSON},
+		{"application/com.github.proto-openapi.spec.v2@v1.0+protobuf, application/json", 200, returnedPb},
+		{"application/com.github.proto-openapi.spec.v2@v1.0+protobuf; q=0.5, application/json", 200, returnedJSON},
 	}
 
 	for _, tc := range tcs {
@@ -84,13 +83,6 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 
 		if resp.StatusCode != tc.respStatus {
 			t.Errorf("Accept: %v: Unexpected response status code, want: %v, got: %v", tc.acceptHeader, tc.respStatus, resp.StatusCode)
-		}
-		if resp.StatusCode != 200 {
-			continue
-		}
-
-		if resp.Header.Get("Content-Type") != tc.expectedContentType {
-			t.Errorf("Content-Type: Unexpected content type, want: %v, got: %v", tc.expectedContentType, resp.Header.Get("Content-Type"))
 		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Reverts https://github.com/kubernetes/kube-openapi/pull/333 since it breaks serving of the openapi doc in kubernetes (xref https://github.com/kubernetes/kubernetes/pull/114869#discussion_r1063439550 and https://github.com/kubernetes/kubernetes/pull/114869#issuecomment-1373127716)

The proto content type has an invalid subtype (`@` is not a valid character in mime subtypes) and gets rejected by the server when writing: https://github.com/kubernetes/kube-openapi/issues/354