### PR TITLE
fixup broken test

### DIFF
--- a/pkg/validation/validate/object_validator_test.go
+++ b/pkg/validation/validate/object_validator_test.go
@@ -113,6 +113,14 @@ func TestMinPropertiesMaxPropertiesDontShortCircuit(t *testing.T) {
 				},
 			},
 		},
+		Options: SchemaValidatorOptions{
+			NewValidatorForIndex: func(index int, schema *spec.Schema, rootSchema interface{}, root string, formats strfmt.Registry, opts ...Option) ValueValidator {
+				return NewSchemaValidator(schema, rootSchema, root, formats, opts...)
+			},
+			NewValidatorForField: func(field string, schema *spec.Schema, rootSchema interface{}, root string, formats strfmt.Registry, opts ...Option) ValueValidator {
+				return NewSchemaValidator(schema, rootSchema, root, formats, opts...)
+			},
+		},
 	}
 
 	obj := map[string]interface{}{


### PR DESCRIPTION
When merging #406 CI did not run the new test recently introduced in #412

This adds the missing objectValidator option causing NPE after merging both PRs

/cc @apelisse @sttts 
