### PR TITLE
bugfix: dont throw error if +required is set with omitempty

### DIFF
--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -121,7 +121,7 @@ func parseEnums(c *generator.Context) enumMap {
 					Value:   *c.ConstValue,
 					Comment: strings.Join(c.CommentLines, " "),
 				}
-				enumTypes[enumType.Name].appendValue(value)
+				enumTypes[enumType.Name].addIfNotPresent(value)
 			}
 		}
 	}
@@ -129,7 +129,15 @@ func parseEnums(c *generator.Context) enumMap {
 	return enumTypes
 }
 
-func (et *enumType) appendValue(value *enumValue) {
+func (et *enumType) addIfNotPresent(value *enumValue) {
+	// If we already have an enum case with the same value, then ignore this new
+	// one. This can happen if an enum aliases one from another package and
+	// re-exports the cases.
+	for _, existing := range et.Values {
+		if existing.Value == value.Value {
+			return
+		}
+	}
 	et.Values = append(et.Values, value)
 }
 

--- a/pkg/generators/enum_test.go
+++ b/pkg/generators/enum_test.go
@@ -167,6 +167,91 @@ func TestParseEnums(t *testing.T) {
 				"foo.Foo": {"different", "same"},
 			},
 		},
+		{
+			name: "aliasing and re-exporting enum from different package",
+			universe: types.Universe{
+				"foo": &types.Package{
+					Name: "foo",
+					Types: map[string]*types.Type{
+						"Foo": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "Foo",
+							},
+							Kind:         types.Alias,
+							Underlying:   types.String,
+							CommentLines: []string{"+enum"},
+						},
+					},
+					Constants: map[string]*types.Type{
+						"FooCase1": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "FooCase1",
+							},
+							Kind: types.DeclarationOf,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"case1"}[0],
+						},
+						"FooCase2": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "FooCase2",
+							},
+							Kind: types.DeclarationOf,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"case2"}[0],
+						},
+					},
+				},
+				"bar": &types.Package{
+					Name: "bar",
+					Constants: map[string]*types.Type{
+						"FooCase1": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "FooCase1",
+							},
+							Kind: types.DeclarationOf,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"case1"}[0],
+						},
+						"FooCase2": {
+							Name: types.Name{
+								Package: "foo",
+								Name:    "FooCase2",
+							},
+							Kind: types.DeclarationOf,
+							Underlying: &types.Type{
+								Name: types.Name{
+									Package: "foo",
+									Name:    "Foo",
+								},
+							},
+							ConstValue: &[]string{"case2"}[0],
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				"foo.Foo": {"case1", "case2"},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			enums := parseEnums(&generator.Context{Universe: tc.universe})

--- a/pkg/generators/union.go
+++ b/pkg/generators/union.go
@@ -163,7 +163,7 @@ func parseUnionStruct(t *types.Type) (*union, []error) {
 		if types.ExtractCommentTags("+", m.CommentLines)[tagUnionDiscriminator] != nil {
 			errors = append(errors, u.setDiscriminator(jsonName)...)
 		} else {
-			if !hasOptionalTag(&m) {
+			if optional, err := isOptional(&m); !optional || err != nil {
 				errors = append(errors, fmt.Errorf("union members must be optional: %v.%v", t.Name, m.Name))
 			}
 			u.addMember(jsonName, m.Name)
@@ -194,7 +194,7 @@ func parseUnionMembers(t *types.Type) (*union, []error) {
 			continue
 		}
 		if types.ExtractCommentTags("+", m.CommentLines)[tagUnionDeprecated] != nil {
-			if !hasOptionalTag(&m) {
+			if optional, err := isOptional(&m); !optional || err != nil {
 				errors = append(errors, fmt.Errorf("union members must be optional: %v.%v", t.Name, m.Name))
 			}
 			u.addMember(jsonName, m.Name)


### PR DESCRIPTION
I had included a bug into previous PR #448 which throws an error if +required is set on an `omitempty` field which ran counter to my interests.

Took another stab at it, this time including tests :)


/assign @Jefftree 
sorry for the churn.

/hold

Am also going to try to pin dep after this one so will wait for green PR there before merging this