### PR TITLE
refactor: make CommentTags internal

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -412,6 +412,7 @@ func (g openAPITypeWriter) generateValueValidations(vs *spec.SchemaProps) error 
 	if vs.UniqueItems {
 		g.Do("UniqueItems: true,\n", nil)
 	}
+
 	return nil
 }
 
@@ -419,7 +420,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 	// Only generate for struct type and ignore the rest
 	switch t.Kind {
 	case types.Struct:
-		overrides, err := ParseCommentTags(t, t.CommentLines, markerPrefix)
+		validationSchema, err := ParseCommentTags(t, t.CommentLines, markerPrefix)
 		if err != nil {
 			return err
 		}
@@ -444,12 +445,12 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			g.generateDescription(t.CommentLines)
 			g.Do("Type:$.type|raw${}.OpenAPISchemaType(),\n"+
 				"Format:$.type|raw${}.OpenAPISchemaFormat(),\n", args)
-			err = g.generateValueValidations(&overrides.SchemaProps)
+			err = g.generateValueValidations(&validationSchema.SchemaProps)
 			if err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
-			if err := g.generateStructExtensions(t, overrides); err != nil {
+			if err := g.generateStructExtensions(t, validationSchema.Extensions); err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
@@ -463,12 +464,12 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			g.generateDescription(t.CommentLines)
 			g.Do("OneOf:common.GenerateOpenAPIV3OneOfSchema($.type|raw${}.OpenAPIV3OneOfTypes()),\n"+
 				"Format:$.type|raw${}.OpenAPISchemaFormat(),\n", args)
-			err = g.generateValueValidations(&overrides.SchemaProps)
+			err = g.generateValueValidations(&validationSchema.SchemaProps)
 			if err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
-			if err := g.generateStructExtensions(t, overrides); err != nil {
+			if err := g.generateStructExtensions(t, validationSchema.Extensions); err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
@@ -480,12 +481,12 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			g.generateDescription(t.CommentLines)
 			g.Do("Type:$.type|raw${}.OpenAPISchemaType(),\n"+
 				"Format:$.type|raw${}.OpenAPISchemaFormat(),\n", args)
-			err = g.generateValueValidations(&overrides.SchemaProps)
+			err = g.generateValueValidations(&validationSchema.SchemaProps)
 			if err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
-			if err := g.generateStructExtensions(t, overrides); err != nil {
+			if err := g.generateStructExtensions(t, validationSchema.Extensions); err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
@@ -498,12 +499,12 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			g.generateDescription(t.CommentLines)
 			g.Do("Type:$.type|raw${}.OpenAPISchemaType(),\n"+
 				"Format:$.type|raw${}.OpenAPISchemaFormat(),\n", args)
-			err = g.generateValueValidations(&overrides.SchemaProps)
+			err = g.generateValueValidations(&validationSchema.SchemaProps)
 			if err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
-			if err := g.generateStructExtensions(t, overrides); err != nil {
+			if err := g.generateStructExtensions(t, validationSchema.Extensions); err != nil {
 				return err
 			}
 			g.Do("},\n", nil)
@@ -517,7 +518,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		g.Do("return $.OpenAPIDefinition|raw${\nSchema: spec.Schema{\nSchemaProps: spec.SchemaProps{\n", args)
 		g.generateDescription(t.CommentLines)
 		g.Do("Type: []string{\"object\"},\n", nil)
-		err = g.generateValueValidations(&overrides.SchemaProps)
+		err = g.generateValueValidations(&validationSchema.SchemaProps)
 		if err != nil {
 			return err
 		}
@@ -541,7 +542,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			g.Do("Required: []string{\"$.$\"},\n", strings.Join(required, "\",\""))
 		}
 		g.Do("},\n", nil)
-		if err := g.generateStructExtensions(t, overrides); err != nil {
+		if err := g.generateStructExtensions(t, validationSchema.Extensions); err != nil {
 			return err
 		}
 		g.Do("},\n", nil)
@@ -574,7 +575,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 	return nil
 }
 
-func (g openAPITypeWriter) generateStructExtensions(t *types.Type, tags CommentTags) error {
+func (g openAPITypeWriter) generateStructExtensions(t *types.Type, otherExtensions map[string]interface{}) error {
 	extensions, errors := parseExtensions(t.CommentLines)
 	// Initially, we will only log struct extension errors.
 	if len(errors) > 0 {
@@ -590,11 +591,11 @@ func (g openAPITypeWriter) generateStructExtensions(t *types.Type, tags CommentT
 	}
 
 	// TODO(seans3): Validate struct extensions here.
-	g.emitExtensions(extensions, unions, tags.CEL)
+	g.emitExtensions(extensions, unions, otherExtensions)
 	return nil
 }
 
-func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *types.Type, tags CommentTags) error {
+func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *types.Type, otherExtensions map[string]interface{}) error {
 	extensions, parseErrors := parseExtensions(m.CommentLines)
 	validationErrors := validateMemberExtensions(extensions, m)
 	errors := append(parseErrors, validationErrors...)
@@ -605,13 +606,13 @@ func (g openAPITypeWriter) generateMemberExtensions(m *types.Member, parent *typ
 			klog.V(2).Infof("%s %s\n", errorPrefix, e)
 		}
 	}
-	g.emitExtensions(extensions, nil, tags.CEL)
+	g.emitExtensions(extensions, nil, otherExtensions)
 	return nil
 }
 
-func (g openAPITypeWriter) emitExtensions(extensions []extension, unions []union, celRules []CELTag) {
+func (g openAPITypeWriter) emitExtensions(extensions []extension, unions []union, otherExtensions map[string]interface{}) {
 	// If any extensions exist, then emit code to create them.
-	if len(extensions) == 0 && len(unions) == 0 && len(celRules) == 0 {
+	if len(extensions) == 0 && len(unions) == 0 && len(otherExtensions) == 0 {
 		return
 	}
 	g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
@@ -635,42 +636,13 @@ func (g openAPITypeWriter) emitExtensions(extensions []extension, unions []union
 		g.Do("},\n", nil)
 	}
 
-	if len(celRules) > 0 {
-		g.Do("\"x-kubernetes-validations\": []interface{}{\n", nil)
-		for _, rule := range celRules {
-			g.Do("map[string]interface{}{\n", nil)
-
-			g.Do("\"rule\": $.$,\n", fmt.Sprintf("%#v", rule.Rule))
-
-			if len(rule.Message) > 0 {
-				g.Do("\"message\": $.$,\n", fmt.Sprintf("%#v", rule.Message))
-			}
-
-			if len(rule.MessageExpression) > 0 {
-				g.Do("\"messageExpression\": $.$,\n", fmt.Sprintf("%#v", rule.MessageExpression))
-			}
-
-			if rule.OptionalOldSelf != nil && *rule.OptionalOldSelf {
-				g.Do("\"optionalOldSelf\": $.ptrTo|raw$[bool](true),\n", generator.Args{
-					"ptrTo": &types.Type{
-						Name: types.Name{
-							Package: "k8s.io/utils/ptr",
-							Name:    "To",
-						}},
-				})
-			}
-
-			if len(rule.Reason) > 0 {
-				g.Do("\"reason\": $.$,\n", fmt.Sprintf("%#v", rule.Reason))
-			}
-
-			if len(rule.FieldPath) > 0 {
-				g.Do("\"fieldPath\": $.$,\n", fmt.Sprintf("%#v", rule.FieldPath))
-			}
-
-			g.Do("},\n", nil)
+	if len(otherExtensions) > 0 {
+		for k, v := range otherExtensions {
+			g.Do("$.key$: $.value$,\n", map[string]interface{}{
+				"key":   fmt.Sprintf("%#v", k),
+				"value": fmt.Sprintf("%#v", v),
+			})
 		}
-		g.Do("},\n", nil)
 	}
 
 	g.Do("},\n},\n", nil)
@@ -857,7 +829,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 	if name == "" {
 		return nil
 	}
-	overrides, err := ParseCommentTags(m.Type, m.CommentLines, markerPrefix)
+	validationSchema, err := ParseCommentTags(m.Type, m.CommentLines, markerPrefix)
 	if err != nil {
 		return err
 	}
@@ -865,7 +837,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 		return err
 	}
 	g.Do("\"$.$\": {\n", name)
-	if err := g.generateMemberExtensions(m, parent, overrides); err != nil {
+	if err := g.generateMemberExtensions(m, parent, validationSchema.Extensions); err != nil {
 		return err
 	}
 	g.Do("SchemaProps: spec.SchemaProps{\n", nil)
@@ -884,7 +856,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 	if err := g.generateDefault(m.CommentLines, m.Type, omitEmpty, parent); err != nil {
 		return fmt.Errorf("failed to generate default in %v: %v: %v", parent, m.Name, err)
 	}
-	err = g.generateValueValidations(&overrides.SchemaProps)
+	err = g.generateValueValidations(&validationSchema.SchemaProps)
 	if err != nil {
 		return err
 	}

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -2045,7 +2045,7 @@ func TestCELMarkerComments(t *testing.T) {
 
 	assert.NoError(funcErr)
 	assert.NoError(callErr)
-	assert.ElementsMatch(imports, []string{`foo "base/foo"`, `common "k8s.io/kube-openapi/pkg/common"`, `spec "k8s.io/kube-openapi/pkg/validation/spec"`, `ptr "k8s.io/utils/ptr"`})
+	assert.ElementsMatch(imports, []string{`foo "base/foo"`, `common "k8s.io/kube-openapi/pkg/common"`, `spec "k8s.io/kube-openapi/pkg/validation/spec"`})
 
 	if formatted, err := format.Source(funcBuffer.Bytes()); err != nil {
 		t.Fatalf("%v\n%v", err, string(funcBuffer.Bytes()))
@@ -2059,17 +2059,7 @@ func TestCELMarkerComments(t *testing.T) {
 						"Field": {
 							VendorExtensible: spec.VendorExtensible{
 								Extensions: spec.Extensions{
-									"x-kubernetes-validations": []interface{}{
-										map[string]interface{}{
-											"rule": "self.length() > 0",
-											"message": "string message",
-										},
-										map[string]interface{}{
-											"rule": "self.length() % 2 == 0",
-											"messageExpression": "self + ' hello'",
-											"optionalOldSelf": ptr.To[bool](true),
-										},
-									},
+									"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "string message", "rule": "self.length() > 0"}, map[string]interface{}{"messageExpression": "self + ' hello'", "optionalOldSelf": true, "rule": "self.length() % 2 == 0"}},
 								},
 							},
 							SchemaProps: spec.SchemaProps{
@@ -2082,12 +2072,7 @@ func TestCELMarkerComments(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validations": []interface{}{
-							map[string]interface{}{
-								"rule": "self == oldSelf",
-								"message": "message1",
-							},
-						},
+						"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "message1", "rule": "self == oldSelf"}},
 					},
 				},
 			},
@@ -2127,7 +2112,7 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 
 	assert.NoError(funcErr)
 	assert.NoError(callErr)
-	assert.ElementsMatch(imports, []string{`foo "base/foo"`, `common "k8s.io/kube-openapi/pkg/common"`, `spec "k8s.io/kube-openapi/pkg/validation/spec"`, `ptr "k8s.io/utils/ptr"`})
+	assert.ElementsMatch(imports, []string{`foo "base/foo"`, `common "k8s.io/kube-openapi/pkg/common"`, `spec "k8s.io/kube-openapi/pkg/validation/spec"`})
 
 	if formatted, err := format.Source(funcBuffer.Bytes()); err != nil {
 		t.Fatalf("%v\n%v", err, string(funcBuffer.Bytes()))
@@ -2141,18 +2126,7 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 						"Field": {
 							VendorExtensible: spec.VendorExtensible{
 								Extensions: spec.Extensions{
-									"x-kubernetes-validations": []interface{}{
-										map[string]interface{}{
-											"rule": "self.length() > 0",
-											"message": "string message",
-											"reason": "Invalid",
-										},
-										map[string]interface{}{
-											"rule": "!oldSelf.hasValue() || self.length() % 2 == 0\n? self.field == \"even\"\n: self.field == \"odd\"",
-											"messageExpression": "field must be whether the length of the string is even or odd",
-											"optionalOldSelf": ptr.To[bool](true),
-										},
-									},
+									"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "string message", "reason": "Invalid", "rule": "self.length() > 0"}, map[string]interface{}{"messageExpression": "field must be whether the length of the string is even or odd", "optionalOldSelf": true, "rule": "!oldSelf.hasValue() || self.length() % 2 == 0\n? self.field == \"even\"\n: self.field == \"odd\""}},
 								},
 							},
 							SchemaProps: spec.SchemaProps{
@@ -2165,13 +2139,7 @@ func TestMultilineCELMarkerComments(t *testing.T) {
 				},
 				VendorExtensible: spec.VendorExtensible{
 					Extensions: spec.Extensions{
-						"x-kubernetes-validations": []interface{}{
-							map[string]interface{}{
-								"rule": "self == oldSelf",
-								"message": "message1",
-								"fieldPath": "field",
-							},
-						},
+						"x-kubernetes-validations": []interface{}{map[string]interface{}{"fieldPath": "field", "message": "message1", "rule": "self == oldSelf"}},
 					},
 				},
 			},


### PR DESCRIPTION
I think it more straightforward to convert the commentTags into a spec.Schema and generate from that. Especially as we begin to add more "virtual" markers to the struct rather than direct spec.SchemaProps. Generating from an intermediate `spec.SchemaProps` I think will make things more maintainable in the long run