### PR TITLE
spec: support string slices in GetStringSlice

### DIFF
--- a/pkg/validation/spec/info.go
+++ b/pkg/validation/spec/info.go
@@ -53,11 +53,16 @@ func (e Extensions) GetBool(key string) (bool, bool) {
 // GetStringSlice gets a string value from the extensions
 func (e Extensions) GetStringSlice(key string) ([]string, bool) {
 	if v, ok := e[strings.ToLower(key)]; ok {
+		var strs []string
+		if stringSlice, isStringSlice := v.([]string); isStringSlice {
+			strs = make([]string, len(stringSlice))
+			copy(strs, stringSlice)
+			return strs, true
+		}
 		arr, isSlice := v.([]interface{})
 		if !isSlice {
 			return nil, false
 		}
-		var strs []string
 		for _, iface := range arr {
 			str, isString := iface.(string)
 			if !isString {

--- a/pkg/validation/spec/info_test.go
+++ b/pkg/validation/spec/info_test.go
@@ -102,3 +102,62 @@ func TestInfoRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStringSlice(t *testing.T) {
+	type stringSliceCase struct {
+		name  string
+		slice any
+
+		expectedValue []string
+	}
+
+	cases := []stringSliceCase{
+		{
+			name:          "interfaces",
+			slice:         []interface{}{"key1", "key2", "key3"},
+			expectedValue: []string{"key1", "key2", "key3"},
+		},
+		{
+			name:          "strings",
+			slice:         []string{"key1", "key2", "key3"},
+			expectedValue: []string{"key1", "key2", "key3"},
+		},
+		{
+			name:  "ints",
+			slice: []int{1, 2, 3},
+		},
+		{
+			name:  "string",
+			slice: "hello world",
+		},
+		{
+			name: "badkey",
+		},
+	}
+
+	exts := VendorExtensible{}
+	for _, c := range cases {
+		if c.slice != nil {
+			exts.AddExtension(c.name, c.slice)
+		}
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			slice, ok := exts.Extensions.GetStringSlice(c.name)
+			assert.Equal(t, c.expectedValue != nil, ok)
+			assert.Equal(t, c.expectedValue, slice)
+
+			// Make sure modifying the result slice doesn't touch the original
+			if len(slice) > 0 {
+				slice[0] = "changed value"
+			} else {
+				slice = append(slice, "new value")
+			}
+
+			slice, ok = exts.Extensions.GetStringSlice(c.name)
+			assert.Equal(t, c.expectedValue != nil, ok)
+			assert.Equal(t, c.expectedValue, slice)
+		})
+	}
+}


### PR DESCRIPTION
makes GetStringSlice support slices of strings

[ConvertJSONSchemaPropsWithPostProcess](https://github.com/kubernetes/kubernetes/blob/95c8d61918de9f2a55512ac70a03a4ae161cc1f6/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go#L289-L291) in k/k directly places its []string of x-kubernetes-list-map-keys into the extensions map, which are then used with validation code.

Running into this problem of `GetStringSlice` not seeing the MapKeys added by this function, since they are `[]string` and it only supports `[]interface{}`

Adding this logic alleviates the issue and makes the implementation match the expected behavior of the function

/cc @apelisse 