### PR TITLE
Adds support for CEL marker comments

### DIFF
--- a/pkg/generators/markers.go
+++ b/pkg/generators/markers.go
@@ -295,8 +295,9 @@ func putNestedValue(m map[string]any, k []string, v any) (map[string]any, error)
 	rest := k[1:]
 
 	if idxIdx := strings.Index(key, "["); idxIdx > -1 {
+		subscript := strings.Split(key[idxIdx+1:], "]")[0]
 		key := key[:idxIdx]
-		index, err := strconv.Atoi(strings.Split(key[idxIdx+1:], "]")[0])
+		index, err := strconv.Atoi(subscript)
 		if err != nil {
 			// Ignore key
 			return nil, fmt.Errorf("expected integer index in key %v, got %v", key, key[idxIdx+1:])

--- a/pkg/generators/markers.go
+++ b/pkg/generators/markers.go
@@ -306,9 +306,15 @@ func putNestedValue(m map[string]any, k []string, v any) (map[string]any, error)
 		var arrayDestination []any
 		if existing, ok := m[key]; !ok {
 			arrayDestination = make([]any, index+1)
-		} else {
+		} else if existing, ok := existing.([]any); !ok {
+			// Error case. Existing isn't of correct type. Can happen if
+			// someone is subscripting a field that was previously not an array
+			return nil, fmt.Errorf("expected []any at key %v, got %T", key, existing)
+		} else if index >= len(existing) {
 			// Ensure array is big enough
-			arrayDestination = append(existing.([]any), make([]any, index-len(existing.([]any))+1)...)
+			arrayDestination = append(existing, make([]any, index-len(existing)+1)...)
+		} else {
+			arrayDestination = existing
 		}
 
 		m[key] = arrayDestination

--- a/pkg/generators/markers.go
+++ b/pkg/generators/markers.go
@@ -315,11 +315,10 @@ func putNestedValue(m map[string]any, k []string, v any) (map[string]any, error)
 		if arrayDestination[index] == nil {
 			// Doesn't exist case
 			destination := make(map[string]any)
-			arrayDestination[index] = destination
-			return putNestedValue(destination, rest, v)
+			arrayDestination[index], err = putNestedValue(destination, rest, v)
 		} else if dst, ok := arrayDestination[index].(map[string]any); ok {
 			// Already exists case, correct type
-			return putNestedValue(dst, rest, v)
+			arrayDestination[index], err = putNestedValue(dst, rest, v)
 		}
 
 		// Already exists, incorrect type. Error

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -1077,8 +1077,39 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 							},
 						},
 					},
+					"celField": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-validations": []interface{}{
+									map[string]interface{}{
+										"rule":    "self.length() > 0",
+										"message": "string message",
+									},
+									map[string]interface{}{
+										"rule":              "self.length() % 2 == 0",
+										"messageExpression": "self + ' hello'",
+									},
+								},
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 				},
 				Required: []string{"StringValue", "NumberValue", "ArrayValue", "MapValue"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1093,6 +1124,16 @@ func schema_test_integration_testdata_valuevalidation_Foo2(ref common.ReferenceC
 				Format:        valuevalidation.Foo2{}.OpenAPISchemaFormat(),
 				MaxProperties: ptr.To[int64](5),
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo2",
+						},
+					},
+				},
+			},
 		},
 	})
 }
@@ -1106,6 +1147,16 @@ func schema_test_integration_testdata_valuevalidation_Foo3(ref common.ReferenceC
 				Format:        valuevalidation.Foo3{}.OpenAPISchemaFormat(),
 				MaxProperties: ptr.To[int64](5),
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo3",
+						},
+					},
+				},
+			},
 		},
 	}, common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -1114,6 +1165,16 @@ func schema_test_integration_testdata_valuevalidation_Foo3(ref common.ReferenceC
 				Type:          valuevalidation.Foo3{}.OpenAPISchemaType(),
 				Format:        valuevalidation.Foo3{}.OpenAPISchemaFormat(),
 				MaxProperties: ptr.To[int64](5),
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo3",
+						},
+					},
+				},
 			},
 		},
 	})
@@ -1127,6 +1188,16 @@ func schema_test_integration_testdata_valuevalidation_Foo5(ref common.ReferenceC
 				Format:        valuevalidation.Foo5{}.OpenAPISchemaFormat(),
 				MinProperties: ptr.To[int64](1),
 				MaxProperties: ptr.To[int64](5),
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo5",
+						},
+					},
+				},
 			},
 		},
 	})

--- a/test/integration/testdata/golden.v2.json
+++ b/test/integration/testdata/golden.v2.json
@@ -1265,20 +1265,52 @@
       "maxLength": 5,
       "minLength": 1,
       "pattern": "^a.*b$"
+     },
+     "celField": {
+      "type": "string",
+      "default": "",
+      "x-kubernetes-validations": [
+       {
+        "message": "string message",
+        "rule": "self.length() \u003e 0"
+       },
+       {
+        "messageExpression": "self + ' hello'",
+        "rule": "self.length() % 2 == 0"
+       }
+      ]
      }
-    }
+    },
+    "x-kubernetes-validations": [
+     {
+      "message": "foo",
+      "rule": "self == oldSelf"
+     }
+    ]
    },
    "valuevalidation.Foo2": {
     "description": "This one has an open API v3 definition",
     "type": "test-type",
     "format": "test-format",
-    "maxProperties": 5
+    "maxProperties": 5,
+    "x-kubernetes-validations": [
+     {
+      "message": "foo2",
+      "rule": "self == oldSelf"
+     }
+    ]
    },
    "valuevalidation.Foo3": {
     "description": "This one has a OneOf",
     "type": "string",
     "format": "string",
-    "maxProperties": 5
+    "maxProperties": 5,
+    "x-kubernetes-validations": [
+     {
+      "message": "foo3",
+      "rule": "self == oldSelf"
+     }
+    ]
    },
    "valuevalidation.Foo4": {
     "type": "integer"
@@ -1287,7 +1319,13 @@
     "type": "test-type",
     "format": "test-format",
     "maxProperties": 5,
-    "minProperties": 1
+    "minProperties": 1,
+    "x-kubernetes-validations": [
+     {
+      "message": "foo5",
+      "rule": "self == oldSelf"
+     }
+    ]
    }
   },
   "responses": {

--- a/test/integration/testdata/golden.v3.json
+++ b/test/integration/testdata/golden.v3.json
@@ -1227,8 +1227,28 @@
        "maxLength": 5,
        "minLength": 1,
        "pattern": "^a.*b$"
+      },
+      "celField": {
+       "type": "string",
+       "default": "",
+       "x-kubernetes-validations": [
+        {
+         "message": "string message",
+         "rule": "self.length() \u003e 0"
+        },
+        {
+         "messageExpression": "self + ' hello'",
+         "rule": "self.length() % 2 == 0"
+        }
+       ]
       }
-     }
+     },
+     "x-kubernetes-validations": [
+      {
+       "message": "foo",
+       "rule": "self == oldSelf"
+      }
+     ]
     },
     "valuevalidation.Foo2": {
      "type": "object"
@@ -1243,6 +1263,12 @@
       },
       {
        "type": "string"
+      }
+     ],
+     "x-kubernetes-validations": [
+      {
+       "message": "foo3",
+       "rule": "self == oldSelf"
       }
      ]
     },

--- a/test/integration/testdata/valuevalidation/alpha.go
+++ b/test/integration/testdata/valuevalidation/alpha.go
@@ -12,6 +12,8 @@ import (
 // +k8s:validation:maxProperties=5
 // +k8s:validation:minProperties=1
 // +k8s:openapi-gen=true
+// +k8s:validation:cel[0]:rule="self == oldSelf"
+// +k8s:validation:cel[0]:message="foo"
 type Foo struct {
 	// +k8s:validation:maxLength=5
 	// +k8s:validation:minLength=1
@@ -33,11 +35,20 @@ type Foo struct {
 	// +k8s:validation:minProperties=1
 	// +k8s:validation:maxProperties=5
 	MapValue map[string]string
+
+	// +k8s:validation:cel[0]:rule="self.length() > 0"
+	// +k8s:validation:cel[0]:message="string message"
+	// +k8s:validation:cel[1]:rule="self.length() % 2 == 0"
+	// +k8s:validation:cel[1]:messageExpression="self + ' hello'"
+	// +optional
+	CELField string `json:"celField"`
 }
 
 // This one has an open API v3 definition
 // +k8s:validation:maxProperties=5
 // +k8s:openapi-gen=true
+// +k8s:validation:cel[0]:rule="self == oldSelf"
+// +k8s:validation:cel[0]:message="foo2"
 type Foo2 struct{}
 
 func (Foo2) OpenAPIV3Definition() common.OpenAPIDefinition {
@@ -62,6 +73,8 @@ func (Foo2) OpenAPISchemaFormat() string {
 // +k8s:openapi-gen=true
 // +k8s:validation:maxProperties=5
 // +k8s:openapi-gen=true
+// +k8s:validation:cel[0]:rule="self == oldSelf"
+// +k8s:validation:cel[0]:message="foo3"
 type Foo3 struct{}
 
 func (Foo3) OpenAPIV3OneOfTypes() []string {
@@ -77,6 +90,8 @@ func (Foo3) OpenAPISchemaFormat() string {
 // this one should ignore marker comments
 // +k8s:openapi-gen=true
 // +k8s:validation:maximum=6
+// +k8s:validation:cel[0]:rule="self == oldSelf"
+// +k8s:validation:cel[0]:message="foo4"
 type Foo4 struct{}
 
 func (Foo4) OpenAPIDefinition() common.OpenAPIDefinition {
@@ -92,6 +107,8 @@ func (Foo4) OpenAPIDefinition() common.OpenAPIDefinition {
 // +k8s:openapi-gen=true
 // +k8s:validation:maxProperties=5
 // +k8s:validation:minProperties=1
+// +k8s:validation:cel[0]:rule="self == oldSelf"
+// +k8s:validation:cel[0]:message="foo5"
 type Foo5 struct{}
 
 func (Foo5) OpenAPIV3Definition() common.OpenAPIDefinition {


### PR DESCRIPTION
Adds CEL marker comments support to kube-openapi. Previous extension support only allowed strings. This PR makes use of new marker comment system introduced in #435 to emit CEL vendor extensions.

Multiline syntax is not yet supported. Proposed syntax is 1:1 with CEL CRD fields:

```go
	// +k8s:validation:cel[0]:rule="self.length() > 0"
	// +k8s:validation:cel[0]:message="string message"
	// +k8s:validation:cel[1]:rule="self.length() % 2 == 0"
	// +k8s:validation:cel[1]:messageExpression="self + ' hello'"
	// +optional
	CELField string `json:"celField"`
```

There are linter errors to help keep the indexing straight


/assign @jefftree
/cc @Schnides123 