### PR TITLE
Use gomod version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,10 @@
 name: ci-pipeline
-
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
 jobs:
-
   ci:
     runs-on: ubuntu-latest
     strategy:
@@ -15,12 +12,10 @@ jobs:
         go: [ '1.19', '1.x' ]
     steps:
     - uses: actions/checkout@v3
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
         go-version: "${{ matrix.go }}"
-
     - name: Build
       run: |
         go mod tidy && git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,12 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.19', '1.x' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: "${{ matrix.go }}"
+        go-version-file: 'go.mod'
     - name: Build
       run: |
         go mod tidy && git diff --exit-code


### PR DESCRIPTION
Remove the matrix testing that we constantly have to update and let's use the version that is specified in go.mod.

There's also a `go.mod` in `./test/integration/go.mod`, not sure we're going to remember to udpate that one.

cc @alexzielenski @liggitt 