### PR TITLE
add alexzielenski to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,11 +8,13 @@ reviewers:
 - sttts
 - jpbetz
 - jefftree
+- alexzielenski
 approvers:
-- lavalamp
 - sttts
 - apelisse
 - jpbetz
 - jefftree
+- alexzielenski
 emeritus_approvers:
 - mbohlool
+- lavalamp


### PR DESCRIPTION
Nominating myself for approver. I'm a top contributor to kube-openapi for last few years over all portions of repo. I also have plans for many changes related to OpenAPI and Declarative Validation features coming up. Approvership would be use for delegating and making these changes

Also moves lavalamp to emeritus approvers

/cc @sttts @apelisse @jpbetz @Jefftree 