### PR TITLE
test/integration: bump timeout to 20s

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -50,7 +50,7 @@ const (
 	generatedOpenAPIv3FileName = "generated.v3.json"
 	goldenOpenAPIv3Filename    = "golden.v3.json"
 
-	timeoutSeconds = 10.0
+	timeoutSeconds = 20.0
 )
 
 var (


### PR DESCRIPTION
The current timeout seems to assume a relatively fast host, double it to make the testsuite pass on slower hosts.

This is need for instance to build kube-openapi on Debian riscv64 build daemons, which are a tad too slow for the current timeout: https://buildd.debian.org/status/fetch.php?pkg=golang-k8s-kube-openapi&arch=riscv64&ver=0.0%7Egit20231214.ab13479-1&stamp=1707440925&raw=0