### PR TITLE
add raw string/multiline syntax to marker comments

### DIFF
--- a/pkg/generators/markers_test.go
+++ b/pkg/generators/markers_test.go
@@ -180,7 +180,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[2]:rule="self > 5"`,
 				`+k8s:validation:cel[2]:message="must be greater than 5"`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[2]:rule="self > 5": non-consecutive index 2 for key '+k8s:validation:cel'`,
+			expectedError: `failed to parse marker comments: error parsing cel[2]:rule="self > 5": non-consecutive index 2 for key 'cel'`,
 		},
 		{
 			t:    types.Float64,
@@ -243,7 +243,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[2]:optionalOldSelf=true`,
 				`+k8s:validation:cel[2]:message="must be greater than 5"`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[2]:rule="self > 5": non-consecutive index 2 for key '+k8s:validation:cel'`,
+			expectedError: `failed to parse marker comments: error parsing cel[2]:rule="self > 5": non-consecutive index 2 for key 'cel'`,
 		},
 		{
 			t:    types.Float64,
@@ -255,7 +255,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[0]:optionalOldSelf=true`,
 				`+k8s:validation:cel[0]:message="must be greater than 5"`,
 			},
-			expectedError: "failed to parse marker comments: error parsing +k8s:validation:cel[0]:optionalOldSelf=true: non-consecutive index 0 for key '+k8s:validation:cel'",
+			expectedError: "failed to parse marker comments: error parsing cel[0]:optionalOldSelf=true: non-consecutive index 0 for key 'cel'",
 		},
 		{
 			t:    types.Float64,
@@ -269,7 +269,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[2]:rule="a rule"`,
 				`+k8s:validation:cel[2]:message="message 2"`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[2]:rule="a rule": non-consecutive index 2 for key '+k8s:validation:cel'`,
+			expectedError: "failed to parse marker comments: error parsing cel[2]:rule=\"a rule\": non-consecutive index 2 for key 'cel'",
 		},
 		{
 			t:    types.Float64,
@@ -283,7 +283,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[2]:rule="a rule"`,
 				`+k8s:validation:cel[2]:message="message 2"`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[2]:rule="a rule": non-consecutive index 2 for key '+k8s:validation:cel'`,
+			expectedError: "failed to parse marker comments: error parsing cel[2]:rule=\"a rule\": non-consecutive index 2 for key 'cel'",
 		},
 		{
 			t:    types.Float64,
@@ -294,22 +294,46 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[1]:message="must be greater than 5"`,
 				`+k8s:validation:cel[0]:message>another raw string message`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[0]:message>another raw string message: non-consecutive index 0 for key '+k8s:validation:cel'`,
+			expectedError: "failed to parse marker comments: error parsing cel[0]:message>another raw string message: non-consecutive index 0 for key 'cel'",
 		},
 		{
-			t:    types.Float64,
+			t:    types.String,
 			name: "non-consecutive string indexing false positive",
 			comments: []string{
-				`+k8s:validation:cel[0]:rule> raw string rule [1]`,
+				`+k8s:validation:cel[0]:message>[3]string rule [1]`,
+				`+k8s:validation:cel[0]:rule="string rule [1]"`,
 				`+k8s:validation:pattern="self[3] == 'hi'"`,
+			},
+			expected: generators.CommentTags{
+				CEL: []generators.CELTag{
+					{
+						Rule:    "string rule [1]",
+						Message: "[3]string rule [1]",
+					},
+				},
+				SchemaProps: spec.SchemaProps{
+					Pattern: "self[3] == 'hi'",
+				},
 			},
 		},
 		{
-			t:    types.Float64,
+			t:    types.String,
 			name: "non-consecutive raw string indexing false positive",
 			comments: []string{
+				`+k8s:validation:cel[0]:message>[3]raw string message with subscirpt [3]"`,
 				`+k8s:validation:cel[0]:rule> raw string rule [1]`,
 				`+k8s:validation:pattern>"self[3] == 'hi'"`,
+			},
+			expected: generators.CommentTags{
+				CEL: []generators.CELTag{
+					{
+						Rule:    "raw string rule [1]",
+						Message: "[3]raw string message with subscirpt [3]\"",
+					},
+				},
+				SchemaProps: spec.SchemaProps{
+					Pattern: `"self[3] == 'hi'"`,
+				},
 			},
 		},
 		{
@@ -320,7 +344,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+k8s:validation:cel[0]:message="cant change"`,
 				`+k8s:validation:cel[2]:optionalOldSelf`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[2]:optionalOldSelf: non-consecutive index 2 for key '+k8s:validation:cel'`,
+			expectedError: `failed to parse marker comments: error parsing cel[2]:optionalOldSelf: non-consecutive index 2 for key 'cel'`,
 		},
 		{
 			t:    types.Float64,
@@ -333,7 +357,7 @@ func TestParseCommentTags(t *testing.T) {
 				`+minimum=5`,
 				`+k8s:validation:cel[1]:optionalOldSelf`,
 			},
-			expectedError: `failed to parse marker comments: error parsing +k8s:validation:cel[1]:optionalOldSelf: non-consecutive index 1 for key '+k8s:validation:cel'`,
+			expectedError: `failed to parse marker comments: error parsing cel[1]:optionalOldSelf: non-consecutive index 1 for key 'cel'`,
 		},
 		{
 			t:    types.Float64,
@@ -369,7 +393,7 @@ func TestParseCommentTags(t *testing.T) {
 			expected: generators.CommentTags{
 				CEL: []generators.CELTag{
 					{
-						Rule:    " raw string rule",
+						Rule:    "raw string rule",
 						Message: "raw string message",
 					},
 				},
@@ -387,7 +411,7 @@ func TestParseCommentTags(t *testing.T) {
 			expected: generators.CommentTags{
 				CEL: []generators.CELTag{
 					{
-						Rule:    " self.length() % 2 == 0\n   ? self.field == self.name + ' is even'\n   : self.field == self.name + ' is odd'",
+						Rule:    "self.length() % 2 == 0\n? self.field == self.name + ' is even'\n: self.field == self.name + ' is odd'",
 						Message: "raw string message",
 					},
 				},
@@ -405,7 +429,7 @@ func TestParseCommentTags(t *testing.T) {
 			expected: generators.CommentTags{
 				CEL: []generators.CELTag{
 					{
-						Rule:    "self.length() % 2 == 0\n  ? self.field == self.name + ' is even'\n  : self.field == self.name + ' is odd'",
+						Rule:    "self.length() % 2 == 0\n? self.field == self.name + ' is even'\n: self.field == self.name + ' is odd'",
 						Message: "raw string message",
 					},
 				},

--- a/pkg/generators/markers_test.go
+++ b/pkg/generators/markers_test.go
@@ -435,6 +435,26 @@ func TestParseCommentTags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "raw string with different key in between",
+			t:    types.Float64,
+			comments: []string{
+				`+k8s:validation:cel[0]:message>raw string message`,
+				`+k8s:validation:cel[0]:rule="self.length() % 2 == 0"`,
+				`+k8s:validation:cel[0]:message>raw string message 2`,
+			},
+			expectedError: `failed to parse marker comments: concatenations to key 'cel[0]:message' must be consecutive with its assignment`,
+		},
+		{
+			name: "raw string with different raw string key in between",
+			t:    types.Float64,
+			comments: []string{
+				`+k8s:validation:cel[0]:message>raw string message`,
+				`+k8s:validation:cel[0]:rule>self.length() % 2 == 0`,
+				`+k8s:validation:cel[0]:message>raw string message 2`,
+			},
+			expectedError: `failed to parse marker comments: concatenations to key 'cel[0]:message' must be consecutive with its assignment`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -640,14 +640,14 @@ func (g openAPITypeWriter) emitExtensions(extensions []extension, unions []union
 		for _, rule := range celRules {
 			g.Do("map[string]interface{}{\n", nil)
 
-			g.Do("\"rule\": \"$.$\",\n", rule.Rule)
+			g.Do("\"rule\": $.$,\n", fmt.Sprintf("%#v", rule.Rule))
 
 			if len(rule.Message) > 0 {
-				g.Do("\"message\": \"$.$\",\n", rule.Message)
+				g.Do("\"message\": $.$,\n", fmt.Sprintf("%#v", rule.Message))
 			}
 
 			if len(rule.MessageExpression) > 0 {
-				g.Do("\"messageExpression\": \"$.$\",\n", rule.MessageExpression)
+				g.Do("\"messageExpression\": $.$,\n", fmt.Sprintf("%#v", rule.MessageExpression))
 			}
 
 			if rule.OptionalOldSelf != nil && *rule.OptionalOldSelf {

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -38,7 +38,7 @@ import (
 
 // This is the comment tag that carries parameters for open API generation.
 const tagName = "k8s:openapi-gen"
-const markerPrefix = "k8s:validation:"
+const markerPrefix = "+k8s:validation:"
 const tagOptional = "optional"
 const tagDefault = "default"
 

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -2113,9 +2113,10 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 		type Blah struct {
 			// +k8s:validation:cel[0]:rule="self.length() > 0"
 			// +k8s:validation:cel[0]:message="string message"
-			// +k8s:validation:cel[1]:rule>  
-			// +k8s:validation:cel[1]:rule>  self.length() % 2 == 0
-			// +k8s:validation:cel[1]:messageExpression="self + ' hello'"
+			// +k8s:validation:cel[1]:rule>  !oldSelf.hasValue() || self.length() % 2 == 0
+			// +k8s:validation:cel[1]:rule>     ? self.field == "even"
+			// +k8s:validation:cel[1]:rule>     : self.field == "odd"
+			// +k8s:validation:cel[1]:messageExpression="field must be whether the length of the string is even or odd"
 			// +k8s:validation:cel[1]:optionalOldSelf
 			// +optional
 			Field string
@@ -2144,8 +2145,8 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 											"message": "string message",
 										},
 										map[string]interface{}{
-											"rule": "self.length() % 2 == 0",
-											"messageExpression": "self + ' hello'",
+											"rule": "!oldSelf.hasValue() || self.length() % 2 == 0\n? self.field == \"even\"\n: self.field == \"odd\"",
+											"messageExpression": "field must be whether the length of the string is even or odd",
 											"optionalOldSelf": ptr.To[bool](true),
 										},
 									},

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -2102,6 +2102,85 @@ func TestCELMarkerComments(t *testing.T) {
 	}
 }
 
+func TestMultilineCELMarkerComments(t *testing.T) {
+
+	callErr, funcErr, assert, _, funcBuffer, imports := testOpenAPITypeWriter(t, `
+		package foo
+
+		// +k8s:openapi-gen=true
+		// +k8s:validation:cel[0]:rule="self == oldSelf"
+		// +k8s:validation:cel[0]:message="message1"
+		type Blah struct {
+			// +k8s:validation:cel[0]:rule="self.length() > 0"
+			// +k8s:validation:cel[0]:message="string message"
+			// +k8s:validation:cel[1]:rule>  
+			// +k8s:validation:cel[1]:rule>  self.length() % 2 == 0
+			// +k8s:validation:cel[1]:messageExpression="self + ' hello'"
+			// +k8s:validation:cel[1]:optionalOldSelf
+			// +optional
+			Field string
+		}
+	`)
+
+	assert.NoError(funcErr)
+	assert.NoError(callErr)
+	assert.ElementsMatch(imports, []string{`foo "base/foo"`, `common "k8s.io/kube-openapi/pkg/common"`, `spec "k8s.io/kube-openapi/pkg/validation/spec"`, `ptr "k8s.io/utils/ptr"`})
+
+	if formatted, err := format.Source(funcBuffer.Bytes()); err != nil {
+		t.Fatalf("%v\n%v", err, string(funcBuffer.Bytes()))
+	} else {
+		formatted_expected, ree := format.Source([]byte(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+		return common.OpenAPIDefinition{
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: 			  []string{"object"},
+					Properties: map[string]spec.Schema{
+						"Field": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-validations": []interface{}{
+										map[string]interface{}{
+											"rule": "self.length() > 0",
+											"message": "string message",
+										},
+										map[string]interface{}{
+											"rule": "self.length() % 2 == 0",
+											"messageExpression": "self + ' hello'",
+											"optionalOldSelf": ptr.To[bool](true),
+										},
+									},
+								},
+							},
+							SchemaProps: spec.SchemaProps{
+								Default: "",
+								Type:    []string{"string"},
+								Format:  "",
+							},
+						},
+					},
+				},
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: spec.Extensions{
+						"x-kubernetes-validations": []interface{}{
+							map[string]interface{}{
+								"rule": "self == oldSelf",
+								"message": "message1",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+`))
+		if ree != nil {
+			t.Fatal(ree)
+		}
+		assert.Equal(string(formatted_expected), string(formatted))
+	}
+}
+
 func TestMarkerCommentsCustomDefsV3(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer, _ := testOpenAPITypeWriter(t, `
 package foo


### PR DESCRIPTION
adds ability to specify a raw/multiline string in kube-openapi marker comments to make longer strings more ergonomic to use

Syntax Example:

```
+k8s:validation:key> value line 1
+k8s:validation:key> value line 2
```

yields `key=" validation line 2\n validation line 2"`

Using `=` to specify multiple key-value pairs is now an error for `k8s:validation` prefixed items. Lists must be specified using explicit indices

/assign @Jefftree 
/cc @Schnides123 