### PR TITLE
generators: Default is a valid enum value

### DIFF
--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -75,6 +75,17 @@ func (et *enumType) ValueStrings() []string {
 	return values
 }
 
+// IsValue returns true if the given value is one of the possible enum
+// values.
+func (et *enumType) IsValid(val string) bool {
+	for _, value := range et.Values {
+		if val == fmt.Sprintf("%q", value.Value) {
+			return true
+		}
+	}
+	return false
+}
+
 // DescriptionLines returns a description of the enum in this format:
 //
 // Possible enum values:

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1632,10 +1632,10 @@ const EnumB EnumType = "b"
 // +k8s:openapi-gen=true
 // +k8s:openapi-gen=x-kubernetes-type-tag:type_test
 type Blah struct {
-  // Value is the value.
+	// Value is the value.
 	Value EnumType
 	NoCommentEnum EnumType
-  // +optional
+	// +optional
 	OptionalEnum *EnumType
 }`)
 	if callErr != nil {
@@ -1653,8 +1653,8 @@ Description: "Blah is a test.",
 Type: []string{"object"},
 Properties: map[string]spec.Schema{
 "Value": {
-SchemaProps: spec.SchemaProps{`+"\n"+
-		"Description: \"Value is the value.\\n\\nPossible enum values:\\n - `\\\"a\\\"` is a.\\n - `\\\"b\\\"` is b.\","+`
+SchemaProps: spec.SchemaProps{
+Description: "Value is the value.\n\nPossible enum values:\n - `+"`"+`\"a\"`+"`"+` is a.\n - `+"`"+`\"b\"`+"`"+` is b.",
 Default: "",
 Type: []string{"string"},
 Format: "",
@@ -1662,8 +1662,8 @@ Enum: []interface{}{"a", "b"},
 },
 },
 "NoCommentEnum": {
-SchemaProps: spec.SchemaProps{`+"\n"+
-		"Description: \"Possible enum values:\\n - `\\\"a\\\"` is a.\\n - `\\\"b\\\"` is b.\","+`
+SchemaProps: spec.SchemaProps{
+Description: "Possible enum values:\n - `+"`"+`\"a\"`+"`"+` is a.\n - `+"`"+`\"b\"`+"`"+` is b.",
 Default: "",
 Type: []string{"string"},
 Format: "",
@@ -1671,8 +1671,8 @@ Enum: []interface{}{"a", "b"},
 },
 },
 "OptionalEnum": {
-SchemaProps: spec.SchemaProps{`+"\n"+
-		"Description: \"Possible enum values:\\n - `\\\"a\\\"` is a.\\n - `\\\"b\\\"` is b.\","+`
+SchemaProps: spec.SchemaProps{
+Description: "Possible enum values:\n - `+"`"+`\"a\"`+"`"+` is a.\n - `+"`"+`\"b\"`+"`"+` is b.",
 Type: []string{"string"},
 Format: "",
 Enum: []interface{}{"a", "b"},

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1633,8 +1633,8 @@ const EnumB EnumType = "b"
 // +k8s:openapi-gen=x-kubernetes-type-tag:type_test
 type Blah struct {
 	// Value is the value.
-	Value EnumType
-	NoCommentEnum EnumType
+	// +default="b"
+	Value *EnumType
 	// +optional
 	OptionalEnum *EnumType
 }`)
@@ -1655,16 +1655,7 @@ Properties: map[string]spec.Schema{
 "Value": {
 SchemaProps: spec.SchemaProps{
 Description: "Value is the value.\n\nPossible enum values:\n - `+"`"+`\"a\"`+"`"+` is a.\n - `+"`"+`\"b\"`+"`"+` is b.",
-Default: "",
-Type: []string{"string"},
-Format: "",
-Enum: []interface{}{"a", "b"},
-},
-},
-"NoCommentEnum": {
-SchemaProps: spec.SchemaProps{
-Description: "Possible enum values:\n - `+"`"+`\"a\"`+"`"+` is a.\n - `+"`"+`\"b\"`+"`"+` is b.",
-Default: "",
+Default: "b",
 Type: []string{"string"},
 Format: "",
 Enum: []interface{}{"a", "b"},
@@ -1679,7 +1670,7 @@ Enum: []interface{}{"a", "b"},
 },
 },
 },
-Required: []string{"Value","NoCommentEnum"},
+Required: []string{"Value"},
 },
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -338,10 +338,10 @@ func schema_test_integration_testdata_enumtype_FruitsBasket(ref common.Reference
 					"content": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Possible enum values:\n - `\"apple\"` is the Apple\n - `\"banana\"` is the Banana\n - `\"onigiri\"` is the Rice ball that does not seem to belong to a fruits basket but has a long comment that is so long that it spans multiple lines",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-							Enum:        []interface{}{"apple", "banana", "onigiri"}},
+							Enum:        []interface{}{"apple", "banana", "onigiri"},
+						},
 					},
 					"count": {
 						SchemaProps: spec.SchemaProps{
@@ -351,7 +351,7 @@ func schema_test_integration_testdata_enumtype_FruitsBasket(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"content", "count"},
+				Required: []string{"count"},
 			},
 		},
 	}

--- a/test/integration/testdata/enumtype/enum.go
+++ b/test/integration/testdata/enumtype/enum.go
@@ -18,7 +18,8 @@ const FruitRiceBall FruitType = "onigiri"
 // FruitsBasket is the type that contains the enum type.
 // +k8s:openapi-gen=true
 type FruitsBasket struct {
-	Content FruitType `json:"content"`
+	// +optional
+	Content FruitType `json:"content,omitempty"`
 
 	// +default=0
 	Count int `json:"count"`


### PR DESCRIPTION
Fixes #395

This makes sure that the default value is part of the enum values, which makes sense. We shouldn't have a default that doesn't validate. There are probably a lot of other thing that don't exist right now but will exist in the future that we might want to validate for (maximum/minimum comes to mind). I'm also a little confused how we can have a default for a required value, we might want to disallow that.