### PR TITLE
remove use of embed so CRDs aren't pulled into vendor

### DIFF
--- a/pkg/schemaconv/openapi.go
+++ b/pkg/schemaconv/openapi.go
@@ -48,12 +48,15 @@ func ToSchemaFromOpenAPI(models map[string]*spec.Schema, preserveUnknownFields b
 		}
 
 		var a schema.Atom
-		if name == quantityResource || name == rawExtensionResource {
-			//!TODO: add support to the openapi schema to properly support these
-			// Hardcode both quantity and raw extension to use untyped schemas
+
+		// Hard-coded schemas for now as proto_models implementation functions.
+		// https://github.com/kubernetes/kube-openapi/issues/364
+		if name == quantityResource {
 			a = schema.Atom{
-				Scalar: ptr(schema.Scalar("untyped")),
+				Scalar: untypedDef.Atom.Scalar,
 			}
+		} else if name == rawExtensionResource {
+			a = untypedDef.Atom
 		} else {
 			c2 := c.push(name, &a)
 			c2.visitSpec(spec)


### PR DESCRIPTION
Does a few things from feedback when pulling into k8s:

- Remove todos in favor of issues
- Remove use of embed in test
- Make test blackbox instead of whitebox
- Ensure `RawExtension` and `Quantity` are the same for both protomodels and openapi implementations

/assign @apelisse 