### PR TITLE
Experimental unmarshal for OpenAPI V3

### DIFF
--- a/pkg/internal/flags.go
+++ b/pkg/internal/flags.go
@@ -18,7 +18,7 @@ package internal
 
 // Used by tests to selectively disable experimental JSON unmarshaler
 var UseOptimizedJSONUnmarshaling bool = true
-var UseOptimizedJSONUnmarshalingV3 bool = false
+var UseOptimizedJSONUnmarshalingV3 bool = true
 
 // Used by tests to selectively disable experimental JSON marshaler
 var UseOptimizedJSONMarshaling bool = true

--- a/pkg/spec3/benchmark_serialization_test.go
+++ b/pkg/spec3/benchmark_serialization_test.go
@@ -111,7 +111,7 @@ func BenchmarkOpenAPIV3Deserialize(b *testing.B) {
 			internal.UseOptimizedJSONUnmarshalingV3 = true
 			for i := 0; i < b2.N; i++ {
 				var result *OpenAPI
-				if err := result.CustomUnmarshalJSON(originalJSON); err != nil {
+				if err := result.UnmarshalJSON(originalJSON); err != nil {
 					b2.Fatal(err)
 				}
 			}

--- a/pkg/spec3/benchmark_serialization_test.go
+++ b/pkg/spec3/benchmark_serialization_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/kube-openapi/pkg/internal"
-	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -112,7 +111,7 @@ func BenchmarkOpenAPIV3Deserialize(b *testing.B) {
 			internal.UseOptimizedJSONUnmarshalingV3 = true
 			for i := 0; i < b2.N; i++ {
 				var result *OpenAPI
-				if err := jsonv2.Unmarshal(originalJSON, &result); err != nil {
+				if err := result.CustomUnmarshalJSON(originalJSON); err != nil {
 					b2.Fatal(err)
 				}
 			}

--- a/pkg/spec3/benchmark_serialization_test.go
+++ b/pkg/spec3/benchmark_serialization_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -105,16 +106,16 @@ func BenchmarkOpenAPIV3Deserialize(b *testing.B) {
 			}
 		})
 
-		// TODO: Enable this benchmark when jsonv2 is functional for OpenAPI V3.
-		// b.Run("jsonv2", func(b2 *testing.B) {
-		// b2.ReportAllocs()
-		// 	internal.UseOptimizedJSONUnmarshaling = true
-		// 	for i := 0; i < b2.N; i++ {
-		// 		var result OpenAPI
-		// 		if err := result.UnmarshalJSON(originalJSON); err != nil {
-		// 			b2.Fatal(err)
-		// 		}
-		// 	}
-		// })
+		b.Run("jsonv2", func(b2 *testing.B) {
+			b2.ReportAllocs()
+			internal.UseOptimizedJSONUnmarshaling = true
+			internal.UseOptimizedJSONUnmarshalingV3 = true
+			for i := 0; i < b2.N; i++ {
+				var result *OpenAPI
+				if err := jsonv2.Unmarshal(originalJSON, &result); err != nil {
+					b2.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/pkg/spec3/encoding_test.go
+++ b/pkg/spec3/encoding_test.go
@@ -21,9 +21,33 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestEncodingRoundtrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Encoding{
+				spec3.EncodingProps{
+					ContentType: "image/png",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Encoding{}))
+		})
+	}
+}
 
 func TestEncodingJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/example.go
+++ b/pkg/spec3/example.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
+
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -49,6 +52,9 @@ func (e *Example) MarshalJSON() ([]byte, error) {
 }
 
 func (e *Example) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, e)
+	}
 	if err := json.Unmarshal(data, &e.Refable); err != nil {
 		return err
 	}
@@ -58,6 +64,23 @@ func (e *Example) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &e.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (e *Example) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		ExampleProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	if err := internal.JSONRefFromMap(&e.Ref.Ref, x.Extensions); err != nil {
+		return err
+	}
+	e.Extensions = internal.SanitizeExtensions(x.Extensions)
+	e.ExampleProps = x.ExampleProps
+
 	return nil
 }
 

--- a/pkg/spec3/example_test.go
+++ b/pkg/spec3/example_test.go
@@ -21,8 +21,34 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestExampleRoundtrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Example{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.ExampleProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Example{}))
+		})
+	}
+}
 
 func TestExampleJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/external_documentation.go
+++ b/pkg/spec3/external_documentation.go
@@ -18,7 +18,10 @@ package spec3
 
 import (
 	"encoding/json"
+
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -48,11 +51,27 @@ func (e *ExternalDocumentation) MarshalJSON() ([]byte, error) {
 }
 
 func (e *ExternalDocumentation) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, e)
+	}
 	if err := json.Unmarshal(data, &e.ExternalDocumentationProps); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, &e.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (e *ExternalDocumentation) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		ExternalDocumentationProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	e.Extensions = internal.SanitizeExtensions(x.Extensions)
+	e.ExternalDocumentationProps = x.ExternalDocumentationProps
 	return nil
 }

--- a/pkg/spec3/external_documentation_test.go
+++ b/pkg/spec3/external_documentation_test.go
@@ -21,8 +21,33 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestExternalDocumentationRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.ExternalDocumentation{
+				spec3.ExternalDocumentationProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.ExternalDocumentation{}))
+		})
+	}
+}
 
 func TestExternalDocumentationJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/header.go
+++ b/pkg/spec3/header.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -50,6 +52,9 @@ func (h *Header) MarshalJSON() ([]byte, error) {
 }
 
 func (h *Header) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, h)
+	}
 	if err := json.Unmarshal(data, &h.Refable); err != nil {
 		return err
 	}
@@ -60,6 +65,22 @@ func (h *Header) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	return nil
+}
+
+func (h *Header) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		HeaderProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	if err := internal.JSONRefFromMap(&h.Ref.Ref, x.Extensions); err != nil {
+		return err
+	}
+	h.Extensions = internal.SanitizeExtensions(x.Extensions)
+	h.HeaderProps = x.HeaderProps
 	return nil
 }
 

--- a/pkg/spec3/header_test.go
+++ b/pkg/spec3/header_test.go
@@ -21,9 +21,34 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestHeaderRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Header{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.HeaderProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Header{}))
+		})
+	}
+}
 
 func TestHeaderJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/media_type.go
+++ b/pkg/spec3/media_type.go
@@ -18,7 +18,10 @@ package spec3
 
 import (
 	"encoding/json"
+
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -44,12 +47,29 @@ func (m *MediaType) MarshalJSON() ([]byte, error) {
 }
 
 func (m *MediaType) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, m)
+	}
 	if err := json.Unmarshal(data, &m.MediaTypeProps); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, &m.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (m *MediaType) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		MediaTypeProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	m.Extensions = internal.SanitizeExtensions(x.Extensions)
+	m.MediaTypeProps = x.MediaTypeProps
+
 	return nil
 }
 

--- a/pkg/spec3/media_type_test.go
+++ b/pkg/spec3/media_type_test.go
@@ -21,9 +21,33 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestMediaTypeRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.MediaType{
+				spec3.MediaTypeProps{
+					Example: "default",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.MediaType{}))
+		})
+	}
+}
 
 func TestMediaTypeJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/operation_test.go
+++ b/pkg/spec3/operation_test.go
@@ -20,11 +20,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/util/jsontesting"
-	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 

--- a/pkg/spec3/operation_test.go
+++ b/pkg/spec3/operation_test.go
@@ -20,10 +20,35 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/util/jsontesting"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestOperationRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Operation{
+				spec3.OperationProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Operation{}))
+		})
+	}
+}
 
 func TestOperationJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/parameter_test.go
+++ b/pkg/spec3/parameter_test.go
@@ -21,9 +21,34 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestParameterRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Parameter{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.ParameterProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Parameter{}))
+		})
+	}
+}
 
 func TestParameterJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/path.go
+++ b/pkg/spec3/path.go
@@ -87,7 +87,8 @@ func (p *Paths) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Deco
 	}
 	switch k := tok.Kind(); k {
 	case 'n':
-		return nil // noop
+		*p = Paths{}
+		return nil
 	case '{':
 		for {
 			tok, err := dec.ReadToken()

--- a/pkg/spec3/path.go
+++ b/pkg/spec3/path.go
@@ -18,9 +18,12 @@ package spec3
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -45,6 +48,9 @@ func (p *Paths) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON hydrates this items instance with the data from JSON
 func (p *Paths) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, p)
+	}
 	var res map[string]json.RawMessage
 	if err := json.Unmarshal(data, &res); err != nil {
 		return err
@@ -74,6 +80,58 @@ func (p *Paths) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (p *Paths) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	tok, err := dec.ReadToken()
+	if err != nil {
+		return err
+	}
+	switch k := tok.Kind(); k {
+	case 'n':
+		return nil // noop
+	case '{':
+		for {
+			tok, err := dec.ReadToken()
+			if err != nil {
+				return err
+			}
+
+			if tok.Kind() == '}' {
+				return nil
+			}
+
+			switch k := tok.String(); {
+			case internal.IsExtensionKey(k):
+				var ext any
+				if err := opts.UnmarshalNext(dec, &ext); err != nil {
+					return err
+				}
+
+				if p.Extensions == nil {
+					p.Extensions = make(map[string]any)
+				}
+				p.Extensions[k] = ext
+			case len(k) > 0 && k[0] == '/':
+				pi := Path{}
+				if err := opts.UnmarshalNext(dec, &pi); err != nil {
+					return err
+				}
+
+				if p.Paths == nil {
+					p.Paths = make(map[string]*Path)
+				}
+				p.Paths[k] = &pi
+			default:
+				_, err := dec.ReadValue() // skip value
+				if err != nil {
+					return err
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("unknown JSON kind: %v", k)
+	}
+}
+
 // Path describes the operations available on a single path, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject
 //
 // Note that this struct is actually a thin wrapper around PathProps to make it referable and extensible
@@ -101,6 +159,9 @@ func (p *Path) MarshalJSON() ([]byte, error) {
 }
 
 func (p *Path) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, p)
+	}
 	if err := json.Unmarshal(data, &p.Refable); err != nil {
 		return err
 	}
@@ -110,6 +171,24 @@ func (p *Path) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &p.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (p *Path) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		PathProps
+	}
+
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	if err := internal.JSONRefFromMap(&p.Ref.Ref, x.Extensions); err != nil {
+		return err
+	}
+	p.Extensions = internal.SanitizeExtensions(x.Extensions)
+	p.PathProps = x.PathProps
+
 	return nil
 }
 

--- a/pkg/spec3/path_test.go
+++ b/pkg/spec3/path_test.go
@@ -22,10 +22,35 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestPathRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Path{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.PathProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Path{}))
+		})
+	}
+}
 
 func TestPathJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/path_test.go
+++ b/pkg/spec3/path_test.go
@@ -18,9 +18,11 @@ package spec3_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -110,5 +112,18 @@ func TestPathJSONSerialization(t *testing.T) {
 				t.Fatalf("diff %s", cmp.Diff(serializedTarget, tc.expectedOutput))
 			}
 		})
+	}
+}
+
+func TestPathsNullUnmarshal(t *testing.T) {
+	nullByte := []byte(`null`)
+
+	expected := spec3.Paths{}
+	test := spec3.Paths{
+		Paths: map[string]*spec3.Path{"/path": {}},
+	}
+	jsonv2.Unmarshal(nullByte, &test)
+	if !reflect.DeepEqual(test, expected) {
+		t.Error("Expected unmarshal of null to reset the Paths struct")
 	}
 }

--- a/pkg/spec3/request_body.go
+++ b/pkg/spec3/request_body.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -50,6 +52,9 @@ func (r *RequestBody) MarshalJSON() ([]byte, error) {
 }
 
 func (r *RequestBody) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, r)
+	}
 	if err := json.Unmarshal(data, &r.Refable); err != nil {
 		return err
 	}
@@ -70,4 +75,20 @@ type RequestBodyProps struct {
 	Content map[string]*MediaType `json:"content,omitempty"`
 	// Required determines if the request body is required in the request
 	Required bool `json:"required,omitempty"`
+}
+
+func (r *RequestBody) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		RequestBodyProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	if err := internal.JSONRefFromMap(&r.Ref.Ref, x.Extensions); err != nil {
+		return err
+	}
+	r.Extensions = internal.SanitizeExtensions(x.Extensions)
+	r.RequestBodyProps = x.RequestBodyProps
+	return nil
 }

--- a/pkg/spec3/request_body_test.go
+++ b/pkg/spec3/request_body_test.go
@@ -21,9 +21,34 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestRequestBodyRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.RequestBody{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.RequestBodyProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.RequestBody{}))
+		})
+	}
+}
 
 func TestRequestBodyJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/response.go
+++ b/pkg/spec3/response.go
@@ -87,7 +87,7 @@ func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
 		return jsonv2.Unmarshal(data, r)
 	}
 	var res map[string]json.RawMessage
-		if err := json.Unmarshal(data, &res); err != nil {
+	if err := json.Unmarshal(data, &res); err != nil {
 		return err
 	}
 	if v, ok := res["default"]; ok {

--- a/pkg/spec3/response.go
+++ b/pkg/spec3/response.go
@@ -18,9 +18,12 @@ package spec3
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -46,13 +49,15 @@ func (r *Responses) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Responses) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, r)
+	}
 	if err := json.Unmarshal(data, &r.ResponsesProps); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, &r.VendorExtensible); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -78,8 +83,11 @@ func (r ResponsesProps) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals responses from JSON
 func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, r)
+	}
 	var res map[string]json.RawMessage
-	if err := json.Unmarshal(data, &res); err != nil {
+		if err := json.Unmarshal(data, &res); err != nil {
 		return err
 	}
 	if v, ok := res["default"]; ok {
@@ -104,6 +112,59 @@ func (r *ResponsesProps) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+
+func (r *Responses) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) (err error) {
+	tok, err := dec.ReadToken()
+	if err != nil {
+		return err
+	}
+	switch k := tok.Kind(); k {
+	case 'n':
+		return nil // noop
+	case '{':
+		for {
+			tok, err := dec.ReadToken()
+			if err != nil {
+				return err
+			}
+			if tok.Kind() == '}' {
+				return nil
+			}
+			switch k := tok.String(); {
+			case internal.IsExtensionKey(k):
+				var ext any
+				if err := opts.UnmarshalNext(dec, &ext); err != nil {
+					return err
+				}
+
+				if r.Extensions == nil {
+					r.Extensions = make(map[string]any)
+				}
+				r.Extensions[k] = ext
+			case k == "default":
+				resp := Response{}
+				if err := opts.UnmarshalNext(dec, &resp); err != nil {
+					return err
+				}
+				r.ResponsesProps.Default = &resp
+			default:
+				if nk, err := strconv.Atoi(k); err == nil {
+					resp := Response{}
+					if err := opts.UnmarshalNext(dec, &resp); err != nil {
+						return err
+					}
+
+					if r.StatusCodeResponses == nil {
+						r.StatusCodeResponses = map[int]*Response{}
+					}
+					r.StatusCodeResponses[nk] = &resp
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("unknown JSON kind: %v", k)
+	}
 }
 
 // Response describes a single response from an API Operation, more at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject
@@ -133,6 +194,9 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Response) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, r)
+	}
 	if err := json.Unmarshal(data, &r.Refable); err != nil {
 		return err
 	}
@@ -142,7 +206,22 @@ func (r *Response) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &r.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
 
+func (r *Response) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		ResponseProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	if err := internal.JSONRefFromMap(&r.Ref.Ref, x.Extensions); err != nil {
+		return err
+	}
+	r.Extensions = internal.SanitizeExtensions(x.Extensions)
+	r.ResponseProps = x.ResponseProps
 	return nil
 }
 
@@ -183,6 +262,9 @@ func (r *Link) MarshalJSON() ([]byte, error) {
 }
 
 func (r *Link) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, r)
+	}
 	if err := json.Unmarshal(data, &r.Refable); err != nil {
 		return err
 	}
@@ -193,6 +275,22 @@ func (r *Link) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	return nil
+}
+
+func (l *Link) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		LinkProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	if err := internal.JSONRefFromMap(&l.Ref.Ref, x.Extensions); err != nil {
+		return err
+	}
+	l.Extensions = internal.SanitizeExtensions(x.Extensions)
+	l.LinkProps = x.LinkProps
 	return nil
 }
 

--- a/pkg/spec3/response.go
+++ b/pkg/spec3/response.go
@@ -121,7 +121,8 @@ func (r *Responses) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.
 	}
 	switch k := tok.Kind(); k {
 	case 'n':
-		return nil // noop
+		*r = Responses{}
+		return nil
 	case '{':
 		for {
 			tok, err := dec.ReadToken()

--- a/pkg/spec3/response_test.go
+++ b/pkg/spec3/response_test.go
@@ -18,10 +18,12 @@ package spec3_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/spec3"
 	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -90,5 +92,20 @@ func TestResponseJSONSerialization(t *testing.T) {
 				t.Fatalf("diff %s", cmp.Diff(serializedTarget, tc.expectedOutput))
 			}
 		})
+	}
+}
+
+func TestResponsesNullUnmarshal(t *testing.T) {
+	nullByte := []byte(`null`)
+
+	expected := spec3.Responses{}
+	test := spec3.Responses{
+		ResponsesProps: spec3.ResponsesProps{
+			Default: &spec3.Response{},
+		},
+	}
+	jsonv2.Unmarshal(nullByte, &test)
+	if !reflect.DeepEqual(test, expected) {
+		t.Error("Expected unmarshal of null to reset the Responses struct")
 	}
 }

--- a/pkg/spec3/response_test.go
+++ b/pkg/spec3/response_test.go
@@ -54,6 +54,29 @@ func TestResponsesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestResponseRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Response{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.ResponseProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Response{}))
+		})
+	}
+}
+
 func TestResponseJSONSerialization(t *testing.T) {
 	cases := []struct {
 		name           string

--- a/pkg/spec3/security_scheme_test.go
+++ b/pkg/spec3/security_scheme_test.go
@@ -21,10 +21,35 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/kube-openapi/pkg/validation/spec"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestSecuritySchemeRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.SecurityScheme{
+				spec.Refable{Ref: spec.MustCreateRef("Dog")},
+				spec3.SecuritySchemeProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.SecurityScheme{}))
+		})
+	}
+}
 
 func TestSecuritySchemaJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/server.go
+++ b/pkg/spec3/server.go
@@ -18,7 +18,10 @@ package spec3
 
 import (
 	"encoding/json"
+
 	"github.com/go-openapi/swag"
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -50,12 +53,30 @@ func (s *Server) MarshalJSON() ([]byte, error) {
 }
 
 func (s *Server) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, s)
+	}
+
 	if err := json.Unmarshal(data, &s.ServerProps); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, &s.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (s *Server) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		ServerProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	s.Extensions = internal.SanitizeExtensions(x.Extensions)
+	s.ServerProps = x.ServerProps
+
 	return nil
 }
 
@@ -87,11 +108,28 @@ func (s *ServerVariable) MarshalJSON() ([]byte, error) {
 }
 
 func (s *ServerVariable) UnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, s)
+	}
 	if err := json.Unmarshal(data, &s.ServerVariableProps); err != nil {
 		return err
 	}
 	if err := json.Unmarshal(data, &s.VendorExtensible); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (s *ServerVariable) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Decoder) error {
+	var x struct {
+		spec.Extensions
+		ServerVariableProps
+	}
+	if err := opts.UnmarshalNext(dec, &x); err != nil {
+		return err
+	}
+	s.Extensions = internal.SanitizeExtensions(x.Extensions)
+	s.ServerVariableProps = x.ServerVariableProps
+
 	return nil
 }

--- a/pkg/spec3/server_test.go
+++ b/pkg/spec3/server_test.go
@@ -21,8 +21,34 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
 	"k8s.io/kube-openapi/pkg/spec3"
+	jsontesting "k8s.io/kube-openapi/pkg/util/jsontesting"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
+
+func TestServerRoundTrip(t *testing.T) {
+	cases := []jsontesting.RoundTripTestCase{
+		{
+			Name: "Basic Roundtrip",
+			Object: &spec3.Server{
+				spec3.ServerProps{
+					Description: "foo",
+				},
+				spec.VendorExtensible{Extensions: spec.Extensions{
+					"x-framework": "go-swagger",
+				}},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.Name, func(t *testing.T) {
+			require.NoError(t, tcase.RoundTripTest(&spec3.Server{}))
+		})
+	}
+}
 
 func TestServerJSONSerialization(t *testing.T) {
 	cases := []struct {

--- a/pkg/spec3/spec.go
+++ b/pkg/spec3/spec.go
@@ -17,6 +17,10 @@ limitations under the License.
 package spec3
 
 import (
+	"encoding/json"
+
+	"k8s.io/kube-openapi/pkg/internal"
+	jsonv2 "k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
@@ -34,4 +38,11 @@ type OpenAPI struct {
 	Components *Components `json:"components,omitempty"`
 	// ExternalDocs holds additional external documentation
 	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+}
+
+func (o *OpenAPI) CustomUnmarshalJSON(data []byte) error {
+	if internal.UseOptimizedJSONUnmarshalingV3 {
+		return jsonv2.Unmarshal(data, &o)
+	}
+	return json.Unmarshal(data, &o)
 }

--- a/pkg/spec3/spec.go
+++ b/pkg/spec3/spec.go
@@ -40,9 +40,11 @@ type OpenAPI struct {
 	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
 }
 
-func (o *OpenAPI) CustomUnmarshalJSON(data []byte) error {
+func (o *OpenAPI) UnmarshalJSON(data []byte) error {
+	type OpenAPIWithNoFunctions OpenAPI
+	p := (*OpenAPIWithNoFunctions)(o)
 	if internal.UseOptimizedJSONUnmarshalingV3 {
-		return jsonv2.Unmarshal(data, &o)
+		return jsonv2.Unmarshal(data, &p)
 	}
-	return json.Unmarshal(data, &o)
+	return json.Unmarshal(data, &p)
 }


### PR DESCRIPTION
Implement the experimental unmarshaler for OpenAPI V3.

Testing: `TestOpenAPIV3Deserialize` unmarshal the appsv1 and authorizationv1 OpenAPI specs via jsonv1 and jsonv2 and compares for equality.

Benchmarks:

Run `go test ./pkg/spec3/... -bench=BenchmarkOpenAPIV3Deserialize`

```
goos: linux
goarch: amd64
pkg: k8s.io/kube-openapi/pkg/spec3
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
BenchmarkOpenAPIV3Deserialize
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv1
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv1-24                        9         118930200 ns/op        17571548 B/op     208938 allocs/op
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv2_via_jsonv1_v2_partial_optimized
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv2_via_jsonv1_v2_partial_optimized-24                       10         100551076 ns/op        14432451 B/op     154751 allocs/op
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv2_via_jsonv1_full_optimized
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv2_via_jsonv1_full_optimized-24                             56          21943007 ns/op         5527198 B/op      27295 allocs/op
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv2
BenchmarkOpenAPIV3Deserialize/appsv1spec.json_jsonv2-24                                                       75          14364996 ns/op         5516345 B/op      26968 allocs/op
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv1
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv1-24                                             136           8863784 ns/op         1484916 B/op      16969 allocs/op
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv2_via_jsonv1_v2_partial_optimized
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv2_via_jsonv1_v2_partial_optimized-24                     181           6520713 ns/op         1100177 B/op      10570 allocs/op
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv2_via_jsonv1_full_optimized
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv2_via_jsonv1_full_optimized-24                           648           1881193 ns/op          539557 B/op       2571 allocs/op
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv2
BenchmarkOpenAPIV3Deserialize/authorizationv1spec.json_jsonv2-24                                                     969           1234902 ns/op          538057 B/op       2522 allocs/op
PASS
```

/cc @apelisse @alexzielenski 