### PR TITLE
Bump go version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-openapi
 
-go 1.18
+go 1.19
 
 require (
 	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46


### PR DESCRIPTION
Required after https://github.com/kubernetes/kube-openapi/pull/371 uses `atomic.Pointer`

Closes https://github.com/kubernetes/kube-openapi/issues/379