### PR TITLE
Use better API for string comparison

### DIFF
--- a/pkg/generators/rules/names_match.go
+++ b/pkg/generators/rules/names_match.go
@@ -135,7 +135,7 @@ func namesMatch(goName, jsonName string) bool {
 	if !isAllowedName(goName) || !isAllowedName(jsonName) {
 		return false
 	}
-	if strings.ToLower(goName) != strings.ToLower(jsonName) {
+	if !strings.EqualFold(goName, jsonName) {
 		return false
 	}
 	// Go field names must be CamelCase. JSON field names must be camelCase.


### PR DESCRIPTION
## Description
While triaging your project, our bug fixing tool generated the following message-

> In file: [names_match.go](https://github.com/kubernetes/kube-openapi/blob/master/pkg/generators/rules/names_match.go#L138), there is a function `namesMatch` that performs a case insensitive String equality check. String comparison with `strings.ToLower` or `strings.ToUpper` is significantly more expensive. For example, `strings.ToLower` will have to allocate memory for the new strings, and then convert the string to lower case. It is better to do the case insensitive equality check using the [EqualFold](https://pkg.go.dev/strings#EqualFold) function. This function does not need to create two intermediate strings and can return as soon as the first non-matching character has been found. iCR fixed the issue by introducing the `strings.EqualFold` function.

As a performance upgrade, I've replaced the string comparison using the `EqualFold` method.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.


---
P.S: This PR is **NOT** generated by a bot.