### PR TITLE
Remove empty error returned from registering OpenAPI

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -203,5 +203,5 @@ func BuildAndRegisterOpenAPIVersionedServiceFromRoutes(servePath string, routeCo
 	}
 	o := NewOpenAPIService(spec)
 	o.RegisterOpenAPIVersionedService(servePath, handler)
-	return nil, o
+	return o, nil
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -119,13 +119,14 @@ func ToProtoBinary(json []byte) ([]byte, error) {
 // RegisterOpenAPIVersionedService registers a handler to provide access to provided swagger spec.
 //
 // Deprecated: use OpenAPIService.RegisterOpenAPIVersionedService instead.
-func RegisterOpenAPIVersionedService(spec *spec.Swagger, servePath string, handler common.PathHandler) (*OpenAPIService, error) {
+func RegisterOpenAPIVersionedService(spec *spec.Swagger, servePath string, handler common.PathHandler) *OpenAPIService {
 	o := NewOpenAPIService(spec)
-	return o, o.RegisterOpenAPIVersionedService(servePath, handler)
+	o.RegisterOpenAPIVersionedService(servePath, handler)
+	return o
 }
 
 // RegisterOpenAPIVersionedService registers a handler to provide access to provided swagger spec.
-func (o *OpenAPIService) RegisterOpenAPIVersionedService(servePath string, handler common.PathHandler) error {
+func (o *OpenAPIService) RegisterOpenAPIVersionedService(servePath string, handler common.PathHandler) {
 	// Mutex protects the cache chain
 	var mutex sync.Mutex
 
@@ -183,8 +184,6 @@ func (o *OpenAPIService) RegisterOpenAPIVersionedService(servePath string, handl
 			return
 		}),
 	))
-
-	return nil
 }
 
 // BuildAndRegisterOpenAPIVersionedService builds the spec and registers a handler to provide access to it.
@@ -203,5 +202,6 @@ func BuildAndRegisterOpenAPIVersionedServiceFromRoutes(servePath string, routeCo
 		return nil, err
 	}
 	o := NewOpenAPIService(spec)
-	return o, o.RegisterOpenAPIVersionedService(servePath, handler)
+	o.RegisterOpenAPIVersionedService(servePath, handler)
+	return nil, o
 }

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -168,9 +168,7 @@ func TestUpdateSpecLazy(t *testing.T) {
 
 	mux := http.NewServeMux()
 	o := NewOpenAPIService(&s)
-	if err := o.RegisterOpenAPIVersionedService("/openapi/v2", mux); err != nil {
-		t.Errorf("Unexpected error in register OpenAPI versioned service: %v", err)
-	}
+	o.RegisterOpenAPIVersionedService("/openapi/v2", mux)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
@@ -219,9 +217,7 @@ func TestConcurrentReadStaleCache(t *testing.T) {
 
 	mux := http.NewServeMux()
 	o := NewOpenAPIService(&s)
-	if err := o.RegisterOpenAPIVersionedService("/openapi/v2", mux); err != nil {
-		t.Errorf("Unexpected error in register OpenAPI versioned service: %v", err)
-	}
+	o.RegisterOpenAPIVersionedService("/openapi/v2", mux)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -41,9 +41,7 @@ func TestRegisterOpenAPIVersionedService(t *testing.T) {
 
 	mux := http.NewServeMux()
 	o := NewOpenAPIService(&s)
-	if err := o.RegisterOpenAPIVersionedService("/openapi/v2", mux); err != nil {
-		t.Errorf("Unexpected error in register OpenAPI versioned service: %v", err)
-	}
+	o.RegisterOpenAPIVersionedService("/openapi/v2", mux)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 	client := server.Client()


### PR DESCRIPTION
We never return an error from registering the openapi so remove it from the function signature