### PR TITLE
validate: dont short circuit validator on MinProperties/MaxProperties error

### DIFF
--- a/pkg/validation/validate/object_validator.go
+++ b/pkg/validation/validate/object_validator.go
@@ -55,14 +55,14 @@ func (o *objectValidator) Validate(data interface{}) *Result {
 	// TODO: guard against nil data
 	numKeys := int64(len(val))
 
+	res := new(Result)
+
 	if o.MinProperties != nil && numKeys < *o.MinProperties {
-		return errorHelp.sErr(errors.TooFewProperties(o.Path, o.In, *o.MinProperties, numKeys))
+		res.AddErrors(errors.TooFewProperties(o.Path, o.In, *o.MinProperties, numKeys))
 	}
 	if o.MaxProperties != nil && numKeys > *o.MaxProperties {
-		return errorHelp.sErr(errors.TooManyProperties(o.Path, o.In, *o.MaxProperties, numKeys))
+		res.AddErrors(errors.TooManyProperties(o.Path, o.In, *o.MaxProperties, numKeys))
 	}
-
-	res := new(Result)
 
 	// check validity of field names
 	if o.AdditionalProperties != nil && !o.AdditionalProperties.Allows {

--- a/pkg/validation/validate/object_validator_test.go
+++ b/pkg/validation/validate/object_validator_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	kubeopenapierrors "k8s.io/kube-openapi/pkg/validation/errors"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
 )
 
 func itemsFixture() map[string]interface{} {
@@ -79,4 +82,70 @@ func TestObjectValidator_EdgeCases(t *testing.T) {
 	s := objectValidator{}
 	s.SetPath("path")
 	assert.Equal(t, "path", s.Path)
+}
+
+func TestMinPropertiesMaxPropertiesDontShortCircuit(t *testing.T) {
+	s := objectValidator{
+		In:            "body",
+		Path:          "some.path[5]",
+		KnownFormats:  strfmt.Default,
+		MinProperties: ptr(int64(20)),
+		MaxProperties: ptr(int64(0)),
+		Properties: map[string]spec.Schema{
+			"intField": {
+				SchemaProps: spec.SchemaProps{
+					Type: spec.StringOrArray{"integer"},
+				},
+			},
+			"requiredField": {
+				SchemaProps: spec.SchemaProps{
+					Type: spec.StringOrArray{"string"},
+				},
+			},
+		},
+		Required: []string{"requiredField"},
+		AdditionalProperties: &spec.SchemaOrBool{
+			Allows: true,
+			Schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type:    spec.StringOrArray{"string"},
+					Pattern: "^20[0-9][0-9]",
+				},
+			},
+		},
+	}
+
+	obj := map[string]interface{}{
+		"field": "hello, world",
+	}
+	res := s.Validate(obj)
+
+	assert.ElementsMatch(t, []*kubeopenapierrors.Validation{
+		kubeopenapierrors.TooFewProperties(s.Path, s.In, *s.MinProperties, int64(len(obj))),
+		kubeopenapierrors.TooManyProperties(s.Path, s.In, *s.MaxProperties, int64(len(obj))),
+		kubeopenapierrors.FailedPattern(s.Path+"."+"field", s.In, s.AdditionalProperties.Schema.Pattern, "hello, world"),
+		kubeopenapierrors.Required(s.Path+"."+"requiredField", s.In),
+	}, res.Errors)
+
+	obj = map[string]interface{}{
+		"field":    "hello, world",
+		"field2":   "hello, other world",
+		"field3":   "hello, third world",
+		"intField": "a string",
+	}
+	res = s.Validate(obj)
+
+	assert.ElementsMatch(t, []*kubeopenapierrors.Validation{
+		kubeopenapierrors.TooFewProperties(s.Path, s.In, *s.MinProperties, int64(len(obj))),
+		kubeopenapierrors.TooManyProperties(s.Path, s.In, *s.MaxProperties, int64(len(obj))),
+		kubeopenapierrors.FailedPattern(s.Path+"."+"field", s.In, s.AdditionalProperties.Schema.Pattern, "hello, world"),
+		kubeopenapierrors.FailedPattern(s.Path+"."+"field2", s.In, s.AdditionalProperties.Schema.Pattern, "hello, other world"),
+		kubeopenapierrors.FailedPattern(s.Path+"."+"field3", s.In, s.AdditionalProperties.Schema.Pattern, "hello, third world"),
+		kubeopenapierrors.InvalidType(s.Path+"."+"intField", s.In, "integer", "string"),
+		kubeopenapierrors.Required(s.Path+"."+"requiredField", s.In),
+	}, res.Errors)
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
Currently `object_validator` does not explore any of the fields of an object if the number of fields violates any MinProperties/MaxProperties condition. This is inconsistent with slice_validator, which validates MinItems/MaxItems after visiting any of the items.

This prevents us from seeing all errors if MinProperties/MaxProperties is violated.

This is the only location in validation where a part of the input object is not explored/short circuited. Having this property would greatly simplify logic for map-type aware DeepEqual logic for CRD validation ratcheting. The map-type aware DeepEqual uses the tree traversed by SchemaValidator to inform which schema is associated with which subobject. Unfortunately if there is a MaxProperties/MinProperties error a portion of the tree is missing.

This change makes the validator keep going after seeing an error with number of properties and validate each of the subfields anyway, just as it does for arrays.