### PR TITLE
Fix x-kubernetes-validations and add OpenAPI value validations support

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -326,3 +326,7 @@ func GenerateOpenAPIV3OneOfSchema(types []string) (oneOf []spec.Schema) {
 func Int64Pointer(i int64) *int64 {
 	return &i
 }
+
+func Float64Pointer(f float64) *float64 {
+	return &f
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -322,3 +322,7 @@ func GenerateOpenAPIV3OneOfSchema(types []string) (oneOf []spec.Schema) {
 	}
 	return
 }
+
+func Int64Pointer(i int64) *int64 {
+	return &i
+}

--- a/pkg/generators/api_linter.go
+++ b/pkg/generators/api_linter.go
@@ -151,7 +151,7 @@ type apiViolation struct {
 	packageName string
 	typeName    string
 
-	// Optional: name of field that violates API rule. Empty fieldName implies that
+	// Optional: name of field that violates API rule. Empty goFieldName implies that
 	// the entire type violates the rule.
 	field string
 }

--- a/pkg/generators/extension.go
+++ b/pkg/generators/extension.go
@@ -21,18 +21,39 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/gengo/examples/set-gen/sets"
 	"k8s.io/gengo/types"
 )
 
 const extensionPrefix = "x-kubernetes-"
 
+// fieldSet is a map of field keys and values, but ordered purely to keep the code generator stable
+type fieldSet []field
+type field struct {
+	key, value string
+}
+
+// fieldExtractor is a function that extracts a fieldSet from each input string
+// E.g.
+// +mytag=a:1,b:2
+// +mytag=a:3,b:4
+//
+// Would result in:
+//
+//	[]fieldSet{
+//	  fieldSet{field{"a", "1"}, field{"b", "2"}},
+//	  fieldSet{field{"a", "3"}, field{"b", "4"}},
+//	}
+type fieldExtractor func([]string) ([]fieldSet, error)
+
 // extensionAttributes encapsulates common traits for particular extensions.
 type extensionAttributes struct {
-	xName         string
-	kind          types.Kind
-	allowedValues sets.String
-	enforceArray  bool
+	xName          string
+	kind           types.Kind
+	allowedValues  sets.String
+	enforceArray   bool
+	fieldExtractor fieldExtractor
 }
 
 // Extension tag to openapi extension attributes
@@ -67,16 +88,18 @@ var tagToExtension = map[string]extensionAttributes{
 		allowedValues: sets.NewString("atomic", "granular"),
 	},
 	"validations": {
-		xName: "x-kubernetes-validations",
-		kind:  types.Slice,
+		xName:          "x-kubernetes-validations",
+		enforceArray:   true,
+		fieldExtractor: validationsFieldExtractor,
 	},
 }
 
 // Extension encapsulates information necessary to generate an OpenAPI extension.
 type extension struct {
-	idlTag string   // Example: listType
-	xName  string   // Example: x-kubernetes-list-type
-	values []string // Example: [atomic]
+	idlTag      string   // Example: listType
+	xName       string   // Example: x-kubernetes-list-type
+	values      []string // Example: [atomic]
+	fieldValues []fieldSet
 }
 
 func (e extension) hasAllowedValues() bool {
@@ -177,11 +200,22 @@ func parseExtensions(comments []string) ([]extension, []error) {
 		if !exists {
 			continue
 		}
+
 		values := tagValues[idlTag]
+		var fieldValues []fieldSet
+		if xAttrs.fieldExtractor != nil {
+			var err error
+			fieldValues, err = xAttrs.fieldExtractor(values)
+			if err != nil {
+				errors = append(errors, err)
+			}
+			values = nil
+		}
 		e := extension{
-			idlTag: idlTag,       // listType
-			xName:  xAttrs.xName, // x-kubernetes-list-type
-			values: values,       // [atomic]
+			idlTag:      idlTag,       // listType
+			xName:       xAttrs.xName, // x-kubernetes-list-type
+			values:      values,       // [atomic]
+			fieldValues: fieldValues,
 		}
 		extensions = append(extensions, e)
 	}
@@ -199,4 +233,36 @@ func validateMemberExtensions(extensions []extension, m *types.Member) []error {
 		}
 	}
 	return errors
+}
+
+type ValidationRule struct {
+	Rule              string `yaml:"rule"`
+	Message           string `yaml:"message,omitempty"`
+	MessageExpression string `yaml:"messageExpression,omitempty"`
+}
+
+func (v ValidationRule) toFieldSet() fieldSet {
+	result := []field{{key: "rule", value: v.Rule}}
+	if len(v.Message) > 0 {
+		result = append(result, field{key: "message", value: v.Message})
+	}
+	if len(v.MessageExpression) > 0 {
+		result = append(result, field{key: "messageExpression", value: v.MessageExpression})
+	}
+	return result
+}
+
+func validationsFieldExtractor(rawStrings []string) ([]fieldSet, error) {
+	// TODO: Need a better parser so keys don't need to be quoted. Kubebuilder uses
+	// https://github.com/kubernetes-sigs/controller-tools/tree/master/pkg/markers
+	result := make([]fieldSet, len(rawStrings))
+	for i, raw := range rawStrings {
+		r := ValidationRule{}
+		err := yaml.Unmarshal([]byte("{"+raw+"}"), &r)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = r.toFieldSet()
+	}
+	return result, nil
 }

--- a/pkg/generators/extension.go
+++ b/pkg/generators/extension.go
@@ -215,7 +215,7 @@ func parseExtensions(comments []string) ([]extension, []error) {
 			idlTag:      idlTag,       // listType
 			xName:       xAttrs.xName, // x-kubernetes-list-type
 			values:      values,       // [atomic]
-			fieldValues: fieldValues,
+			fieldValues: fieldValues,  // 'rule':'x<y','message':'x must be less than y'
 		}
 		extensions = append(extensions, e)
 	}

--- a/pkg/generators/extension.go
+++ b/pkg/generators/extension.go
@@ -69,7 +69,7 @@ var tagToExtension = map[string]extensionAttributes{
 		kind:          types.Struct,
 		allowedValues: sets.NewString("atomic", "granular"),
 	},
-	"validations": {
+	"cel": {
 		xName:                 "x-kubernetes-validations",
 		enforceArray:          true,
 		isFieldValueExtension: true,

--- a/pkg/generators/extension_test.go
+++ b/pkg/generators/extension_test.go
@@ -91,8 +91,8 @@ func TestSingleTagExtension(t *testing.T) {
 			extensionValues: []string{"success"},
 		},
 		{
-			comments:      []string{`+validations=rule:"x > y",message:"This is a message",messageExpression:"'this is an expression'"`},
-			extensionTag:  "validations",
+			comments:      []string{`+cel=rule:"x > y",message:"This is a message",messageExpression:"'this is an expression'"`},
+			extensionTag:  "cel",
 			extensionName: "x-kubernetes-validations",
 			extensionFieldValues: []tags.FieldValue{
 				{

--- a/pkg/generators/extension_test.go
+++ b/pkg/generators/extension_test.go
@@ -23,6 +23,8 @@ import (
 
 	"k8s.io/gengo/examples/set-gen/sets"
 	"k8s.io/gengo/types"
+
+	"k8s.io/kube-openapi/pkg/generators/tags"
 )
 
 func TestSingleTagExtension(t *testing.T) {
@@ -33,7 +35,7 @@ func TestSingleTagExtension(t *testing.T) {
 		extensionTag         string
 		extensionName        string
 		extensionValues      []string
-		extensionFieldValues []fieldSet
+		extensionFieldValues []tags.FieldValue
 	}{
 		{
 			comments:        []string{"+patchMergeKey=name"},
@@ -89,36 +91,38 @@ func TestSingleTagExtension(t *testing.T) {
 			extensionValues: []string{"success"},
 		},
 		{
-			comments:      []string{"+validations='rule':'x > y','message':'This is a message','messageExpression':'\"this is an expression\"'"},
+			comments:      []string{`+validations=rule:"x > y",message:"This is a message",messageExpression:"'this is an expression'"`},
 			extensionTag:  "validations",
 			extensionName: "x-kubernetes-validations",
-			extensionFieldValues: []fieldSet{
+			extensionFieldValues: []tags.FieldValue{
 				{
-					field{key: "rule", value: "x > y"},
-					field{key: "message", value: "This is a message"},
-					field{key: "messageExpression", value: "\"this is an expression\""},
+					"rule":              "x > y",
+					"message":           "This is a message",
+					"messageExpression": "'this is an expression'",
 				},
 			},
 		},
 	}
 	for _, test := range tests {
-		extensions, _ := parseExtensions(test.comments)
-		actual := extensions[0]
-		if actual.idlTag != test.extensionTag {
-			t.Errorf("Extension Tag: expected (%s), actual (%s)\n", test.extensionTag, actual.idlTag)
-		}
-		if actual.xName != test.extensionName {
-			t.Errorf("Extension Name: expected (%s), actual (%s)\n", test.extensionName, actual.xName)
-		}
-		if !reflect.DeepEqual(actual.values, test.extensionValues) {
-			t.Errorf("Extension Values: expected (%s), actual (%s)\n", test.extensionValues, actual.values)
-		}
-		if !reflect.DeepEqual(actual.fieldValues, test.extensionFieldValues) {
-			t.Errorf("Extension Field Values: expected (%s), actual (%s)\n", test.extensionFieldValues, actual.fieldValues)
-		}
-		if actual.hasMultipleValues() {
-			t.Errorf("%s: hasMultipleValues() should be false\n", actual.xName)
-		}
+		t.Run(strings.Join(test.comments, "__"), func(t *testing.T) {
+			extensions, _ := parseExtensions(test.comments)
+			actual := extensions[0]
+			if actual.idlTag != test.extensionTag {
+				t.Errorf("Extension Tag: expected (%s), actual (%s)\n", test.extensionTag, actual.idlTag)
+			}
+			if actual.xName != test.extensionName {
+				t.Errorf("Extension Name: expected (%s), actual (%s)\n", test.extensionName, actual.xName)
+			}
+			if !reflect.DeepEqual(actual.values, test.extensionValues) {
+				t.Errorf("Extension Values: expected (%s), actual (%s)\n", test.extensionValues, actual.values)
+			}
+			if !reflect.DeepEqual(actual.fieldValues, test.extensionFieldValues) {
+				t.Errorf("Extension Field Values: expected (%s), actual (%s)\n", test.extensionFieldValues, actual.fieldValues)
+			}
+			if actual.hasMultipleValues() {
+				t.Errorf("%s: hasMultipleValues() should be false\n", actual.xName)
+			}
+		})
 	}
 
 }

--- a/pkg/generators/extension_test.go
+++ b/pkg/generators/extension_test.go
@@ -33,7 +33,7 @@ func TestSingleTagExtension(t *testing.T) {
 		extensionTag         string
 		extensionName        string
 		extensionValues      []string
-		extensionFieldValues []map[string]string
+		extensionFieldValues []fieldSet
 	}{
 		{
 			comments:        []string{"+patchMergeKey=name"},
@@ -89,13 +89,14 @@ func TestSingleTagExtension(t *testing.T) {
 			extensionValues: []string{"success"},
 		},
 		{
-			comments:      []string{"+validations='rule':'x > y','message':'This is a message'"},
+			comments:      []string{"+validations='rule':'x > y','message':'This is a message','messageExpression':'\"this is an expression\"'"},
 			extensionTag:  "validations",
 			extensionName: "x-kubernetes-validations",
-			extensionFieldValues: []map[string]string{
+			extensionFieldValues: []fieldSet{
 				{
-					"rule":    "x > y",
-					"message": "This is a message",
+					field{key: "rule", value: "x > y"},
+					field{key: "message", value: "This is a message"},
+					field{key: "messageExpression", value: "\"this is an expression\""},
 				},
 			},
 		},

--- a/pkg/generators/extension_test.go
+++ b/pkg/generators/extension_test.go
@@ -29,10 +29,11 @@ func TestSingleTagExtension(t *testing.T) {
 
 	// Comments only contain one tag extension and one value.
 	var tests = []struct {
-		comments        []string
-		extensionTag    string
-		extensionName   string
-		extensionValues []string
+		comments             []string
+		extensionTag         string
+		extensionName        string
+		extensionValues      []string
+		extensionFieldValues []map[string]string
 	}{
 		{
 			comments:        []string{"+patchMergeKey=name"},
@@ -87,6 +88,17 @@ func TestSingleTagExtension(t *testing.T) {
 			extensionName:   "x-kubernetes-member-success",
 			extensionValues: []string{"success"},
 		},
+		{
+			comments:      []string{"+validations='rule':'x > y','message':'This is a message'"},
+			extensionTag:  "validations",
+			extensionName: "x-kubernetes-validations",
+			extensionFieldValues: []map[string]string{
+				{
+					"rule":    "x > y",
+					"message": "This is a message",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		extensions, _ := parseExtensions(test.comments)
@@ -99,6 +111,9 @@ func TestSingleTagExtension(t *testing.T) {
 		}
 		if !reflect.DeepEqual(actual.values, test.extensionValues) {
 			t.Errorf("Extension Values: expected (%s), actual (%s)\n", test.extensionValues, actual.values)
+		}
+		if !reflect.DeepEqual(actual.fieldValues, test.extensionFieldValues) {
+			t.Errorf("Extension Field Values: expected (%s), actual (%s)\n", test.extensionFieldValues, actual.fieldValues)
 		}
 		if actual.hasMultipleValues() {
 			t.Errorf("%s: hasMultipleValues() should be false\n", actual.xName)

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -552,18 +552,18 @@ func (g openAPITypeWriter) emitExtensions(extensions []extension, unions []union
 				keys := make([]string, 0, len(fieldMap))
 				for k := range fieldMap {
 					keys = append(keys, k)
-					sort.Strings(keys) // output map into generated code in a consistent order
-					for _, k := range keys {
-						value := fieldMap[k]
-						var vStr string
-						switch v := value.(type) {
-						case string:
-							vStr = strconv.Quote(v)
-						default:
-							vStr = fmt.Sprintf("%v", value)
-						}
-						g.Do("$.key$: $.value$,\n", map[string]string{"key": strconv.Quote(k), "value": vStr})
+				}
+				sort.Strings(keys) // output map into generated code in a consistent order
+				for _, k := range keys {
+					value := fieldMap[k]
+					var vStr string
+					switch v := value.(type) {
+					case string:
+						vStr = strconv.Quote(v)
+					default:
+						vStr = fmt.Sprintf("%v", value)
 					}
+					g.Do("$.key$: $.value$,\n", map[string]string{"key": strconv.Quote(k), "value": vStr})
 				}
 
 				g.Do("},\n", nil)

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1708,10 +1708,10 @@ type Blah struct {
 	StringValue string
 	// +maximum=99.5
     // +minimum=55.5
+	// +exclusiveMaximum=true
+    // +exclusiveMinimum=true
     // +optional
 	IntValue int64
-	// +exclusiveMaximum=16.25
-    // +exclusiveMinimum=32.125
     // +multipleOf=2.5
     // +optional
 	IntValueExclusive int64
@@ -1737,9 +1737,9 @@ Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "StringValue": {
 SchemaProps: spec.SchemaProps{
+Pattern: ".+-.+",
 MinLength: common.Int64Pointer(1),
 MaxLength: common.Int64Pointer(10),
-Pattern: ".+-.+",
 Default: "",
 Type: []string{"string"},
 Format: "dnssubdomain",
@@ -1748,7 +1748,9 @@ Format: "dnssubdomain",
 "IntValue": {
 SchemaProps: spec.SchemaProps{
 Minimum: common.Float64Pointer(55.5),
+ExclusiveMinimum: true,
 Maximum: common.Float64Pointer(99.5),
+ExclusiveMaximum: true,
 Default: 0,
 Type: []string{"integer"},
 Format: "int64",
@@ -1756,8 +1758,6 @@ Format: "int64",
 },
 "IntValueExclusive": {
 SchemaProps: spec.SchemaProps{
-ExclusiveMinimum: common.Float64Pointer(32.125),
-ExclusiveMaximum: common.Float64Pointer(16.25),
 MultipleOf: common.Float64Pointer(2.5),
 Default: 0,
 Type: []string{"integer"},

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1738,8 +1738,8 @@ Properties: map[string]spec.Schema{
 "StringValue": {
 SchemaProps: spec.SchemaProps{
 Pattern: ".+-.+",
-MinLength: common.Int64Pointer(1),
 MaxLength: common.Int64Pointer(10),
+MinLength: common.Int64Pointer(1),
 Default: "",
 Type: []string{"string"},
 Format: "dnssubdomain",
@@ -1747,10 +1747,10 @@ Format: "dnssubdomain",
 },
 "IntValue": {
 SchemaProps: spec.SchemaProps{
-Minimum: common.Float64Pointer(55.5),
-ExclusiveMinimum: true,
 Maximum: common.Float64Pointer(99.5),
 ExclusiveMaximum: true,
+Minimum: common.Float64Pointer(55.5),
+ExclusiveMinimum: true,
 Default: 0,
 Type: []string{"integer"},
 Format: "int64",
@@ -1766,8 +1766,8 @@ Format: "int64",
 },
 "ArrayValue": {
 SchemaProps: spec.SchemaProps{
-MinItems: common.Int64Pointer(5),
 MaxItems: common.Int64Pointer(10),
+MinItems: common.Int64Pointer(5),
 Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
@@ -1782,8 +1782,8 @@ Format: "",
 },
 "MapValue": {
 SchemaProps: spec.SchemaProps{
-MinProperties: common.Int64Pointer(2),
 MaxProperties: common.Int64Pointer(4),
+MinProperties: common.Int64Pointer(2),
 Type: []string{"object"},
 AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1706,13 +1706,13 @@ type Blah struct {
     // +pattern=".+-.+"
     // +optional
 	StringValue string
-	// +maximum=100
-    // +minimum=50
+	// +maximum=99.5
+    // +minimum=55.5
     // +optional
 	IntValue int64
-	// +exclusiveMaximum=16
-    // +exclusiveMinimum=32
-    // +multipleOf=2
+	// +exclusiveMaximum=16.25
+    // +exclusiveMinimum=32.125
+    // +multipleOf=2.5
     // +optional
 	IntValueExclusive int64
     // +minItems=5
@@ -1747,8 +1747,8 @@ Format: "dnssubdomain",
 },
 "IntValue": {
 SchemaProps: spec.SchemaProps{
-Minimum: common.Int64Pointer(50),
-Maximum: common.Int64Pointer(100),
+Minimum: common.Float64Pointer(55.5),
+Maximum: common.Float64Pointer(99.5),
 Default: 0,
 Type: []string{"integer"},
 Format: "int64",
@@ -1756,9 +1756,9 @@ Format: "int64",
 },
 "IntValueExclusive": {
 SchemaProps: spec.SchemaProps{
-ExclusiveMinimum: common.Int64Pointer(32),
-ExclusiveMaximum: common.Int64Pointer(16),
-MultipleOf: common.Int64Pointer(2),
+ExclusiveMinimum: common.Float64Pointer(32.125),
+ExclusiveMaximum: common.Float64Pointer(16.25),
+MultipleOf: common.Float64Pointer(2.5),
 Default: 0,
 Type: []string{"integer"},
 Format: "int64",

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1819,7 +1819,7 @@ package foo
 // +k8s:openapi-gen=true
 // +k8s:openapi-gen=x-kubernetes-type-tag:validation_rule_test
 type Blah struct {
-	// +validations='rule':'a < b','message':'a must be less than b','messageExpression':'"a ("+string(a)+") must be less than b ("+string(b)+")"'
+	// +cel=rule:"a < b",message:"a must be less than b",messageExpression:"'a ('+string(a)+') must be less than b ('+string(b)+')'"
     // +optional
 	IntValue int64
 }`)
@@ -1841,9 +1841,9 @@ VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{
 "x-kubernetes-validations": []interface{}{
 map[string]string {
-"rule": "a < b",
 "message": "a must be less than b",
-"messageExpression": "\"a (\"+string(a)+\") must be less than b (\"+string(b)+\")\"",
+"messageExpression": "'a ('+string(a)+') must be less than b ('+string(b)+')'",
+"rule": "a < b",
 },
 },
 },

--- a/pkg/generators/tags/parser.go
+++ b/pkg/generators/tags/parser.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tags
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -55,13 +54,13 @@ func ParseFieldValues(in string) (FieldValue, error) {
 	s.Mode ^= scanner.SkipComments // disallow comments
 	s.Init(strings.NewReader(in))
 
-	var errs []error
+	var errs []string
 	s.Error = func(scanner *scanner.Scanner, msg string) {
-		errs = append(errs, fmt.Errorf("error parsing '%s' at %v: %s", in, scanner.Position, msg))
+		errs = append(errs, fmt.Errorf("error parsing '%s' at %v: %s", in, scanner.Position, msg).Error())
 	}
 	unexpectedTokenError := func(expected string, token string) (FieldValue, error) {
 		s.Error(&s, fmt.Sprintf("expected %s but got (%q)", expected, token))
-		return nil, errors.Join(errs...)
+		return nil, fmt.Errorf(strings.Join(errs, ", "))
 	}
 
 	for {

--- a/pkg/generators/tags/parser.go
+++ b/pkg/generators/tags/parser.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/scanner"
+)
+
+// FieldValue represents a IDL tag value with multiple fields.
+type FieldValue map[string]interface{}
+
+// ParseFieldValues parses an IDL tag value with multiple fields.
+// The value must be a comma separated list of fields. Each
+// field must be a ':' separated name and value pair.
+// The name must be a valid go identifier. The value may be
+// a string, number (integer of float), boolean or valid go
+// identifier. Strings may be quoted with double quotes or backticks
+// and adhere to go string escaping rules. Whitespace between tokens
+// is insignificant and allowed.
+//
+// The IDL tag value must be of the form:
+//
+//	<tag-field-values> ::= <field> | <tag-field-values> ',' <field>
+//	<field>            ::= <key> ':' <value>
+//	<key>              ::= IDENT
+//	<value>            ::= STRING | RAW_STRING | FLOAT | INT | BOOL | IDENT
+//
+// Examples:
+//
+//	rule:"a < b",message:"a must be less than b" // FieldValue{"rule": "a < b", "message": "a must be less than b"}
+//	arg1:100,arg2:"xyz",arg3:true, arg4:-1.5,arg5:Blue // FieldValue{"arg1": int64(100), "arg2": "xyz", "arg3": true, "arg4": float64(-1.5), "arg5": "Blue"}
+//
+// If an error is encountered during parsing, it is returned.
+func ParseFieldValues(in string) (FieldValue, error) {
+	fields := FieldValue{}
+	var s scanner.Scanner
+	s.Mode ^= scanner.SkipComments // disallow comments
+	s.Init(strings.NewReader(in))
+
+	var errs []error
+	s.Error = func(scanner *scanner.Scanner, msg string) {
+		errs = append(errs, fmt.Errorf("error parsing '%s' at %v: %s", in, scanner.Position, msg))
+	}
+	unexpectedTokenError := func(expected string, token string) (FieldValue, error) {
+		s.Error(&s, fmt.Sprintf("expected %s but got (%q)", expected, token))
+		return nil, errors.Join(errs...)
+	}
+
+	for {
+		var name string
+		var value interface{}
+		var err error
+
+		if s.Scan() != scanner.Ident {
+			return unexpectedTokenError("field name", s.TokenText())
+		}
+		name = s.TokenText()
+
+		if s.Scan() != ':' {
+			return unexpectedTokenError("','", s.TokenText())
+		}
+
+		token := s.Scan()
+		switch token {
+		case scanner.String, scanner.RawString:
+			value, err = strconv.Unquote(s.TokenText())
+			if err != nil {
+				return unexpectedTokenError(fmt.Sprintf("error parsing string: %s", err), s.TokenText())
+			}
+		case '-', scanner.Int, scanner.Float:
+			value, err = parseNumber(&s, token, unexpectedTokenError)
+			if err != nil {
+				return nil, err
+			}
+		case scanner.Ident:
+			switch s.TokenText() {
+			case "true":
+				value = true
+			case "false":
+				value = false
+			default:
+				value = s.TokenText()
+			}
+		default:
+			return unexpectedTokenError("field value", s.TokenText())
+		}
+
+		fields[name] = value
+
+		switch s.Scan() {
+		case ',':
+		case scanner.EOF:
+			return fields, nil
+		default:
+			return unexpectedTokenError("',' or end of tag", s.TokenText())
+		}
+	}
+}
+
+func parseNumber(s *scanner.Scanner, token rune, unexpectedTokenError func(expected string, token string) (FieldValue, error)) (interface{}, error) {
+	positive := true
+	if token == '-' {
+		positive = false
+		token = s.Scan()
+	}
+
+	switch token {
+	case scanner.Int:
+		i, err := strconv.ParseInt(s.TokenText(), 10, 64)
+		if err != nil {
+			return unexpectedTokenError(fmt.Sprintf("error parsing string: %s", err), s.TokenText())
+		}
+		if !positive {
+			i = -i
+		}
+		return i, nil
+	case scanner.Float:
+		f, err := strconv.ParseFloat(s.TokenText(), 64)
+		if err != nil {
+			return unexpectedTokenError(fmt.Sprintf("error parsing string: %s", err), s.TokenText())
+		}
+		if !positive {
+			f = -f
+		}
+		return f, nil
+	default:
+		return unexpectedTokenError("number", s.TokenText())
+	}
+}

--- a/pkg/generators/tags/parser_test.go
+++ b/pkg/generators/tags/parser_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFieldValuesParser(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected FieldValue
+		err      error
+	}{
+		{
+			name:  "multiple fields",
+			input: `rule:"a < b",message:"just no", messageExpression : "'some expression'"`,
+			expected: FieldValue{
+				"rule":              "a < b",
+				"message":           "just no",
+				"messageExpression": "'some expression'",
+			},
+		},
+		{
+			name:  "escaped string",
+			input: `f:"\"abc\""`,
+			expected: FieldValue{
+				"f": `"abc"`,
+			},
+		},
+		{
+			name:  "raw string value",
+			input: "f1:`backticks`",
+			expected: FieldValue{
+				"f1": "backticks",
+			},
+		},
+		{
+			name:  "ints",
+			input: "negative:-100,zero:0,positive:200",
+			expected: FieldValue{
+				"negative": int64(-100),
+				"zero":     int64(0),
+				"positive": int64(200),
+			},
+		},
+		{
+			name:  "floats",
+			input: "negative:-1.5,zero:0.0,positive:2.75",
+			expected: FieldValue{
+				"negative": -1.5,
+				"zero":     0.0,
+				"positive": 2.75,
+			},
+		},
+		{
+			name:  "booleans",
+			input: "true:true,false:false", // yes, this is allowed
+			expected: FieldValue{
+				"true":  true,
+				"false": false,
+			},
+		},
+		{
+			name:  "ident values",
+			input: "enum:MyEnumValue",
+			expected: FieldValue{
+				"enum": "MyEnumValue",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ParseFieldValues(tc.input)
+			if tc.err != nil {
+				if err == nil {
+					t.Fatalf("expected error %v but got none", tc.err)
+				}
+				if tc.err.Error() != err.Error() {
+					t.Fatalf("expected error %v but got err %v", tc.err, err)
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(out, tc.expected) {
+				t.Errorf("expected %+v but got %+v", tc.expected, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
TODO:

- [ ] Add 'reason' field to x-kuberenetes-validations so we can support 'required', 'forbidden', ...