### PR TITLE
Include missing param options in requestBody

### DIFF
--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -156,7 +156,9 @@ func (o *openAPI) buildRequestBody(parameters []common.Parameter, consumes []str
 			}
 			r := &spec3.RequestBody{
 				RequestBodyProps: spec3.RequestBodyProps{
-					Content: map[string]*spec3.MediaType{},
+					Content:     map[string]*spec3.MediaType{},
+					Description: param.Description(),
+					Required:    param.Required(),
 				},
 			}
 			for _, consume := range consumes {


### PR DESCRIPTION
Include missing param options in requestBody. 

Fixes: https://github.com/kubernetes/kube-openapi/issues/427

See k/k OpenAPI v3 diff at https://github.com/Jefftree/kubernetes/commit/43d92b108b929bfa8aaf492d5de8075e0f5da279

/assign @apelisse 

