### PR TITLE
feature: make cel marker comments aware of reason and field path

### DIFF
--- a/pkg/generators/markers.go
+++ b/pkg/generators/markers.go
@@ -35,6 +35,8 @@ type CELTag struct {
 	Message           string `json:"message,omitempty"`
 	MessageExpression string `json:"messageExpression,omitempty"`
 	OptionalOldSelf   *bool  `json:"optionalOldSelf,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+	FieldPath         string `json:"fieldPath,omitempty"`
 }
 
 func (c *CELTag) Validate() error {

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -660,6 +660,14 @@ func (g openAPITypeWriter) emitExtensions(extensions []extension, unions []union
 				})
 			}
 
+			if len(rule.Reason) > 0 {
+				g.Do("\"reason\": $.$,\n", fmt.Sprintf("%#v", rule.Reason))
+			}
+
+			if len(rule.FieldPath) > 0 {
+				g.Do("\"fieldPath\": $.$,\n", fmt.Sprintf("%#v", rule.FieldPath))
+			}
+
 			g.Do("},\n", nil)
 		}
 		g.Do("},\n", nil)

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -2110,9 +2110,11 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 		// +k8s:openapi-gen=true
 		// +k8s:validation:cel[0]:rule="self == oldSelf"
 		// +k8s:validation:cel[0]:message="message1"
+		// +k8s:validation:cel[0]:fieldPath="field"
 		type Blah struct {
 			// +k8s:validation:cel[0]:rule="self.length() > 0"
 			// +k8s:validation:cel[0]:message="string message"
+			// +k8s:validation:cel[0]:reason="Invalid"
 			// +k8s:validation:cel[1]:rule>  !oldSelf.hasValue() || self.length() % 2 == 0
 			// +k8s:validation:cel[1]:rule>     ? self.field == "even"
 			// +k8s:validation:cel[1]:rule>     : self.field == "odd"
@@ -2143,6 +2145,7 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 										map[string]interface{}{
 											"rule": "self.length() > 0",
 											"message": "string message",
+											"reason": "Invalid",
 										},
 										map[string]interface{}{
 											"rule": "!oldSelf.hasValue() || self.length() % 2 == 0\n? self.field == \"even\"\n: self.field == \"odd\"",
@@ -2166,6 +2169,7 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 							map[string]interface{}{
 								"rule": "self == oldSelf",
 								"message": "message1",
+								"fieldPath": "field",
 							},
 						},
 					},


### PR DESCRIPTION
These fields were not included in the original feature implementation, but necessary for annotations

/cc @jefftree