### PR TITLE
Add security requirement to root OpenAPI V3

### DIFF
--- a/pkg/spec3/fuzz.go
+++ b/pkg/spec3/fuzz.go
@@ -35,6 +35,18 @@ var OpenAPIV3FuzzFuncs []interface{} = []interface{}{
 	func(o *OpenAPI, c fuzz.Continue) {
 		c.FuzzNoCustom(o)
 		o.Version = "3.0.0"
+		for i, val := range o.SecurityRequirement {
+			if val == nil {
+				o.SecurityRequirement[i] = make(map[string][]string)
+			}
+
+			for k, v := range val {
+				if v == nil {
+					val[k] = make([]string, 0)
+				}
+			}
+		}
+
 	},
 	func(r *interface{}, c fuzz.Continue) {
 		switch c.Intn(3) {

--- a/pkg/spec3/spec.go
+++ b/pkg/spec3/spec.go
@@ -36,6 +36,8 @@ type OpenAPI struct {
 	Servers []*Server `json:"servers,omitempty"`
 	// Components hold various schemas for the specification
 	Components *Components `json:"components,omitempty"`
+	// SecurityRequirement holds a declaration of which security mechanisms can be used across the API
+	SecurityRequirement []map[string][]string `json:"security,omitempty"`
 	// ExternalDocs holds additional external documentation
 	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
 }
@@ -60,12 +62,13 @@ func (o *OpenAPI) MarshalJSON() ([]byte, error) {
 
 func (o *OpenAPI) MarshalNextJSON(opts jsonv2.MarshalOptions, enc *jsonv2.Encoder) error {
 	type OpenAPIOmitZero struct {
-		Version      string                 `json:"openapi"`
-		Info         *spec.Info             `json:"info"`
-		Paths        *Paths                 `json:"paths,omitzero"`
-		Servers      []*Server              `json:"servers,omitempty"`
-		Components   *Components            `json:"components,omitzero"`
-		ExternalDocs *ExternalDocumentation `json:"externalDocs,omitzero"`
+		Version             string                 `json:"openapi"`
+		Info                *spec.Info             `json:"info"`
+		Paths               *Paths                 `json:"paths,omitzero"`
+		Servers             []*Server              `json:"servers,omitempty"`
+		Components          *Components            `json:"components,omitzero"`
+		SecurityRequirement []map[string][]string  `json:"security,omitempty"`
+		ExternalDocs        *ExternalDocumentation `json:"externalDocs,omitzero"`
 	}
 	x := (*OpenAPIOmitZero)(o)
 	return opts.MarshalNext(enc, x)


### PR DESCRIPTION
While looking into k8s authentication, noticed this field should be used but is missing from the OpenAPI V3. See https://spec.openapis.org/oas/v3.0.0#openapi-object and https://spec.openapis.org/oas/v3.0.0#securityRequirementObject

/assign @apelisse