### PR TITLE
Move sanitize and fromMap to internal package

### DIFF
--- a/pkg/internal/serialization.go
+++ b/pkg/internal/serialization.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"github.com/go-openapi/jsonreference"
+)
+
+// JSONRefFromMap populates a json reference object if the map v contains a $ref key.
+func JSONRefFromMap(jsonRef *jsonreference.Ref, v map[string]interface{}) error {
+	if v == nil {
+		return nil
+	}
+	if vv, ok := v["$ref"]; ok {
+		if str, ok := vv.(string); ok {
+			ref, err := jsonreference.New(str)
+			if err != nil {
+				return err
+			}
+			*jsonRef = ref
+		}
+	}
+	return nil
+}
+
+// SanitizeExtensions sanitizes the input map such that non extension
+// keys (non x-*, X-*) keys are dropped from the map. Returns the new
+// modified map, or nil if the map is now empty.
+func SanitizeExtensions(e map[string]interface{}) map[string]interface{} {
+	for k := range e {
+		if !IsExtensionKey(k) {
+			delete(e, k)
+		}
+	}
+	if len(e) == 0 {
+		e = nil
+	}
+	return e
+}
+
+// IsExtensionKey returns true if the input string is of format x-* or X-*
+func IsExtensionKey(k string) bool {
+	return len(k) > 1 && (k[0] == 'x' || k[0] == 'X') && k[1] == '-'
+}

--- a/pkg/internal/serialization_test.go
+++ b/pkg/internal/serialization_test.go
@@ -1,0 +1,85 @@
+/*
+ Copyright 2023 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package internal
+
+import (
+	"github.com/go-openapi/jsonreference"
+	"reflect"
+	"testing"
+)
+
+func TestJSONRefFromMap(t *testing.T) {
+	testcases := []struct {
+		name            string
+		fromMap         map[string]interface{}
+		expectNil       bool
+		expectRefString string
+	}{
+		{
+			name:            "nil map",
+			expectRefString: "",
+		}, {
+			name:            "map with no $ref",
+			fromMap:         map[string]interface{}{"a": "b"},
+			expectRefString: "",
+		}, {
+			name:            "ref path",
+			fromMap:         map[string]interface{}{"$ref": "#/path"},
+			expectRefString: "#/path",
+		},
+	}
+
+	for _, tc := range testcases {
+		var tmp jsonreference.Ref
+		err := JSONRefFromMap(&tmp, tc.fromMap)
+		if err != nil {
+			t.Errorf("Expect no error from JSONRefMap %s, got error %v", tc.name, err)
+		}
+
+		if tmp.String() != tc.expectRefString {
+			t.Errorf("Expect jsonRef to be %s, got %s for %s", tc.expectRefString, tmp.String(), tc.name)
+		}
+
+	}
+}
+
+func TestSanitizeExtensions(t *testing.T) {
+	testcases := []struct {
+		in       map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			in:       map[string]interface{}{"a": "b", "x-extension": "foo"},
+			expected: map[string]interface{}{"x-extension": "foo"},
+		},
+		{
+			in:       map[string]interface{}{"a": "b"},
+			expected: nil,
+		},
+		{
+			in:       map[string]interface{}{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		e := SanitizeExtensions(tc.in)
+		if !reflect.DeepEqual(tc.expected, e) {
+			t.Errorf("Error: sanitize extensions does not match expected")
+		}
+	}
+}

--- a/pkg/validation/spec/header.go
+++ b/pkg/validation/spec/header.go
@@ -94,12 +94,8 @@ func (h *Header) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Dec
 
 	h.CommonValidations = x.CommonValidations
 	h.SimpleSchema = x.SimpleSchema
-	h.Extensions = x.Extensions
+	h.Extensions = internal.SanitizeExtensions(x.Extensions)
 	h.HeaderProps = x.HeaderProps
 
-	h.Extensions.sanitize()
-	if len(h.Extensions) == 0 {
-		h.Extensions = nil
-	}
 	return nil
 }

--- a/pkg/validation/spec/info.go
+++ b/pkg/validation/spec/info.go
@@ -89,17 +89,9 @@ func (e Extensions) GetObject(key string, out interface{}) error {
 	return nil
 }
 
-func (e Extensions) sanitize() {
-	for k := range e {
-		if !isExtensionKey(k) {
-			delete(e, k)
-		}
-	}
-}
-
 func (e Extensions) sanitizeWithExtra() (extra map[string]any) {
 	for k, v := range e {
-		if !isExtensionKey(k) {
+		if !internal.IsExtensionKey(k) {
 			if extra == nil {
 				extra = make(map[string]any)
 			}
@@ -108,10 +100,6 @@ func (e Extensions) sanitizeWithExtra() (extra map[string]any) {
 		}
 	}
 	return extra
-}
-
-func isExtensionKey(k string) bool {
-	return len(k) > 1 && (k[0] == 'x' || k[0] == 'X') && k[1] == '-'
 }
 
 // VendorExtensible composition block.
@@ -212,11 +200,7 @@ func (i *Info) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decod
 	if err := opts.UnmarshalNext(dec, &x); err != nil {
 		return err
 	}
-	x.Extensions.sanitize()
-	if len(x.Extensions) == 0 {
-		x.Extensions = nil
-	}
-	i.VendorExtensible.Extensions = x.Extensions
+	i.Extensions = internal.SanitizeExtensions(x.Extensions)
 	i.InfoProps = x.InfoProps
 	return nil
 }

--- a/pkg/validation/spec/items.go
+++ b/pkg/validation/spec/items.go
@@ -105,13 +105,10 @@ func (i *Items) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Deco
 	if err := i.Refable.Ref.fromMap(x.Extensions); err != nil {
 		return err
 	}
-	x.Extensions.sanitize()
-	if len(x.Extensions) == 0 {
-		x.Extensions = nil
-	}
+
 	i.CommonValidations = x.CommonValidations
 	i.SimpleSchema = x.SimpleSchema
-	i.VendorExtensible.Extensions = x.Extensions
+	i.Extensions = internal.SanitizeExtensions(x.Extensions)
 	return nil
 }
 

--- a/pkg/validation/spec/operation.go
+++ b/pkg/validation/spec/operation.go
@@ -96,11 +96,7 @@ func (o *Operation) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.
 	if err := opts.UnmarshalNext(dec, &x); err != nil {
 		return err
 	}
-	x.Extensions.sanitize()
-	if len(x.Extensions) == 0 {
-		x.Extensions = nil
-	}
-	o.VendorExtensible.Extensions = x.Extensions
+	o.Extensions = internal.SanitizeExtensions(x.Extensions)
 	o.OperationProps = OperationProps(x.OperationPropsNoMethods)
 	return nil
 }

--- a/pkg/validation/spec/parameter.go
+++ b/pkg/validation/spec/parameter.go
@@ -109,13 +109,9 @@ func (p *Parameter) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.
 	if err := p.Refable.Ref.fromMap(x.Extensions); err != nil {
 		return err
 	}
-	x.Extensions.sanitize()
-	if len(x.Extensions) == 0 {
-		x.Extensions = nil
-	}
 	p.CommonValidations = x.CommonValidations
 	p.SimpleSchema = x.SimpleSchema
-	p.VendorExtensible.Extensions = x.Extensions
+	p.Extensions = internal.SanitizeExtensions(x.Extensions)
 	p.ParamProps = x.ParamProps
 	return nil
 }

--- a/pkg/validation/spec/path_item.go
+++ b/pkg/validation/spec/path_item.go
@@ -70,18 +70,11 @@ func (p *PathItem) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.D
 	if err := opts.UnmarshalNext(dec, &x); err != nil {
 		return err
 	}
-
-	p.Extensions = x.Extensions
-	p.PathItemProps = x.PathItemProps
-
-	if err := p.Refable.Ref.fromMap(p.Extensions); err != nil {
+	if err := p.Refable.Ref.fromMap(x.Extensions); err != nil {
 		return err
 	}
-
-	p.Extensions.sanitize()
-	if len(p.Extensions) == 0 {
-		p.Extensions = nil
-	}
+	p.Extensions = internal.SanitizeExtensions(x.Extensions)
+	p.PathItemProps = x.PathItemProps
 
 	return nil
 }

--- a/pkg/validation/spec/paths.go
+++ b/pkg/validation/spec/paths.go
@@ -92,7 +92,7 @@ func (p *Paths) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Deco
 			}
 
 			switch k := tok.String(); {
-			case isExtensionKey(k):
+			case internal.IsExtensionKey(k):
 				ext = nil
 				if err := opts.UnmarshalNext(dec, &ext); err != nil {
 					return err

--- a/pkg/validation/spec/ref.go
+++ b/pkg/validation/spec/ref.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 
 	"github.com/go-openapi/jsonreference"
+
+	"k8s.io/kube-openapi/pkg/internal"
 )
 
 // Refable is a struct for things that accept a $ref property
@@ -149,19 +151,5 @@ func (r *Ref) UnmarshalJSON(d []byte) error {
 }
 
 func (r *Ref) fromMap(v map[string]interface{}) error {
-	if v == nil {
-		return nil
-	}
-
-	if vv, ok := v["$ref"]; ok {
-		if str, ok := vv.(string); ok {
-			ref, err := jsonreference.New(str)
-			if err != nil {
-				return err
-			}
-			*r = Ref{Ref: ref}
-		}
-	}
-
-	return nil
+	return internal.JSONRefFromMap(&r.Ref, v)
 }

--- a/pkg/validation/spec/response.go
+++ b/pkg/validation/spec/response.go
@@ -68,17 +68,11 @@ func (r *Response) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.D
 		return err
 	}
 
-	r.Extensions = x.Extensions
-	r.ResponseProps = x.ResponseProps
-
-	if err := r.Refable.Ref.fromMap(r.Extensions); err != nil {
+	if err := r.Refable.Ref.fromMap(x.Extensions); err != nil {
 		return err
 	}
-
-	r.Extensions.sanitize()
-	if len(r.Extensions) == 0 {
-		r.Extensions = nil
-	}
+	r.Extensions = internal.SanitizeExtensions(x.Extensions)
+	r.ResponseProps = x.ResponseProps
 
 	return nil
 }

--- a/pkg/validation/spec/responses.go
+++ b/pkg/validation/spec/responses.go
@@ -148,7 +148,7 @@ func (r *Responses) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.
 				return nil
 			}
 			switch k := tok.String(); {
-			case isExtensionKey(k):
+			case internal.IsExtensionKey(k):
 				ext = nil
 				if err := opts.UnmarshalNext(dec, &ext); err != nil {
 					return err

--- a/pkg/validation/spec/security_scheme.go
+++ b/pkg/validation/spec/security_scheme.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
 	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 )
 
@@ -72,11 +73,7 @@ func (s *SecurityScheme) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *js
 	if err := opts.UnmarshalNext(dec, &x); err != nil {
 		return err
 	}
-	x.Extensions.sanitize()
-	if len(x.Extensions) == 0 {
-		x.Extensions = nil
-	}
-	s.VendorExtensible.Extensions = x.Extensions
+	s.Extensions = internal.SanitizeExtensions(x.Extensions)
 	s.SecuritySchemeProps = x.SecuritySchemeProps
 	return nil
 }

--- a/pkg/validation/spec/swagger.go
+++ b/pkg/validation/spec/swagger.go
@@ -75,15 +75,8 @@ func (s *Swagger) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.De
 	if err := opts.UnmarshalNext(dec, &x); err != nil {
 		return err
 	}
-
-	s.Extensions = x.Extensions
+	s.Extensions = internal.SanitizeExtensions(x.Extensions)
 	s.SwaggerProps = x.SwaggerProps
-
-	s.Extensions.sanitize()
-	if len(s.Extensions) == 0 {
-		s.Extensions = nil
-	}
-
 	return nil
 }
 

--- a/pkg/validation/spec/tag.go
+++ b/pkg/validation/spec/tag.go
@@ -72,11 +72,7 @@ func (t *Tag) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decode
 	if err := opts.UnmarshalNext(dec, &x); err != nil {
 		return err
 	}
-	x.Extensions.sanitize()
-	if len(x.Extensions) == 0 {
-		x.Extensions = nil
-	}
-	t.VendorExtensible.Extensions = x.Extensions
+	t.Extensions = internal.SanitizeExtensions(x.Extensions)
 	t.TagProps = x.TagProps
 	return nil
 }


### PR DESCRIPTION
These functions are used in unmarshaling from both OpenAPI v2 and OpenAPI v3 and need to be accessed from the `pkg/spec3` package in order to use the go-json-experiment v2 marshaler for OpenAPI V3.

/cc @apelisse 
/cc @liggitt
/cc @alexzielenski 