### PR TITLE
Use new repo for protobuf library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/go-openapi/jsonreference v0.20.1
 	github.com/go-openapi/swag v0.22.3
-	github.com/golang/protobuf v1.5.2
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.5.5
 	github.com/google/gofuzz v1.1.0
@@ -33,6 +32,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v0.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/emicklei/go-restful/v3"
-	"github.com/golang/protobuf/proto"
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"github.com/google/uuid"
 	"github.com/munnerz/goautoneg"
+	"google.golang.org/protobuf/proto"
 	klog "k8s.io/klog/v2"
 	"k8s.io/kube-openapi/pkg/builder"
 	"k8s.io/kube-openapi/pkg/cached"

--- a/pkg/handler3/handler.go
+++ b/pkg/handler3/handler.go
@@ -29,10 +29,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	openapi_v3 "github.com/google/gnostic-models/openapiv3"
 	"github.com/google/uuid"
 	"github.com/munnerz/goautoneg"
+	"google.golang.org/protobuf/proto"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-openapi/pkg/cached"
 	"k8s.io/kube-openapi/pkg/common"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kube-openapi/issues/397

Per https://github.com/golang/protobuf#go-support-for-protocol-buffers, github.com/golang/protobuf is deprecated and superceded by google.golang.org/protobuf.

/assign @apelisse 
/cc @abhithmv



