### PR TITLE
spec: Fix missing field in v2 serialization

### DIFF
--- a/pkg/spec3/fuzz.go
+++ b/pkg/spec3/fuzz.go
@@ -1,9 +1,10 @@
 package spec3
 
 import (
-	fuzz "github.com/google/gofuzz"
 	"math/rand"
 	"strings"
+
+	fuzz "github.com/google/gofuzz"
 
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -182,11 +183,15 @@ var OpenAPIV3FuzzFuncs []interface{} = []interface{}{
 		c.Fuzz(&v.Description)
 		v.URL = "https://" + randAlphanumString()
 	},
+	func(v *spec.SchemaURL, c fuzz.Continue) {
+		*v = spec.SchemaURL("https://" + randAlphanumString())
+	},
 	func(v *spec.Schema, c fuzz.Continue) {
 		if c.Intn(refChance) == 0 {
 			c.Fuzz(&v.Ref)
 			return
 		}
+		c.Fuzz(&v.Schema)
 		c.Fuzz(&v.VendorExtensible)
 		c.Fuzz(&v.Description)
 		c.Fuzz(&v.Nullable)

--- a/pkg/spec3/fuzz.go
+++ b/pkg/spec3/fuzz.go
@@ -170,13 +170,12 @@ var OpenAPIV3FuzzFuncs []interface{} = []interface{}{
 		c.Fuzz(&v.VendorExtensible)
 	},
 	func(v *spec.Extensions, c fuzz.Continue) {
-		*v = spec.Extensions{}
 		numChildren := c.Intn(5)
-		if numChildren == 0 {
-			*v = nil
-		}
 		for i := 0; i < numChildren; i++ {
-			v.Add("x-"+randAlphanumString(), c.RandString()+"x")
+			if *v == nil {
+				*v = spec.Extensions{}
+			}
+			(*v)["x-"+c.RandString()] = c.RandString()
 		}
 	},
 	func(v *spec.ExternalDocumentation, c fuzz.Continue) {
@@ -186,70 +185,70 @@ var OpenAPIV3FuzzFuncs []interface{} = []interface{}{
 	func(v *spec.SchemaURL, c fuzz.Continue) {
 		*v = spec.SchemaURL("https://" + randAlphanumString())
 	},
+	func(v *spec.SchemaOrBool, c fuzz.Continue) {
+		*v = spec.SchemaOrBool{}
+
+		if c.RandBool() {
+			v.Allows = c.RandBool()
+		} else {
+			v.Schema = &spec.Schema{}
+			v.Allows = true
+			c.Fuzz(&v.Schema)
+		}
+	},
+	func(v *spec.SchemaOrArray, c fuzz.Continue) {
+		*v = spec.SchemaOrArray{}
+		if c.RandBool() {
+			schema := spec.Schema{}
+			c.Fuzz(&schema)
+			v.Schema = &schema
+		} else {
+			v.Schemas = []spec.Schema{}
+			numChildren := c.Intn(5)
+			for i := 0; i < numChildren; i++ {
+				schema := spec.Schema{}
+				c.Fuzz(&schema)
+				v.Schemas = append(v.Schemas, schema)
+			}
+
+		}
+
+	},
+	func(v *spec.SchemaOrStringArray, c fuzz.Continue) {
+		if c.RandBool() {
+			*v = spec.SchemaOrStringArray{}
+			if c.RandBool() {
+				c.Fuzz(&v.Property)
+			} else {
+				c.Fuzz(&v.Schema)
+			}
+		}
+	},
 	func(v *spec.Schema, c fuzz.Continue) {
 		if c.Intn(refChance) == 0 {
 			c.Fuzz(&v.Ref)
 			return
 		}
-		c.Fuzz(&v.Schema)
-		c.Fuzz(&v.VendorExtensible)
-		c.Fuzz(&v.Description)
-		c.Fuzz(&v.Nullable)
-		c.Fuzz(&v.Title)
-		c.Fuzz(&v.Required)
-		c.Fuzz(&v.ExternalDocs)
-		n := c.Intn(8)
-		switch n {
-		case 0:
-			// To prevent exponential growth from recursively generating properties, only allow the schema to be an object with low frequency
-			if c.Intn(5) == 0 {
-				c.Fuzz(&v.Properties)
-				c.Fuzz(&v.MinProperties)
-				c.Fuzz(&v.MaxProperties)
-			} else {
-				v.Type = spec.StringOrArray{"integer"}
-				switch c.Intn(3) {
-				case 0:
-					v.Format = "int32"
-				case 1:
-					v.Format = "int64"
-				}
-				c.Fuzz(&v.MultipleOf)
-				c.Fuzz(&v.Minimum)
-				c.Fuzz(&v.Maximum)
-				c.Fuzz(&v.ExclusiveMaximum)
-				c.Fuzz(&v.ExclusiveMinimum)
-			}
-		case 1:
-			v.Type = spec.StringOrArray{"number"}
-			switch c.Intn(3) {
-			case 0:
-				v.Format = "float"
-			case 1:
-				v.Format = "double"
-			}
-			c.Fuzz(&v.MultipleOf)
-			c.Fuzz(&v.ExclusiveMaximum)
-			c.Fuzz(&v.ExclusiveMinimum)
-			c.Fuzz(&v.Minimum)
-			c.Fuzz(&v.Maximum)
-		case 2:
-			v.Type = spec.StringOrArray{"string"}
-			c.Fuzz(&v.MinLength)
-			c.Fuzz(&v.MaxLength)
-		case 3:
-			v.Type = spec.StringOrArray{"boolean"}
-		case 4:
-			v.Type = spec.StringOrArray{"array"}
-			s := spec.Schema{}
-			c.Fuzz(&s)
-			v.Items = &spec.SchemaOrArray{Schema: &s}
-		case 5:
-			c.Fuzz(&v.AnyOf)
-		case 6:
-			c.Fuzz(&v.AllOf)
-		case 7:
-			c.Fuzz(&v.OneOf)
+		if c.RandBool() {
+			// file schema
+			c.Fuzz(&v.Default)
+			c.Fuzz(&v.Description)
+			c.Fuzz(&v.Example)
+			c.Fuzz(&v.ExternalDocs)
+
+			c.Fuzz(&v.Format)
+			c.Fuzz(&v.ReadOnly)
+			c.Fuzz(&v.Required)
+			c.Fuzz(&v.Title)
+			v.Type = spec.StringOrArray{"file"}
+
+		} else {
+			// normal schema
+			c.Fuzz(&v.SchemaProps)
+			c.Fuzz(&v.SwaggerSchemaProps)
+			c.Fuzz(&v.VendorExtensible)
+			c.Fuzz(&v.ExtraProps)
 		}
+
 	},
 }

--- a/pkg/util/jsontesting/json_roundtrip.go
+++ b/pkg/util/jsontesting/json_roundtrip.go
@@ -108,11 +108,6 @@ func (t RoundTripTestCase) RoundTripTest(example MarshalerUnmarshaler) error {
 		return fmt.Errorf("failed to marshal decoded value: %w", err)
 	}
 
-	reEncodedV2, err := example.MarshalJSON()
-	if err != nil {
-		return fmt.Errorf("failed to marshal decoded value with v2: %w", err)
-	}
-
 	// Check expected marshal error if it has not yet been checked
 	// (for case where JSON is provided, and object is not)
 	if testFinished, err := expectError(err, "marshal", t.ExpectedMarshalError); testFinished {
@@ -133,10 +128,6 @@ func (t RoundTripTestCase) RoundTripTest(example MarshalerUnmarshaler) error {
 
 	if !reflect.DeepEqual(expected, actual) {
 		return fmt.Errorf("expected equal values: %v", cmp.Diff(expected, actual))
-	}
-
-	if err := JsonCompare(reEncoded, reEncodedV2); err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/validation/spec/schema.go
+++ b/pkg/validation/spec/schema.go
@@ -523,6 +523,7 @@ func (s Schema) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder)
 		ArbitraryKeys
 		SchemaProps        schemaPropsOmitZero        `json:",inline"`
 		SwaggerSchemaProps swaggerSchemaPropsOmitZero `json:",inline"`
+		Schema             string                     `json:"$schema,omitempty"`
 		Ref                string                     `json:"$ref,omitempty"`
 	}
 	x.ArbitraryKeys = make(map[string]any, len(s.Extensions)+len(s.ExtraProps))
@@ -537,6 +538,7 @@ func (s Schema) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder)
 	x.SchemaProps = schemaPropsOmitZero(s.SchemaProps)
 	x.SwaggerSchemaProps = swaggerSchemaPropsOmitZero(s.SwaggerSchemaProps)
 	x.Ref = s.Ref.String()
+	x.Schema = string(s.Schema)
 	return opts.MarshalNext(enc, x)
 }
 

--- a/pkg/validation/spec/schema.go
+++ b/pkg/validation/spec/schema.go
@@ -624,7 +624,7 @@ func (s *Schema) UnmarshalNextJSON(opts jsonv2.UnmarshalOptions, dec *jsonv2.Dec
 	}
 
 	s.ExtraProps = x.Extensions.sanitizeWithExtra()
-	s.VendorExtensible.Extensions = x.Extensions
+	s.Extensions = internal.SanitizeExtensions(x.Extensions)
 	s.SchemaProps = x.SchemaProps
 	s.SwaggerSchemaProps = x.SwaggerSchemaProps
 	return nil

--- a/pkg/validation/spec/schema_test.go
+++ b/pkg/validation/spec/schema_test.go
@@ -27,6 +27,7 @@ var schema = Schema{
 	VendorExtensible: VendorExtensible{Extensions: map[string]interface{}{"x-framework": "go-swagger"}},
 	SchemaProps: SchemaProps{
 		Ref:              MustCreateRef("Cat"),
+		Schema:           "schemaURL",
 		Type:             []string{"string"},
 		Format:           "date",
 		Description:      "the description of this schema",
@@ -81,6 +82,7 @@ var schema = Schema{
 var schemaJSON = `{
 	"x-framework": "go-swagger",
   "$ref": "Cat",
+  "$schema": "schemaURL",
   "description": "the description of this schema",
   "maximum": 100,
   "minimum": 5,
@@ -155,6 +157,7 @@ func TestSchema(t *testing.T) {
 	actual2 := Schema{}
 	if assert.NoError(t, json.Unmarshal([]byte(schemaJSON), &actual2)) {
 		assert.Equal(t, schema.Ref, actual2.Ref)
+		assert.Equal(t, schema.Schema, actual2.Schema)
 		assert.Equal(t, schema.Description, actual2.Description)
 		assert.Equal(t, schema.Maximum, actual2.Maximum)
 		assert.Equal(t, schema.Minimum, actual2.Minimum)

--- a/pkg/validation/spec/swagger.go
+++ b/pkg/validation/spec/swagger.go
@@ -164,15 +164,15 @@ func (s *SchemaOrBool) UnmarshalJSON(data []byte) error {
 	}
 
 	var nw SchemaOrBool
-	if len(data) >= 4 {
-		if data[0] == '{' {
-			var sch Schema
-			if err := json.Unmarshal(data, &sch); err != nil {
-				return err
-			}
-			nw.Schema = &sch
+	if len(data) > 0 && data[0] == '{' {
+		var sch Schema
+		if err := json.Unmarshal(data, &sch); err != nil {
+			return err
 		}
-		nw.Allows = !(data[0] == 'f' && data[1] == 'a' && data[2] == 'l' && data[3] == 's' && data[4] == 'e')
+		nw.Schema = &sch
+		nw.Allows = true
+	} else {
+		json.Unmarshal(data, &nw.Allows)
 	}
 	*s = nw
 	return nil

--- a/pkg/validation/spec/swagger.go
+++ b/pkg/validation/spec/swagger.go
@@ -385,7 +385,7 @@ func (s SchemaOrArray) MarshalJSON() ([]byte, error) {
 	if internal.UseOptimizedJSONMarshaling {
 		return internal.DeterministicMarshal(s)
 	}
-	if len(s.Schemas) > 0 {
+	if s.Schemas != nil {
 		return json.Marshal(s.Schemas)
 	}
 	return json.Marshal(s.Schema)
@@ -393,7 +393,7 @@ func (s SchemaOrArray) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON converts this schema object or array into JSON structure
 func (s SchemaOrArray) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
-	if len(s.Schemas) > 0 {
+	if s.Schemas != nil {
 		return opts.MarshalNext(enc, s.Schemas)
 	}
 	return opts.MarshalNext(enc, s.Schema)

--- a/pkg/validation/spec/swagger_test.go
+++ b/pkg/validation/spec/swagger_test.go
@@ -229,6 +229,28 @@ func TestSwaggerSpec_Marshalv2FuzzedIsStable(t *testing.T) {
 	}
 }
 
+func TestUnmarshalAdditionalProperties(t *testing.T) {
+	cases := []string{
+		`{}`,
+		`{"description": "the description of this schema"}`,
+		`false`,
+		`true`,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			var v1, v2 SchemaOrBool
+			internal.UseOptimizedJSONUnmarshaling = true
+			require.NoError(t, json.Unmarshal([]byte(tc), &v2))
+			internal.UseOptimizedJSONUnmarshaling = false
+			require.NoError(t, json.Unmarshal([]byte(tc), &v1))
+			if !cmp.Equal(v1, v2, SwaggerDiffOptions...) {
+				t.Fatal(cmp.Diff(v1, v2, SwaggerDiffOptions...))
+			}
+		})
+	}
+}
+
 func TestSwaggerSpec_ExperimentalUnmarshal(t *testing.T) {
 	fuzzer := fuzz.
 		NewWithSeed(1646791953).

--- a/pkg/validation/spec/swagger_test.go
+++ b/pkg/validation/spec/swagger_test.go
@@ -274,16 +274,6 @@ func TestSwaggerSpec_ExperimentalUnmarshal(t *testing.T) {
 	actual := Swagger{}
 	internal.UseOptimizedJSONUnmarshaling = true
 
-	// Serialize into JSON again
-	jsonBytesV2, err := expected.MarshalJSON()
-	require.NoError(t, err)
-
-	t.Log("Specimen V2", string(jsonBytes))
-
-	if err := jsontesting.JsonCompare(jsonBytes, jsonBytesV2); err != nil {
-		t.Fatal(err)
-	}
-
 	err = json.Unmarshal(jsonBytes, &actual)
 	require.NoError(t, err)
 
@@ -298,12 +288,6 @@ func TestSwaggerSpec_ExperimentalUnmarshal(t *testing.T) {
 
 	if !reflect.DeepEqual(control, actual) {
 		t.Fatal(cmp.Diff(control, actual, SwaggerDiffOptions...))
-	}
-
-	newJsonBytes, err := json.Marshal(actual)
-	require.NoError(t, err)
-	if err := jsontesting.JsonCompare(jsonBytes, newJsonBytes); err != nil {
-		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
cc @Jefftree @alexzielenski @liggitt 

We should disallow certain fields if we want to in the schema fuzzer, not hard-code all the allowed fields, otherwise we might miss fields, or forget to update with new fields, but for now, this code and test properly show the failure and the fix. I've also tested this against k8s, and it fixes the problem properly.