### PR TITLE
Support PostProcessSpec hook in V3

### DIFF
--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -326,6 +326,9 @@ func BuildOpenAPISpecFromRoutes(webServices []common.RouteContainer, config *com
 	if err != nil {
 		return nil, err
 	}
+	if config.PostProcessSpec != nil {
+		return config.PostProcessSpec(a.spec)
+	}
 	return a.spec, nil
 }
 

--- a/pkg/builder3/openapi_test.go
+++ b/pkg/builder3/openapi_test.go
@@ -436,6 +436,11 @@ func TestBuildOpenAPISpec(t *testing.T) {
 				Description: "Test API",
 				Version:     "unversioned",
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: map[string]any{
+					"hello": "world", // set from PostProcessSpec callback
+				},
+			},
 		},
 		Version: "3.0.0",
 		Paths: &spec3.Paths{
@@ -450,6 +455,12 @@ func TestBuildOpenAPISpec(t *testing.T) {
 				"builder3.TestOutput": getTestOutputDefinition(),
 			},
 		},
+	}
+	config.PostProcessSpec = func(s *spec3.OpenAPI) (*spec3.OpenAPI, error) {
+		s.Info.Extensions = map[string]any{
+			"hello": "world",
+		}
+		return s, nil
 	}
 	swagger, err := BuildOpenAPISpec(container.RegisteredWebServices(), config)
 	if !assert.NoError(err) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -164,6 +164,9 @@ type OpenAPIV3Config struct {
 	// It is an optional function to customize model names.
 	GetDefinitionName func(name string) (string, spec.Extensions)
 
+	// PostProcessSpec runs after the spec is ready to serve. It allows a final modification to the spec before serving.
+	PostProcessSpec func(*spec3.OpenAPI) (*spec3.OpenAPI, error)
+
 	// SecuritySchemes is list of all security schemes for OpenAPI service.
 	SecuritySchemes spec3.SecuritySchemes
 


### PR DESCRIPTION
Updated https://github.com/kubernetes/kube-openapi/pull/420 -- this time with the config on on OpenAPIV3Config

---

Currently, the [PostProcessSpec](https://github.com/kubernetes/kube-openapi/blob/master/pkg/common/common.go#L115) hook is only called when creating v2, but does not work for V3.  This PR adds an additional hook and calls it while creating the spec.

While building an agregated api-server I am able to apply my special needs to the V2 spec, but not v3.  The call is initiated from https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go#L68 so I think it makes most sense to hook in here, but also open to any other suggestions!
