### PR TITLE
Cleanup CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,16 @@ jobs:
     strategy:
       matrix:
         go: [ '1.19', '1.18', '1.x' ]
-        gostable: [true]
-        include:
-        - go: '1.x'
-          gostable: false
     steps:
-    - uses: actions/checkout@v2
-      with:
-        path: src/k8s.io/kube-openapi/
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: "${{ matrix.go }}"
-        stable: ${{ matrix.gostable }}"
 
     - name: Build
       run: |
-        cd ${GITHUB_WORKSPACE}/src/k8s.io/kube-openapi/
         go mod tidy && git diff --exit-code
         go build ./cmd/... ./pkg/...
     - name: Format
@@ -39,13 +31,12 @@ jobs:
         if [[ -n "${diff}" ]]; then echo "${diff}"; exit 1; fi
     - name: Test
       run: |
-        cd ${GITHUB_WORKSPACE}/src/k8s.io/kube-openapi/
-        GOPATH=${GITHUB_WORKSPACE} go test ./cmd/... ./pkg/...
+        go test ./cmd/... ./pkg/...
     - name: Run integration tests
       run: |
-        cd ${GITHUB_WORKSPACE}/src/k8s.io/kube-openapi/test/integration
+        cd test/integration
         go mod tidy && git diff --exit-code
-        GOPATH=${GITHUB_WORKSPACE} go test ./...
+        go test ./...
   required:
     # The name of the ci jobs above change based on the golang version.
     # Use this as a stable required job that depends on the above jobs.


### PR DESCRIPTION
- Update GitHub actions
- Remove duplicated entries in Go versions matrix:
  - '1.x' currently resolves to 'go1.19.4', just like '1.19'
  - `stable=false` option (which was [removed](https://github.com/actions/setup-go/pull/195) in actions/setup-go@v3) enabled the installation of pre-release Go versions (now possible without that option), but it does not install "tip" version of Go
  - Jobs '1.x' with gostable=true and gostable=false were therefore duplicates of '1.19'
- Use default checkout path and default GOPATH
