### PR TITLE
builder/parameters: switch to fnv and exclude fieldValidation query parameter

### DIFF
--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -292,12 +292,12 @@ func getTestCommonParameters() []spec.Parameter {
 	ret := make([]spec.Parameter, 2)
 	ret[0] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/path-Xf6bMocQ"),
+			Ref: spec.MustCreateRef("#/parameters/path-z6Ciiujn"),
 		},
 	}
 	ret[1] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/pretty-QYJ-1x8O"),
+			Ref: spec.MustCreateRef("#/parameters/pretty-nN7o5FEq"),
 		},
 	}
 	return ret
@@ -328,12 +328,12 @@ func getAdditionalTestParameters() []spec.Parameter {
 	}
 	ret[1] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/fparam-5GSylsE3"),
+			Ref: spec.MustCreateRef("#/parameters/fparam-xCJg5kHS"),
 		},
 	}
 	ret[2] = spec.Parameter{
 		Refable: spec.Refable{
-			Ref: spec.MustCreateRef("#/parameters/hparam-XbFNLzps"),
+			Ref: spec.MustCreateRef("#/parameters/hparam-tx-jfxM1"),
 		},
 	}
 	return ret
@@ -431,7 +431,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 				"builder.TestOutput": getTestOutputDefinition(),
 			},
 			Parameters: map[string]spec.Parameter{
-				"fparam-5GSylsE3": {
+				"fparam-xCJg5kHS": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},
@@ -444,7 +444,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Description: "a test form parameter",
 					},
 				},
-				"hparam-XbFNLzps": {
+				"hparam-tx-jfxM1": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},
@@ -457,7 +457,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Description: "a test head parameter",
 					},
 				},
-				"path-Xf6bMocQ": {
+				"path-z6Ciiujn": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},
@@ -471,7 +471,7 @@ func TestBuildOpenAPISpec(t *testing.T) {
 						Required:    true,
 					},
 				},
-				"pretty-QYJ-1x8O": {
+				"pretty-nN7o5FEq": {
 					CommonValidations: spec.CommonValidations{
 						UniqueItems: true,
 					},

--- a/pkg/builder/parameters.go
+++ b/pkg/builder/parameters.go
@@ -17,10 +17,10 @@ limitations under the License.
 package builder
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"sort"
 	"strconv"
 	"strings"
@@ -118,6 +118,7 @@ func collectSharedParameters(sp *spec.Swagger) (namesByJSON map[string]string, r
 	for _, k := range keys {
 		name := shared[k].Name
 		if name == "" {
+			// this should never happen as the name is a required field. But if it does, let's be safe.
 			name = "param"
 		}
 		name += "-" + base64Hash(k)
@@ -141,8 +142,9 @@ func operations(path *spec.PathItem) []*spec.Operation {
 }
 
 func base64Hash(s string) string {
-	hash := sha256.Sum224([]byte(s))
-	return base64.URLEncoding.EncodeToString(hash[:6]) // 8 characters
+	hash := fnv.New64()
+	hash.Write([]byte(s))                                                      //nolint:errcheck
+	return base64.URLEncoding.EncodeToString(hash.Sum(make([]byte, 0, 8))[:6]) // 8 characters
 }
 
 func replaceSharedParameters(sharedParameterNamesByJSON map[string]string, sp *spec.Swagger) (*spec.Swagger, error) {

--- a/pkg/builder/parameters.go
+++ b/pkg/builder/parameters.go
@@ -67,6 +67,9 @@ func collectSharedParameters(sp *spec.Swagger) (namesByJSON map[string]string, r
 		if p.In == "query" && p.Name == "fieldValidation" {
 			return nil // keep fieldValidation parameter unshared because kubectl uses it (until 1.27) to detect server-side field validation support
 		}
+		if p.In == "query" && p.Name == "dryRun" {
+			return nil // keep fieldValidation parameter unshared because kubectl uses it (until 1.26) to detect dry-run support
+		}
 		if p.Schema != nil && p.In == "body" && p.Name == "body" && !strings.HasPrefix(p.Schema.Ref.String(), "#/definitions/io.k8s.apimachinery") {
 			return nil // ignore non-generic body parameters as they reference the custom schema of the kind
 		}

--- a/pkg/builder/parameters.go
+++ b/pkg/builder/parameters.go
@@ -64,6 +64,9 @@ func collectSharedParameters(sp *spec.Swagger) (namesByJSON map[string]string, r
 		if (p.In == "query" || p.In == "path") && p.Name == "name" {
 			return nil // ignore name parameter as they are never shared with the Kind in the description
 		}
+		if p.In == "query" && p.Name == "fieldValidation" {
+			return nil // keep fieldValidation parameter unshared because kubectl uses it (until 1.27) to detect server-side field validation support
+		}
 		if p.Schema != nil && p.In == "body" && p.Name == "body" && !strings.HasPrefix(p.Schema.Ref.String(), "#/definitions/io.k8s.apimachinery") {
 			return nil // ignore non-generic body parameters as they reference the custom schema of the kind
 		}

--- a/pkg/builder/parameters_test.go
+++ b/pkg/builder/parameters_test.go
@@ -59,12 +59,12 @@ func TestCollectSharedParameters(t *testing.T) {
   }
 }`,
 			want: map[string]string{
-				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`:  "x-Z2Xub4DK",
-				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`:  "y-y7usp1yI",
-				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`:  "z-zZJItIuA",
-				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x2","in":"query"}`: "x2-c9T21SCy",
-				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y2","in":"query"}`: "y2-DvN7hOA8",
-				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z2","in":"query"}`: "z2-nF5ahw6l",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`:  "x-yaDSHpi7",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`:  "y-g6h7lEsz",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`:  "z--SXYWoM_",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x2","in":"query"}`: "x2-nds6MpS1",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y2","in":"query"}`: "y2-exnalzYE",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z2","in":"query"}`: "z2-8oJfzBQF",
 			},
 		},
 		{
@@ -89,9 +89,9 @@ func TestCollectSharedParameters(t *testing.T) {
   }
 }`,
 			want: map[string]string{
-				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x-Z2Xub4DK",
-				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y-y7usp1yI",
-				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z-zZJItIuA",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x-yaDSHpi7",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y-g6h7lEsz",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z--SXYWoM_",
 			},
 		},
 		{
@@ -120,9 +120,9 @@ func TestCollectSharedParameters(t *testing.T) {
   }
 }`,
 			want: map[string]string{
-				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x-Z2Xub4DK",
-				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y-y7usp1yI",
-				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z-zZJItIuA",
+				`{"uniqueItems":true,"type":"boolean","description":"x","name":"x","in":"query"}`: "x-yaDSHpi7",
+				`{"uniqueItems":true,"type":"boolean","description":"y","name":"y","in":"query"}`: "y-g6h7lEsz",
+				`{"uniqueItems":true,"type":"boolean","description":"z","name":"z","in":"query"}`: "z--SXYWoM_",
 			},
 		},
 	}


### PR DESCRIPTION
- no need for a cryptographic hash. fnv-1 is a magnitude faster.
- pre-1.28 `kubectl`'s incomplete OpenAPI implementation needs a non-shared `fieldValidation` query parameter.
- pre-1.27 `kubectl` needs a non-shared `dryRun` query parameter (compare https://github.com/kubernetes/kubernetes/pull/114294/commits).