### PR TITLE
Deduplicate parameters via references

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -91,16 +91,12 @@ func FilterSpecByPathsWithoutSideEffects(sp *spec.Swagger, keepPathPrefixes []st
 	return &ret
 }
 
-type rename struct {
-	from, to string
-}
-
-// renameDefinition renames references, without mutating the input.
+// renameDefinitions renames definition references, without mutating the input.
 // The output might share data structures with the input.
-func renameDefinition(s *spec.Swagger, renames map[string]string) *spec.Swagger {
-	refRenames := make(map[string]string, len(renames))
+func renameDefinitions(s *spec.Swagger, defRenames map[string]string) *spec.Swagger {
+	refRenames := make(map[string]string, len(defRenames))
 	foundOne := false
-	for k, v := range renames {
+	for k, v := range defRenames {
 		refRenames[definitionPrefix+k] = definitionPrefix + v
 		if _, ok := s.Definitions[k]; ok {
 			foundOne = true
@@ -125,7 +121,7 @@ func renameDefinition(s *spec.Swagger, renames map[string]string) *spec.Swagger 
 
 	renamedDefinitions := make(spec.Definitions, len(ret.Definitions))
 	for k, v := range ret.Definitions {
-		if newRef, found := renames[k]; found {
+		if newRef, found := defRenames[k]; found {
 			k = newRef
 		}
 		renamedDefinitions[k] = v
@@ -135,30 +131,70 @@ func renameDefinition(s *spec.Swagger, renames map[string]string) *spec.Swagger 
 	return ret
 }
 
+// renameDefinitions renames parameter references, without mutating the input.
+// The output might share data structures with the input.
+func renameParameters(s *spec.Swagger, renames map[string]string) *spec.Swagger {
+	refRenames := make(map[string]string, len(renames))
+	foundOne := false
+	for k, v := range renames {
+		refRenames[parameterPrefix+k] = parameterPrefix + v
+		if _, ok := s.Parameters[k]; ok {
+			foundOne = true
+		}
+	}
+
+	if !foundOne {
+		return s
+	}
+
+	ret := &spec.Swagger{}
+	*ret = *s
+
+	ret = schemamutation.ReplaceReferences(func(ref *spec.Ref) *spec.Ref {
+		refName := ref.String()
+		if newRef, found := refRenames[refName]; found {
+			ret := spec.MustCreateRef(newRef)
+			return &ret
+		}
+		return ref
+	}, ret)
+
+	renamed := make(map[string]spec.Parameter, len(ret.Parameters))
+	for k, v := range ret.Parameters {
+		if newRef, found := renames[k]; found {
+			k = newRef
+		}
+		renamed[k] = v
+	}
+	ret.Parameters = renamed
+
+	return ret
+}
+
 // MergeSpecsIgnorePathConflict is the same as MergeSpecs except it will ignore any path
 // conflicts by keeping the paths of destination. It will rename definition conflicts.
 // The source is not mutated.
 func MergeSpecsIgnorePathConflict(dest, source *spec.Swagger) error {
-	return mergeSpecs(dest, source, true, true)
+	return mergeSpecs(dest, source, true, true, true)
 }
 
 // MergeSpecsFailOnDefinitionConflict is differ from MergeSpecs as it fails if there is
 // a definition conflict.
 // The source is not mutated.
 func MergeSpecsFailOnDefinitionConflict(dest, source *spec.Swagger) error {
-	return mergeSpecs(dest, source, false, false)
+	return mergeSpecs(dest, source, false, true, false)
 }
 
 // MergeSpecs copies paths and definitions from source to dest, rename definitions if needed.
 // dest will be mutated, and source will not be changed. It will fail on path conflicts.
 // The source is not mutated.
 func MergeSpecs(dest, source *spec.Swagger) error {
-	return mergeSpecs(dest, source, true, false)
+	return mergeSpecs(dest, source, true, true, false)
 }
 
 // mergeSpecs merges source into dest while resolving conflicts.
 // The source is not mutated.
-func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, ignorePathConflicts bool) (err error) {
+func mergeSpecs(dest, source *spec.Swagger, renameModelConflicts, renameParameterConflicts, ignorePathConflicts bool) (err error) {
 	// Paths may be empty, due to [ACL constraints](http://goo.gl/8us55a#securityFiltering).
 	if source.Paths == nil {
 		// When a source spec does not have any path, that means none of the definitions
@@ -227,19 +263,71 @@ DEFINITIONLOOP:
 		renames[k] = newName
 		usedNames[newName] = true
 	}
-	source = renameDefinition(source, renames)
+	source = renameDefinitions(source, renames)
 
-	// now without conflict (modulo different GVKs), copy definitions to dest
+	// Check for parameter conflicts and rename to make parameters conflict-free
+	usedNames = map[string]bool{}
+	for k := range dest.Definitions {
+		usedNames[k] = true
+	}
+	renames = map[string]string{}
+PARAMETERLOOP:
+	for k, p := range source.Parameters {
+		existing, found := dest.Parameters[k]
+		if !found || reflect.DeepEqual(&existing, &p) {
+			// skip for now, we copy them after the rename loop
+			continue
+		}
+
+		if !renameParameterConflicts {
+			return fmt.Errorf("parameter name conflict in merging OpenAPI spec: %s", k)
+		}
+
+		// Reuse previously renamed parameter if one exists
+		var newName string
+		i := 1
+		for found {
+			i++
+			newName = fmt.Sprintf("%s_v%d", k, i)
+			existing, found = dest.Parameters[newName]
+			if found && reflect.DeepEqual(&existing, &p) {
+				renames[k] = newName
+				continue PARAMETERLOOP
+			}
+		}
+
+		_, foundInSource := source.Parameters[newName]
+		for usedNames[newName] || foundInSource {
+			i++
+			newName = fmt.Sprintf("%s_v%d", k, i)
+			_, foundInSource = source.Parameters[newName]
+		}
+		renames[k] = newName
+		usedNames[newName] = true
+	}
+	source = renameParameters(source, renames)
+
+	// Now without conflict (modulo different GVKs), copy definitions to dest
 	for k, v := range source.Definitions {
 		if existing, found := dest.Definitions[k]; !found {
 			if dest.Definitions == nil {
-				dest.Definitions = spec.Definitions{}
+				dest.Definitions = make(spec.Definitions, len(source.Definitions))
 			}
 			dest.Definitions[k] = v
 		} else if merged, changed, err := mergedGVKs(&existing, &v); err != nil {
 			return err
 		} else if changed {
 			existing.Extensions[gvkKey] = merged
+		}
+	}
+
+	// Now without conflict, copy parameters to dest
+	for k, v := range source.Parameters {
+		if _, found := dest.Parameters[k]; !found {
+			if dest.Parameters == nil {
+				dest.Parameters = make(map[string]spec.Parameter, len(source.Parameters))
+			}
+			dest.Parameters[k] = v
 		}
 	}
 

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"k8s.io/kube-openapi/pkg/handler"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"sigs.k8s.io/yaml"
@@ -253,7 +255,7 @@ definitions:
 
 func TestMergeSpecsSimple(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -269,6 +271,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
       responses:
         405:
           description: "Invalid input"
@@ -286,9 +289,15 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &spec1)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec1))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /othertest:
@@ -308,6 +317,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test2"
+      - $ref: "#/parameters/b"
 definitions:
   Test2:
     type: "object"
@@ -316,9 +326,15 @@ definitions:
         $ref: "#/definitions/Other"
   Other:
     type: "string"
-`), &spec2)
+parameters:
+  b:
+    in: query
+    name: b
+    schema:
+      $ref: "#/definitions/Test2"
+`), &spec2))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -334,6 +350,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
       responses:
         405:
           description: "Invalid input"
@@ -355,6 +372,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test2"
+      - $ref: "#/parameters/b"
 definitions:
   Test:
     type: "object"
@@ -375,20 +393,31 @@ definitions:
         $ref: "#/definitions/Other"
   Other:
     type: "string"
-`), &expected)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+      $ref: "#/definitions/Test"
+  b:
+    in: query
+    name: b
+    schema:
+      $ref: "#/definitions/Test2"
+`), &expected))
 
 	ast := assert.New(t)
 	orig_spec2, _ := cloneSpec(spec2)
 	if !ast.NoError(MergeSpecs(spec1, spec2)) {
 		return
 	}
-	ast.Equal(DebugSpec{expected}, DebugSpec{spec1})
-	ast.Equal(DebugSpec{orig_spec2}, DebugSpec{spec2}, "unexpected mutation of input")
+	ast.Equal(DebugSpec{expected}.String(), DebugSpec{spec1}.String())
+	ast.Equal(DebugSpec{orig_spec2}.String(), DebugSpec{spec2}.String(), "unexpected mutation of input")
 }
 
 func TestMergeSpecsEmptyDefinitions(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -405,9 +434,9 @@ paths:
       responses:
         405:
           description: "Invalid input"
-`), &spec1)
+`), &spec1))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /othertest:
@@ -435,9 +464,9 @@ definitions:
         $ref: "#/definitions/Other"
   Other:
     type: "string"
-`), &spec2)
+`), &spec2))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -479,7 +508,7 @@ definitions:
         $ref: "#/definitions/Other"
   Other:
     type: "string"
-`), &expected)
+`), &expected))
 
 	ast := assert.New(t)
 	orig_spec2, _ := cloneSpec(spec2)
@@ -592,7 +621,7 @@ definitions:
 
 func TestMergeSpecsReuseModel(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -608,6 +637,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
       responses:
         405:
           description: "Invalid input"
@@ -625,9 +655,15 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &spec1)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec1))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /othertest:
@@ -647,6 +683,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
 definitions:
   Test:
     type: "object"
@@ -660,9 +697,15 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &spec2)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec2))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -678,6 +721,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
       responses:
         405:
           description: "Invalid input"
@@ -699,6 +743,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
 definitions:
   Test:
     type: "object"
@@ -712,7 +757,13 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &expected)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &expected))
 
 	ast := assert.New(t)
 	orig_spec2, _ := cloneSpec(spec2)
@@ -725,7 +776,7 @@ definitions:
 
 func TestMergeSpecsRenameModel(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -741,6 +792,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
       responses:
         405:
           description: "Invalid input"
@@ -758,9 +810,15 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &spec1)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec1))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /othertest:
@@ -780,6 +838,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
 definitions:
   Test:
     description: "This Test has a description"
@@ -791,9 +850,15 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &spec2)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec2))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -809,6 +874,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
       responses:
         405:
           description: "Invalid input"
@@ -830,6 +896,7 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Test_v2"
+      - $ref: "#/parameters/a_v2"
 definitions:
   Test:
     type: "object"
@@ -850,7 +917,18 @@ definitions:
   InvalidInput:
     type: "string"
     format: "string"
-`), &expected)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+  a_v2:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test_v2"
+`), &expected))
 
 	ast := assert.New(t)
 	orig_spec2, _ := cloneSpec(spec2)
@@ -863,7 +941,7 @@ definitions:
 
 func TestMergeSpecsRenameModelWithExistingV2InDestination(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -872,21 +950,34 @@ paths:
       - name: "body"
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
   /testv2:
     post:
       parameters:
       - name: "body"
         schema:
           $ref: "#/definitions/Test_v2"
+      - $ref: "#/parameters/a_v2"
 definitions:
   Test:
     type: "object"
   Test_v2:
     description: "This is an existing Test_v2 in destination schema"
     type: "object"
-`), &spec1)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+  a_v2:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test_v2"
+`), &spec1))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /othertest:
@@ -895,13 +986,20 @@ paths:
       - name: "body"
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
 definitions:
   Test:
     description: "This Test has a description"
     type: "object"
-`), &spec2)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec2))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -910,18 +1008,21 @@ paths:
       - name: "body"
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
   /testv2:
     post:
       parameters:
       - name: "body"
         schema:
           $ref: "#/definitions/Test_v2"
+      - $ref: "#/parameters/a_v2"
   /othertest:
     post:
       parameters:
       - name: "body"
         schema:
           $ref: "#/definitions/Test_v3"
+      - $ref: "#/parameters/a_v3"
 definitions:
   Test:
     type: "object"
@@ -931,7 +1032,23 @@ definitions:
   Test_v3:
     description: "This Test has a description"
     type: "object"
-`), &expected)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+  a_v2:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test_v2"
+  a_v3:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test_v3"
+`), &expected))
 
 	ast := assert.New(t)
 	orig_spec2, _ := cloneSpec(spec2)
@@ -944,7 +1061,7 @@ definitions:
 
 func TestMergeSpecsRenameModelWithExistingV2InSource(t *testing.T) {
 	var spec1, spec2, expected *spec.Swagger
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -953,12 +1070,19 @@ paths:
       - name: "body"
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
 definitions:
   Test:
     type: "object"
-`), &spec1)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+`), &spec1))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /othertest:
@@ -967,12 +1091,14 @@ paths:
       - name: "body"
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
   /testv2:
     post:
       parameters:
       - name: "body"
         schema:
           $ref: "#/definitions/Test_v2"
+      - $ref: "#/parameters/a_v2"
 definitions:
   Test:
     description: "This Test has a description"
@@ -980,9 +1106,20 @@ definitions:
   Test_v2:
     description: "This is an existing Test_v2 in source schema"
     type: "object"
-`), &spec2)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+       $ref: "#/definitions/Test"
+  a_v2:
+    in: query
+    name: a
+    schema:
+      $ref: "#/definitions/Test_v2"
+`), &spec2))
 
-	yaml.Unmarshal([]byte(`
+	require.NoError(t, yaml.Unmarshal([]byte(`
 swagger: "2.0"
 paths:
   /test:
@@ -991,18 +1128,21 @@ paths:
       - name: "body"
         schema:
           $ref: "#/definitions/Test"
+      - $ref: "#/parameters/a"
   /testv2:
     post:
       parameters:
       - name: "body"
         schema:
           $ref: "#/definitions/Test_v2"
+      - $ref: "#/parameters/a_v2"
   /othertest:
     post:
       parameters:
       - name: "body"
         schema:
           $ref: "#/definitions/Test_v3"
+      - $ref: "#/parameters/a_v3"
 definitions:
   Test:
     type: "object"
@@ -1012,7 +1152,23 @@ definitions:
   Test_v3:
     description: "This Test has a description"
     type: "object"
-`), &expected)
+parameters:
+  a:
+    in: query
+    name: a
+    schema:
+      $ref: "#/definitions/Test"
+  a_v2:
+    in: query
+    name: a
+    schema:
+      $ref: "#/definitions/Test_v2"
+  a_v3:
+    in: query
+    name: a
+    schema:
+      $ref: "#/definitions/Test_v3"
+`), &expected))
 
 	ast := assert.New(t)
 	orig_spec2, _ := cloneSpec(spec2)

--- a/pkg/aggregator/walker.go
+++ b/pkg/aggregator/walker.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	definitionPrefix = "#/definitions/"
+	parameterPrefix  = "#/parameters/"
 )
 
 // Run a readonlyReferenceWalker method on all references of an OpenAPI spec

--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -152,7 +152,17 @@ func (o *openAPI) finalizeSwagger() (*spec.Swagger, error) {
 		}
 	}
 
-	return o.swagger, nil
+	sp := o.swagger
+	names, parameters, err := collectSharedParameters(sp)
+	if err != nil {
+		return nil, err
+	}
+
+	if sp.Parameters != nil {
+		return nil, fmt.Errorf("shared parameters already exist") // should not happen with the builder, but to be sure
+	}
+	sp.Parameters = parameters
+	return replaceSharedParameters(names, sp)
 }
 
 func (o *openAPI) buildDefinitionRecursively(name string) error {

--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -152,17 +152,7 @@ func (o *openAPI) finalizeSwagger() (*spec.Swagger, error) {
 		}
 	}
 
-	sp := o.swagger
-	names, parameters, err := collectSharedParameters(sp)
-	if err != nil {
-		return nil, err
-	}
-
-	if sp.Parameters != nil {
-		return nil, fmt.Errorf("shared parameters already exist") // should not happen with the builder, but to be sure
-	}
-	sp.Parameters = parameters
-	return replaceSharedParameters(names, sp)
+	return deduplicateParameters(o.swagger)
 }
 
 func (o *openAPI) buildDefinitionRecursively(name string) error {

--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -290,30 +290,13 @@ func getTestResponses() *spec.Responses {
 func getTestCommonParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 2)
 	ret[0] = spec.Parameter{
-		SimpleSchema: spec.SimpleSchema{
-			Type: "string",
-		},
-		ParamProps: spec.ParamProps{
-			Description: "path to the resource",
-			Name:        "path",
-			In:          "path",
-			Required:    true,
-		},
-		CommonValidations: spec.CommonValidations{
-			UniqueItems: true,
+		Refable: spec.Refable{
+			Ref: spec.MustCreateRef("#/parameters/path"),
 		},
 	}
 	ret[1] = spec.Parameter{
-		SimpleSchema: spec.SimpleSchema{
-			Type: "string",
-		},
-		ParamProps: spec.ParamProps{
-			Description: "If 'true', then the output is pretty printed.",
-			Name:        "pretty",
-			In:          "query",
-		},
-		CommonValidations: spec.CommonValidations{
-			UniqueItems: true,
+		Refable: spec.Refable{
+			Ref: spec.MustCreateRef("#/parameters/pretty"),
 		},
 	}
 	return ret
@@ -322,11 +305,8 @@ func getTestCommonParameters() []spec.Parameter {
 func getTestParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 1)
 	ret[0] = spec.Parameter{
-		ParamProps: spec.ParamProps{
-			Name:     "body",
-			In:       "body",
-			Required: true,
-			Schema:   getRefSchema("#/definitions/builder.TestInput"),
+		Refable: spec.Refable{
+			Ref: spec.MustCreateRef("#/parameters/body"),
 		},
 	}
 	return ret
@@ -335,37 +315,18 @@ func getTestParameters() []spec.Parameter {
 func getAdditionalTestParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 3)
 	ret[0] = spec.Parameter{
-		ParamProps: spec.ParamProps{
-			Name:     "body",
-			In:       "body",
-			Required: true,
-			Schema:   getRefSchema("#/definitions/builder.TestInput"),
+		Refable: spec.Refable{
+			Ref: spec.MustCreateRef("#/parameters/body"),
 		},
 	}
 	ret[1] = spec.Parameter{
-		ParamProps: spec.ParamProps{
-			Name:        "fparam",
-			Description: "a test form parameter",
-			In:          "formData",
-		},
-		SimpleSchema: spec.SimpleSchema{
-			Type: "number",
-		},
-		CommonValidations: spec.CommonValidations{
-			UniqueItems: true,
+		Refable: spec.Refable{
+			Ref: spec.MustCreateRef("#/parameters/fparam"),
 		},
 	}
 	ret[2] = spec.Parameter{
-		SimpleSchema: spec.SimpleSchema{
-			Type: "integer",
-		},
-		ParamProps: spec.ParamProps{
-			Description: "a test head parameter",
-			Name:        "hparam",
-			In:          "header",
-		},
-		CommonValidations: spec.CommonValidations{
-			UniqueItems: true,
+		Refable: spec.Refable{
+			Ref: spec.MustCreateRef("#/parameters/hparam"),
 		},
 	}
 	return ret
@@ -461,6 +422,69 @@ func TestBuildOpenAPISpec(t *testing.T) {
 			Definitions: spec.Definitions{
 				"builder.TestInput":  getTestInputDefinition(),
 				"builder.TestOutput": getTestOutputDefinition(),
+			},
+			Parameters: map[string]spec.Parameter{
+				"body": {
+					ParamProps: spec.ParamProps{
+						In:       "body",
+						Name:     "body",
+						Required: true,
+						Schema:   getRefSchema("#/definitions/builder.TestInput"),
+					},
+				},
+				"fparam": {
+					CommonValidations: spec.CommonValidations{
+						UniqueItems: true,
+					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "number",
+					},
+					ParamProps: spec.ParamProps{
+						In:          "formData",
+						Name:        "fparam",
+						Description: "a test form parameter",
+					},
+				},
+				"hparam": {
+					CommonValidations: spec.CommonValidations{
+						UniqueItems: true,
+					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "integer",
+					},
+					ParamProps: spec.ParamProps{
+						In:          "header",
+						Name:        "hparam",
+						Description: "a test head parameter",
+					},
+				},
+				"path": {
+					CommonValidations: spec.CommonValidations{
+						UniqueItems: true,
+					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "string",
+					},
+					ParamProps: spec.ParamProps{
+						In:          "path",
+						Name:        "path",
+						Description: "path to the resource",
+						Required:    true,
+					},
+				},
+				"pretty": {
+					CommonValidations: spec.CommonValidations{
+						UniqueItems: true,
+					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "string",
+					},
+					ParamProps: spec.ParamProps{
+						In:          "query",
+						Name:        "pretty",
+						Description: "If 'true', then the output is pretty printed.",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/stretchr/testify/assert"
+
 	openapi "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -291,12 +292,12 @@ func getTestCommonParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 2)
 	ret[0] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/path"),
+			Ref: spec.MustCreateRef("#/parameters/path-Xf6bMocQ"),
 		},
 	}
 	ret[1] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/pretty"),
+			Ref: spec.MustCreateRef("#/parameters/pretty-QYJ-1x8O"),
 		},
 	}
 	return ret
@@ -306,7 +307,7 @@ func getTestParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 1)
 	ret[0] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/body"),
+			Ref: spec.MustCreateRef("#/parameters/body-GU9eI1QU"),
 		},
 	}
 	return ret
@@ -316,17 +317,17 @@ func getAdditionalTestParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 3)
 	ret[0] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/body"),
+			Ref: spec.MustCreateRef("#/parameters/body-GU9eI1QU"),
 		},
 	}
 	ret[1] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/fparam"),
+			Ref: spec.MustCreateRef("#/parameters/fparam-5GSylsE3"),
 		},
 	}
 	ret[2] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/hparam"),
+			Ref: spec.MustCreateRef("#/parameters/hparam-XbFNLzps"),
 		},
 	}
 	return ret
@@ -424,7 +425,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 				"builder.TestOutput": getTestOutputDefinition(),
 			},
 			Parameters: map[string]spec.Parameter{
-				"body": {
+				"body-GU9eI1QU": {
 					ParamProps: spec.ParamProps{
 						In:       "body",
 						Name:     "body",
@@ -432,7 +433,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Schema:   getRefSchema("#/definitions/builder.TestInput"),
 					},
 				},
-				"fparam": {
+				"fparam-5GSylsE3": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},
@@ -445,7 +446,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Description: "a test form parameter",
 					},
 				},
-				"hparam": {
+				"hparam-XbFNLzps": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},
@@ -458,7 +459,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Description: "a test head parameter",
 					},
 				},
-				"path": {
+				"path-Xf6bMocQ": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},
@@ -472,7 +473,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Required:    true,
 					},
 				},
-				"pretty": {
+				"pretty-QYJ-1x8O": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},

--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -306,8 +306,11 @@ func getTestCommonParameters() []spec.Parameter {
 func getTestParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 1)
 	ret[0] = spec.Parameter{
-		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/body-GU9eI1QU"),
+		ParamProps: spec.ParamProps{
+			In:       "body",
+			Name:     "body",
+			Required: true,
+			Schema:   getRefSchema("#/definitions/builder.TestInput"),
 		},
 	}
 	return ret
@@ -316,8 +319,11 @@ func getTestParameters() []spec.Parameter {
 func getAdditionalTestParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 3)
 	ret[0] = spec.Parameter{
-		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/body-GU9eI1QU"),
+		ParamProps: spec.ParamProps{
+			In:       "body",
+			Name:     "body",
+			Required: true,
+			Schema:   getRefSchema("#/definitions/builder.TestInput"),
 		},
 	}
 	ret[1] = spec.Parameter{
@@ -425,14 +431,6 @@ func TestBuildOpenAPISpec(t *testing.T) {
 				"builder.TestOutput": getTestOutputDefinition(),
 			},
 			Parameters: map[string]spec.Parameter{
-				"body-GU9eI1QU": {
-					ParamProps: spec.ParamProps{
-						In:       "body",
-						Name:     "body",
-						Required: true,
-						Schema:   getRefSchema("#/definitions/builder.TestInput"),
-					},
-				},
 				"fparam-5GSylsE3": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,

--- a/pkg/builder/parameters.go
+++ b/pkg/builder/parameters.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+var minimumSharedParameterCount = 10 // should be more than number of verbs
+
+// collectSharedParameters finds those parameters that show up often and hence can be
+// shared across all the paths to save space.
+func collectSharedParameters(sp *spec.Swagger) (namesByJSON map[string]string, ret map[string]spec.Parameter, err error) {
+
+	if sp == nil || sp.Paths == nil {
+		return nil, nil, nil
+	}
+
+	countsByJSON := map[string]int{}
+	shared := map[string]spec.Parameter{}
+	var keys []string
+
+	for _, path := range sp.Paths.Paths {
+		// per operation parameters
+		for _, op := range []*spec.Operation{path.Get, path.Put, path.Post, path.Delete, path.Options, path.Head, path.Patch} {
+			if op == nil {
+				continue
+			}
+			for _, p := range op.Parameters {
+				if p.Ref.String() != "" {
+					// shouldn't happen, but ignore if it does
+					continue
+				}
+
+				bs, err := json.Marshal(p)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				countsByJSON[string(bs)]++
+				if count := countsByJSON[string(bs)]; count == minimumSharedParameterCount {
+					shared[string(bs)] = p
+					keys = append(keys, string(bs))
+				}
+			}
+		}
+
+		// per path parameters
+		for _, p := range path.Parameters {
+			if p.Ref.String() != "" {
+				// shouldn't happen, but ignore if it does
+				continue
+			}
+
+			bs, err := json.Marshal(p)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			countsByJSON[string(bs)]++
+			if count := countsByJSON[string(bs)]; count == minimumSharedParameterCount {
+				shared[string(bs)] = p
+				keys = append(keys, string(bs))
+			}
+		}
+	}
+
+	// name deterministically
+	sort.Strings(keys)
+	ret = map[string]spec.Parameter{}
+	namesByJSON = map[string]string{}
+	for _, k := range keys {
+		name := shared[k].Name
+		if name == "" {
+			name = "param"
+		}
+		i := 0
+		for {
+			if _, ok := ret[name]; !ok {
+				ret[name] = shared[k]
+				namesByJSON[k] = name
+				break
+			}
+			i++
+			name = shared[k].Name + "-" + strconv.Itoa(i)
+		}
+	}
+
+	return namesByJSON, ret, nil
+}
+
+func replaceSharedParameters(sharedParameterNamesByJSON map[string]string, sp *spec.Swagger) (*spec.Swagger, error) {
+	if sp == nil || sp.Paths == nil {
+		return sp, nil
+	}
+
+	ret := sp
+
+	firstPathChange := true
+	for k, path := range sp.Paths.Paths {
+		pathChanged := false
+
+		// per operation parameters
+		for _, op := range []**spec.Operation{&path.Get, &path.Put, &path.Post, &path.Delete, &path.Options, &path.Head, &path.Patch} {
+			if *op == nil {
+				continue
+			}
+
+			firstParamChange := true
+			for i := range (*op).Parameters {
+				p := (*op).Parameters[i]
+
+				if p.Ref.String() != "" {
+					// shouldn't happen, but be idem-potent if it does
+					continue
+				}
+
+				bs, err := json.Marshal(p)
+				if err != nil {
+					return nil, err
+				}
+
+				if name, ok := sharedParameterNamesByJSON[string(bs)]; ok {
+					if firstParamChange {
+						orig := *op
+						*op = &spec.Operation{}
+						**op = *orig
+						(*op).Parameters = make([]spec.Parameter, len(orig.Parameters))
+						copy((*op).Parameters, orig.Parameters)
+						firstParamChange = false
+					}
+
+					(*op).Parameters[i] = spec.Parameter{
+						Refable: spec.Refable{
+							Ref: spec.MustCreateRef("#/parameters/" + name),
+						},
+					}
+					pathChanged = true
+				}
+			}
+		}
+
+		// per path parameters
+		firstParamChange := true
+		for i := range path.Parameters {
+			p := path.Parameters[i]
+
+			if p.Ref.String() != "" {
+				// shouldn't happen, but be idem-potent if it does
+				continue
+			}
+
+			bs, err := json.Marshal(p)
+			if err != nil {
+				return nil, err
+			}
+
+			if name, ok := sharedParameterNamesByJSON[string(bs)]; ok {
+				if firstParamChange {
+					orig := path.Parameters
+					path.Parameters = make([]spec.Parameter, len(orig))
+					copy(path.Parameters, orig)
+					firstParamChange = false
+				}
+
+				path.Parameters[i] = spec.Parameter{
+					Refable: spec.Refable{
+						Ref: spec.MustCreateRef("#/parameters/" + name),
+					},
+				}
+				pathChanged = true
+			}
+		}
+
+		if pathChanged {
+			if firstPathChange {
+				clone := *sp
+				ret = &clone
+
+				pathsClone := *ret.Paths
+				ret.Paths = &pathsClone
+
+				ret.Paths.Paths = make(map[string]spec.PathItem, len(sp.Paths.Paths))
+				for k, v := range sp.Paths.Paths {
+					ret.Paths.Paths[k] = v
+				}
+
+				firstPathChange = false
+			}
+			ret.Paths.Paths[k] = path
+		}
+	}
+
+	return ret, nil
+}

--- a/pkg/builder/parameters.go
+++ b/pkg/builder/parameters.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"sort"
 	"strconv"
+	"strings"
 
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -39,8 +40,11 @@ func collectSharedParameters(sp *spec.Swagger) (namesByJSON map[string]string, r
 	var keys []string
 
 	collect := func(p *spec.Parameter) error {
-		if p.In == "query" && p.Name == "name" {
+		if (p.In == "query" || p.In == "path") && p.Name == "name" {
 			return nil // ignore name parameter as they are never shared with the Kind in the description
+		}
+		if p.In == "body" && p.Name == "body" && !strings.HasPrefix(p.Ref.String(), "#/definitions/io.k8s.apimachinery") {
+			return nil // ignore body parameter as they are never shared with the custom schema for each kind
 		}
 
 		bs, err := json.Marshal(p)

--- a/pkg/builder/parameters.go
+++ b/pkg/builder/parameters.go
@@ -39,6 +39,10 @@ func collectSharedParameters(sp *spec.Swagger) (namesByJSON map[string]string, r
 	var keys []string
 
 	collect := func(p *spec.Parameter) error {
+		if p.In == "query" && p.Name == "name" {
+			return nil // ignore name parameter as they are never shared with the Kind in the description
+		}
+
 		bs, err := json.Marshal(p)
 		if err != nil {
 			return err

--- a/pkg/builder/parameters_test.go
+++ b/pkg/builder/parameters_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func init() {
+	minimumSharedParameterCount = 2
+}
+
+func TestCollectSharedParameters(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+		want map[string]string
+	}{
+		{
+			name: "empty",
+			spec: "",
+			want: nil,
+		},
+		{
+			name: "no shared",
+			spec: `{
+  "parameters": {"pre": {"in": "body", "name": "body", "required": true, "schema": {}}},
+  "paths": {
+    "/api/v1/a/{name}": {"get": {"parameters": [
+		  {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true},
+		  {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/a/{name}/foo": {"get": {"parameters": [
+		  {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}": {"get": {"parameters": [
+		  {"description": "x","in":"query","name": "x2","type":"boolean","uniqueItems":true},
+		  {"description": "y","in":"query","name": "y2","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}/foo": {"get": {"parameters": [
+		  {"description": "z","in":"query","name": "z2","type":"boolean","uniqueItems":true}
+    ]}}
+  }
+}`,
+			want: map[string]string{},
+		},
+		{
+			name: "shared per operation",
+			spec: `{
+  "parameters": {"pre": {"in": "body", "name": "body", "required": true, "schema": {}}},
+  "paths": {
+    "/api/v1/a/{name}": {"get": {"parameters": [
+		  {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true},
+		  {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/a/{name}/foo": {"get": {"parameters": [
+		  {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true},
+		  {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}": {"get": {"parameters": [
+		  {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}/foo": {"get": {"parameters": [
+		  {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true}
+    ]}}
+  }
+}`,
+			want: map[string]string{
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z",
+			},
+		},
+		{
+			name: "shared per path",
+			spec: `{
+  "parameters": {"pre": {"in": "body", "name": "body", "required": true, "schema": {}}},
+  "paths": {
+    "/api/v1/a/{name}": {"get": {},
+      "parameters": [
+		  {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true},
+		  {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+      ]
+    },
+    "/api/v1/a/{name}/foo": {"get": {"parameters": [
+		  {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true},
+		  {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}": {"get": {},
+      "parameters": [
+		  {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true}
+      ]
+    },
+    "/api/v1/b/{name}/foo": {"get": {"parameters": [
+		  {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true}
+    ]}}
+  }
+}`,
+			want: map[string]string{
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sp *spec.Swagger
+			if tt.spec != "" {
+				err := json.Unmarshal([]byte(tt.spec), &sp)
+				require.NoError(t, err)
+			}
+
+			gotNamesByJSON, _, err := collectSharedParameters(sp)
+			require.NoError(t, err)
+			require.Equalf(t, tt.want, gotNamesByJSON, "unexpected shared parameters")
+		})
+	}
+}
+
+func TestReplaceSharedParameters(t *testing.T) {
+	shared := map[string]string{
+		`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x",
+		`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y",
+		`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z",
+	}
+
+	tests := []struct {
+		name string
+		spec string
+		want string
+	}{
+		{
+			name: "empty",
+			spec: "{}",
+			want: `{"paths":null}`,
+		},
+		{
+			name: "existing parameters",
+			spec: `{"parameters": {"a":{"type":"boolean"}}}`,
+			want: `{"parameters": {"a":{"type":"boolean"}},"paths":null}`,
+		},
+		{
+			name: "replace",
+			spec: `{
+  "parameters": {"pre": {"in": "body", "name": "body", "required": true, "schema": {}}},
+  "paths": {
+    "/api/v1/a/{name}": {"get": {"description":"foo"},
+      "parameters": [
+        {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true},
+	    {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+      ]
+    },
+    "/api/v1/a/{name}/foo": {"get": {"parameters": [
+      {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true},
+	  {"description": "y","in":"query","name": "y","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}": {"get": {"parameters": [
+	  {"description": "z","in":"query","name": "z","type":"boolean","uniqueItems":true}
+    ]}},
+    "/api/v1/b/{name}/foo": {"get": {"parameters": [
+	  {"description": "x","in":"query","name": "x","type":"boolean","uniqueItems":true},
+      {"description": "w","in":"query","name": "w","type":"boolean","uniqueItems":true}
+    ]}}
+  }
+}`,
+			want: `{
+  "parameters": {"pre":{"in":"body","name":"body","required":true,"schema":{}}},
+  "paths": {
+    "/api/v1/a/{name}": {"get": {"description":"foo"},
+      "parameters": [
+        {"$ref": "#/parameters/x"},
+        {"$ref": "#/parameters/y"}
+      ]
+    },
+    "/api/v1/a/{name}/foo": {"get": {"parameters": [
+      {"$ref": "#/parameters/z"},
+      {"$ref": "#/parameters/y"}
+    ]}},
+    "/api/v1/b/{name}": {"get": {"parameters": [
+      {"$ref": "#/parameters/z"}
+    ]}},
+    "/api/v1/b/{name}/foo": {"get": {"parameters": [
+      {"$ref":"#/parameters/x"},
+      {"description": "w","in":"query","name": "w","type":"boolean","uniqueItems":true}
+    ]}}
+  }
+}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var unmarshalled *spec.Swagger
+			err := json.Unmarshal([]byte(tt.spec), &unmarshalled)
+			require.NoError(t, err)
+
+			got, err := replaceSharedParameters(shared, unmarshalled)
+			require.NoError(t, err)
+
+			require.Equalf(t, normalizeJSON(t, tt.want), normalizeJSON(t, toJSON(t, got)), "unexpected result")
+		})
+	}
+}
+
+func toJSON(t *testing.T, x interface{}) string {
+	bs, err := json.Marshal(x)
+	require.NoError(t, err)
+
+	return string(bs)
+}
+
+func normalizeJSON(t *testing.T, j string) string {
+	var obj interface{}
+	err := json.Unmarshal([]byte(j), &obj)
+	require.NoError(t, err)
+	return toJSON(t, obj)
+}

--- a/pkg/builder/parameters_test.go
+++ b/pkg/builder/parameters_test.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -237,4 +238,19 @@ func normalizeJSON(t *testing.T, j string) string {
 	err := json.Unmarshal([]byte(j), &obj)
 	require.NoError(t, err)
 	return toJSON(t, obj)
+}
+
+func TestOperations(t *testing.T) {
+	t.Log("Ensuring that operations() returns all operations in spec.PathItemProps")
+	path := spec.PathItem{}
+	v := reflect.ValueOf(path.PathItemProps)
+	var rOps []any
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Ptr {
+			rOps = append(rOps, v.Field(i).Interface())
+		}
+	}
+
+	ops := operations(&path)
+	require.Equal(t, len(rOps), len(ops), "operations() should return all operations in spec.PathItemProps")
 }

--- a/pkg/builder/parameters_test.go
+++ b/pkg/builder/parameters_test.go
@@ -25,10 +25,6 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
-func init() {
-	minimumSharedParameterCount = 2
-}
-
 func TestCollectSharedParameters(t *testing.T) {
 	tests := []struct {
 		name string
@@ -61,7 +57,14 @@ func TestCollectSharedParameters(t *testing.T) {
     ]}}
   }
 }`,
-			want: map[string]string{},
+			want: map[string]string{
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`:  "x-Z2Xub4DK",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`:  "y-y7usp1yI",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`:  "z-zZJItIuA",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x2","in":"query"}`: "x2-c9T21SCy",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y2","in":"query"}`: "y2-DvN7hOA8",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z2","in":"query"}`: "z2-nF5ahw6l",
+			},
 		},
 		{
 			name: "shared per operation",
@@ -85,9 +88,9 @@ func TestCollectSharedParameters(t *testing.T) {
   }
 }`,
 			want: map[string]string{
-				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x",
-				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y",
-				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x-Z2Xub4DK",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y-y7usp1yI",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z-zZJItIuA",
 			},
 		},
 		{
@@ -116,9 +119,9 @@ func TestCollectSharedParameters(t *testing.T) {
   }
 }`,
 			want: map[string]string{
-				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x",
-				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y",
-				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x-Z2Xub4DK",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y-y7usp1yI",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z-zZJItIuA",
 			},
 		},
 	}


### PR DESCRIPTION
Parameters are large part of the Kubernetes OpenAPI v2 spec. This PR moves parameter definition into
the global parameters section of the spec. It also add deconflicting (renaming) support on spec merge
if parameters of the same name differ.

As renaming in deconflicting might create noise, we make parameter names mostly unique through `name-<base64(sha224(parameter-json))[:8]>`.
So the deconflicting is still in place as there might be conflicts. But in practice this probably won't happen.

Proof PR https://github.com/kubernetes/kubernetes/pull/118204