### PR TITLE
Implement experimental marshaler for OpenAPI V3

### DIFF
--- a/pkg/handler3/handler_test.go
+++ b/pkg/handler3/handler_test.go
@@ -39,7 +39,7 @@ var returnedOpenAPI = []byte(`{
    "title": "Kubernetes",
    "version": "v1.23.0"
   },
-  "paths": {"x-kubernetes-extension": "val"}}`)
+  "paths": {}}`)
 
 func TestRegisterOpenAPIVersionedService(t *testing.T) {
 	var s *spec3.OpenAPI

--- a/pkg/handler3/handler_test.go
+++ b/pkg/handler3/handler_test.go
@@ -39,7 +39,7 @@ var returnedOpenAPI = []byte(`{
    "title": "Kubernetes",
    "version": "v1.23.0"
   },
-  "paths": {}}`)
+  "paths": {"x-kubernetes-extension": "val"}}`)
 
 func TestRegisterOpenAPIVersionedService(t *testing.T) {
 	var s *spec3.OpenAPI

--- a/pkg/internal/flags.go
+++ b/pkg/internal/flags.go
@@ -22,3 +22,4 @@ var UseOptimizedJSONUnmarshalingV3 bool = true
 
 // Used by tests to selectively disable experimental JSON marshaler
 var UseOptimizedJSONMarshaling bool = true
+var UseOptimizedJSONMarshalingV3 bool = true

--- a/pkg/spec3/external_documentation.go
+++ b/pkg/spec3/external_documentation.go
@@ -39,6 +39,9 @@ type ExternalDocumentationProps struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
 func (e *ExternalDocumentation) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(e)
+	}
 	b1, err := json.Marshal(e.ExternalDocumentationProps)
 	if err != nil {
 		return nil, err
@@ -48,6 +51,16 @@ func (e *ExternalDocumentation) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2), nil
+}
+
+func (e *ExternalDocumentation) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		ExternalDocumentationProps `json:",inline"`
+		spec.Extensions
+	}
+	x.Extensions = internal.SanitizeExtensions(e.Extensions)
+	x.ExternalDocumentationProps = e.ExternalDocumentationProps
+	return opts.MarshalNext(enc, x)
 }
 
 func (e *ExternalDocumentation) UnmarshalJSON(data []byte) error {

--- a/pkg/spec3/fuzz.go
+++ b/pkg/spec3/fuzz.go
@@ -169,6 +169,21 @@ var OpenAPIV3FuzzFuncs []interface{} = []interface{}{
 		c.Fuzz(&v.ResponseProps)
 		c.Fuzz(&v.VendorExtensible)
 	},
+	func(v *Operation, c fuzz.Continue) {
+		c.FuzzNoCustom(v)
+		// Do not fuzz null values into the array.
+		for i, val := range v.SecurityRequirement {
+			if val == nil {
+				v.SecurityRequirement[i] = make(map[string][]string)
+			}
+
+			for k, v := range val {
+				if v == nil {
+					val[k] = make([]string, 0)
+				}
+			}
+		}
+	},
 	func(v *spec.Extensions, c fuzz.Continue) {
 		numChildren := c.Intn(5)
 		for i := 0; i < numChildren; i++ {

--- a/pkg/spec3/header.go
+++ b/pkg/spec3/header.go
@@ -36,6 +36,9 @@ type Header struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Header as JSON
 func (h *Header) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(h)
+	}
 	b1, err := json.Marshal(h.Refable)
 	if err != nil {
 		return nil, err
@@ -49,6 +52,18 @@ func (h *Header) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2, b3), nil
+}
+
+func (h *Header) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		Ref         string              `json:"$ref,omitempty"`
+		HeaderProps headerPropsOmitZero `json:",inline"`
+		spec.Extensions
+	}
+	x.Ref = h.Refable.Ref.String()
+	x.Extensions = internal.SanitizeExtensions(h.Extensions)
+	x.HeaderProps = headerPropsOmitZero(h.HeaderProps)
+	return opts.MarshalNext(enc, x)
 }
 
 func (h *Header) UnmarshalJSON(data []byte) error {
@@ -108,4 +123,20 @@ type HeaderProps struct {
 	Example interface{} `json:"example,omitempty"`
 	// Examples of the header
 	Examples map[string]*Example `json:"examples,omitempty"`
+}
+
+// Marshaling structure only, always edit along with corresponding
+// struct (or compilation will fail).
+type headerPropsOmitZero struct {
+	Description     string                `json:"description,omitempty"`
+	Required        bool                  `json:"required,omitzero"`
+	Deprecated      bool                  `json:"deprecated,omitzero"`
+	AllowEmptyValue bool                  `json:"allowEmptyValue,omitzero"`
+	Style           string                `json:"style,omitempty"`
+	Explode         bool                  `json:"explode,omitzero"`
+	AllowReserved   bool                  `json:"allowReserved,omitzero"`
+	Schema          *spec.Schema          `json:"schema,omitzero"`
+	Content         map[string]*MediaType `json:"content,omitempty"`
+	Example         interface{}           `json:"example,omitempty"`
+	Examples        map[string]*Example   `json:"examples,omitempty"`
 }

--- a/pkg/spec3/parameter.go
+++ b/pkg/spec3/parameter.go
@@ -36,6 +36,9 @@ type Parameter struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Parameter as JSON
 func (p *Parameter) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(p)
+	}
 	b1, err := json.Marshal(p.Refable)
 	if err != nil {
 		return nil, err
@@ -49,6 +52,18 @@ func (p *Parameter) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2, b3), nil
+}
+
+func (p *Parameter) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		Ref            string                 `json:"$ref,omitempty"`
+		ParameterProps parameterPropsOmitZero `json:",inline"`
+		spec.Extensions
+	}
+	x.Ref = p.Refable.Ref.String()
+	x.Extensions = internal.SanitizeExtensions(p.Extensions)
+	x.ParameterProps = parameterPropsOmitZero(p.ParameterProps)
+	return opts.MarshalNext(enc, x)
 }
 
 func (p *Parameter) UnmarshalJSON(data []byte) error {
@@ -113,4 +128,20 @@ type ParameterProps struct {
 	Example interface{} `json:"example,omitempty"`
 	// Examples of the parameter's potential value. Each example SHOULD contain a value in the correct format as specified in the parameter encoding
 	Examples map[string]*Example `json:"examples,omitempty"`
+}
+
+type parameterPropsOmitZero struct {
+	Name            string                `json:"name,omitempty"`
+	In              string                `json:"in,omitempty"`
+	Description     string                `json:"description,omitempty"`
+	Required        bool                  `json:"required,omitzero"`
+	Deprecated      bool                  `json:"deprecated,omitzero"`
+	AllowEmptyValue bool                  `json:"allowEmptyValue,omitzero"`
+	Style           string                `json:"style,omitempty"`
+	Explode         bool                  `json:"explode,omitzero"`
+	AllowReserved   bool                  `json:"allowReserved,omitzero"`
+	Schema          *spec.Schema          `json:"schema,omitzero"`
+	Content         map[string]*MediaType `json:"content,omitempty"`
+	Example         interface{}           `json:"example,omitempty"`
+	Examples        map[string]*Example   `json:"examples,omitempty"`
 }

--- a/pkg/spec3/path.go
+++ b/pkg/spec3/path.go
@@ -35,15 +35,41 @@ type Paths struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Paths as JSON
 func (p *Paths) MarshalJSON() ([]byte, error) {
-	b1, err := json.Marshal(p.Paths)
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(p)
+	}
+	b1, err := json.Marshal(p.VendorExtensible)
 	if err != nil {
 		return nil, err
 	}
-	b2, err := json.Marshal(p.VendorExtensible)
+
+	pths := make(map[string]*Path)
+	for k, v := range p.Paths {
+		if strings.HasPrefix(k, "/") {
+			pths[k] = v
+		}
+	}
+	b2, err := json.Marshal(pths)
 	if err != nil {
 		return nil, err
 	}
-	return swag.ConcatJSON(b1, b2), nil
+	concated := swag.ConcatJSON(b1, b2)
+	return concated, nil
+}
+
+func (p *Paths) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	m := make(map[string]any, len(p.Extensions)+len(p.Paths))
+	for k, v := range p.Extensions {
+		if internal.IsExtensionKey(k) {
+			m[k] = v
+		}
+	}
+	for k, v := range p.Paths {
+		if strings.HasPrefix(k, "/") {
+			m[k] = v
+		}
+	}
+	return opts.MarshalNext(enc, m)
 }
 
 // UnmarshalJSON hydrates this items instance with the data from JSON
@@ -144,6 +170,9 @@ type Path struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Path as JSON
 func (p *Path) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(p)
+	}
 	b1, err := json.Marshal(p.Refable)
 	if err != nil {
 		return nil, err
@@ -157,6 +186,18 @@ func (p *Path) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2, b3), nil
+}
+
+func (p *Path) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		Ref string `json:"$ref,omitempty"`
+		spec.Extensions
+		PathProps
+	}
+	x.Ref = p.Refable.Ref.String()
+	x.Extensions = internal.SanitizeExtensions(p.Extensions)
+	x.PathProps = p.PathProps
+	return opts.MarshalNext(enc, x)
 }
 
 func (p *Path) UnmarshalJSON(data []byte) error {

--- a/pkg/spec3/response.go
+++ b/pkg/spec3/response.go
@@ -37,6 +37,9 @@ type Responses struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
 func (r *Responses) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(r)
+	}
 	b1, err := json.Marshal(r.ResponsesProps)
 	if err != nil {
 		return nil, err
@@ -46,6 +49,25 @@ func (r *Responses) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2), nil
+}
+
+func (r Responses) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	type ArbitraryKeys map[string]interface{}
+	var x struct {
+		ArbitraryKeys
+		Default *Response `json:"default,omitzero"`
+	}
+	x.ArbitraryKeys = make(map[string]any, len(r.Extensions)+len(r.StatusCodeResponses))
+	for k, v := range r.Extensions {
+		if internal.IsExtensionKey(k) {
+			x.ArbitraryKeys[k] = v
+		}
+	}
+	for k, v := range r.StatusCodeResponses {
+		x.ArbitraryKeys[strconv.Itoa(k)] = v
+	}
+	x.Default = r.Default
+	return opts.MarshalNext(enc, x)
 }
 
 func (r *Responses) UnmarshalJSON(data []byte) error {
@@ -179,6 +201,9 @@ type Response struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Response as JSON
 func (r *Response) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(r)
+	}
 	b1, err := json.Marshal(r.Refable)
 	if err != nil {
 		return nil, err
@@ -192,6 +217,18 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2, b3), nil
+}
+
+func (r Response) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		Ref string `json:"$ref,omitempty"`
+		spec.Extensions
+		ResponseProps `json:",inline"`
+	}
+	x.Ref = r.Refable.Ref.String()
+	x.Extensions = internal.SanitizeExtensions(r.Extensions)
+	x.ResponseProps = r.ResponseProps
+	return opts.MarshalNext(enc, x)
 }
 
 func (r *Response) UnmarshalJSON(data []byte) error {
@@ -247,6 +284,9 @@ type Link struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Link as JSON
 func (r *Link) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(r)
+	}
 	b1, err := json.Marshal(r.Refable)
 	if err != nil {
 		return nil, err
@@ -260,6 +300,18 @@ func (r *Link) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2, b3), nil
+}
+
+func (r *Link) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		Ref string `json:"$ref,omitempty"`
+		spec.Extensions
+		LinkProps `json:",inline"`
+	}
+	x.Ref = r.Refable.Ref.String()
+	x.Extensions = internal.SanitizeExtensions(r.Extensions)
+	x.LinkProps = r.LinkProps
+	return opts.MarshalNext(enc, x)
 }
 
 func (r *Link) UnmarshalJSON(data []byte) error {

--- a/pkg/spec3/server.go
+++ b/pkg/spec3/server.go
@@ -41,6 +41,9 @@ type ServerProps struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
 func (s *Server) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(s)
+	}
 	b1, err := json.Marshal(s.ServerProps)
 	if err != nil {
 		return nil, err
@@ -50,6 +53,16 @@ func (s *Server) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2), nil
+}
+
+func (s *Server) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		ServerProps `json:",inline"`
+		spec.Extensions
+	}
+	x.Extensions = internal.SanitizeExtensions(s.Extensions)
+	x.ServerProps = s.ServerProps
+	return opts.MarshalNext(enc, x)
 }
 
 func (s *Server) UnmarshalJSON(data []byte) error {
@@ -96,6 +109,9 @@ type ServerVariableProps struct {
 
 // MarshalJSON is a custom marshal function that knows how to encode Responses as JSON
 func (s *ServerVariable) MarshalJSON() ([]byte, error) {
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(s)
+	}
 	b1, err := json.Marshal(s.ServerVariableProps)
 	if err != nil {
 		return nil, err
@@ -105,6 +121,16 @@ func (s *ServerVariable) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return swag.ConcatJSON(b1, b2), nil
+}
+
+func (s *ServerVariable) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
+	var x struct {
+		ServerVariableProps `json:",inline"`
+		spec.Extensions
+	}
+	x.Extensions = internal.SanitizeExtensions(s.Extensions)
+	x.ServerVariableProps = s.ServerVariableProps
+	return opts.MarshalNext(enc, x)
 }
 
 func (s *ServerVariable) UnmarshalJSON(data []byte) error {

--- a/pkg/spec3/spec.go
+++ b/pkg/spec3/spec.go
@@ -48,3 +48,12 @@ func (o *OpenAPI) UnmarshalJSON(data []byte) error {
 	}
 	return json.Unmarshal(data, &p)
 }
+
+func (o *OpenAPI) MarshalJSON() ([]byte, error) {
+	type OpenAPIWithNoFunctions OpenAPI
+	p := (*OpenAPIWithNoFunctions)(o)
+	if internal.UseOptimizedJSONMarshalingV3 {
+		return internal.DeterministicMarshal(&p)
+	}
+	return json.Marshal(&p)
+}

--- a/pkg/spec3/spec.go
+++ b/pkg/spec3/spec.go
@@ -59,7 +59,7 @@ func (o *OpenAPI) MarshalJSON() ([]byte, error) {
 }
 
 func (o *OpenAPI) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
-	var x struct {
+	type OpenAPIOmitZero struct {
 		Version      string                 `json:"openapi"`
 		Info         *spec.Info             `json:"info"`
 		Paths        *Paths                 `json:"paths,omitzero"`
@@ -67,11 +67,6 @@ func (o *OpenAPI) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encode
 		Components   *Components            `json:"components,omitzero"`
 		ExternalDocs *ExternalDocumentation `json:"externalDocs,omitzero"`
 	}
-	x.Version = o.Version
-	x.Info = o.Info
-	x.Paths = o.Paths
-	x.Servers = o.Servers
-	x.Components = o.Components
-	x.ExternalDocs = o.ExternalDocs
+	x := (*OpenAPIOmitZero)(o)
 	return opts.MarshalNext(enc, x)
 }


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: k8s.io/kube-openapi/pkg/spec3
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
                                               │  old1.txt   │              new1.txt              │
                                               │   sec/op    │   sec/op     vs base               │
OpenAPIV3Serialize/appsv1spec.json-24            30.60m ± 2%   12.41m ± 3%  -59.43% (p=0.002 n=6)
OpenAPIV3Serialize/authorizationv1spec.json-24   2.541m ± 1%   1.143m ± 1%  -55.04% (p=0.002 n=6)
geomean                                          8.818m        3.766m       -57.29%

                                               │   old1.txt    │              new1.txt               │
                                               │     B/op      │     B/op      vs base               │
OpenAPIV3Serialize/appsv1spec.json-24            10.586Mi ± 1%   5.175Mi ± 3%  -51.11% (p=0.002 n=6)
OpenAPIV3Serialize/authorizationv1spec.json-24    931.7Ki ± 0%   538.6Ki ± 0%  -42.19% (p=0.002 n=6)
geomean                                           3.103Mi        1.650Mi       -46.83%

                                               │  old1.txt   │              new1.txt              │
                                               │  allocs/op  │  allocs/op   vs base               │
OpenAPIV3Serialize/appsv1spec.json-24            34.00k ± 0%   20.03k ± 0%  -41.08% (p=0.002 n=6)
OpenAPIV3Serialize/authorizationv1spec.json-24   3.021k ± 0%   2.025k ± 0%  -32.96% (p=0.002 n=6)
geomean                                          10.13k        6.369k       -37.15%
```

Slightly less improvement than OpenAPI V2 which is somewhat expected because of the smaller size of OpenAPI V3.