### PR TITLE
Fix cache data race

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/NYTimes/gziphandler"
@@ -135,6 +136,9 @@ func RegisterOpenAPIVersionedService(spec *spec.Swagger, servePath string, handl
 
 // RegisterOpenAPIVersionedService registers a handler to provide access to provided swagger spec.
 func (o *OpenAPIService) RegisterOpenAPIVersionedService(servePath string, handler common.PathHandler) error {
+	// Mutex protects the cache chain
+	var mutex sync.Mutex
+
 	accepted := []struct {
 		Type                string
 		SubType             string
@@ -163,7 +167,9 @@ func (o *OpenAPIService) RegisterOpenAPIVersionedService(servePath string, handl
 						continue
 					}
 					// serve the first matching media type in the sorted clause list
+					mutex.Lock()
 					result := accepts.GetDataAndEtag.Get()
+					mutex.Unlock()
 					if result.Err != nil {
 						klog.Errorf("Error in OpenAPI handler: %s", result.Err)
 						// only return a 503 if we have no older cache data to serve


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/117363

Add lock to all cache get operations for OpenAPI V2. OpenAPI V3 is already handled with a [lock](https://github.com/kubernetes/kube-openapi/blob/master/pkg/handler3/handler.go#L168)