### PR TITLE
Support defining a custom schema from raw json

### DIFF
--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1217,6 +1217,35 @@ Format:foo.Blah{}.OpenAPISchemaFormat(),
 `, funcBuffer.String())
 }
 
+func TestRawJSONSchemaDefs(t *testing.T) {
+	callErr, funcErr, assert, callBuffer, funcBuffer, _ := testOpenAPITypeWriter(t, `
+package foo
+
+import "encoding/json"
+
+// Blah is a custom type
+type Blah struct {
+}
+
+func (_ Blah) OpenAPISchemaJSON() json.RawMessage { return json.RawMessage("{}") } // invalid
+`)
+	if callErr != nil {
+		t.Fatal(callErr)
+	}
+	if funcErr != nil {
+		t.Fatal(funcErr)
+	}
+	assert.Equal(`"base/foo.Blah": schema_base_foo_Blah(ref),
+`, callBuffer.String())
+	assert.Equal(`func schema_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+schema := spec.Schema{}
+_ = schema.UnmarshalJSON( foo.Blah{}.OpenAPISchemaJSON())
+return common.OpenAPIDefinition{Schema: schema}
+}
+
+`, funcBuffer.String())
+}
+
 func TestPointer(t *testing.T) {
 	callErr, funcErr, assert, callBuffer, funcBuffer, _ := testOpenAPITypeWriter(t, `
 package foo

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -40,6 +40,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/kube-openapi/test/integration/testdata/custom.Bak":                          custom.Bak{}.OpenAPIDefinition(),
 		"k8s.io/kube-openapi/test/integration/testdata/custom.Bal":                          custom.Bal{}.OpenAPIV3Definition(),
 		"k8s.io/kube-openapi/test/integration/testdata/custom.FooV3OneOf":                   schema_test_integration_testdata_custom_FooV3OneOf(ref),
+		"k8s.io/kube-openapi/test/integration/testdata/custom.FooV3Raw":                     schema_test_integration_testdata_custom_FooV3Raw(ref),
 		"k8s.io/kube-openapi/test/integration/testdata/defaults.Defaulted":                  schema_test_integration_testdata_defaults_Defaulted(ref),
 		"k8s.io/kube-openapi/test/integration/testdata/defaults.SubStruct":                  schema_test_integration_testdata_defaults_SubStruct(ref),
 		"k8s.io/kube-openapi/test/integration/testdata/dummytype.Bar":                       schema_test_integration_testdata_dummytype_Bar(ref),
@@ -101,6 +102,12 @@ func schema_test_integration_testdata_custom_FooV3OneOf(ref common.ReferenceCall
 			},
 		},
 	})
+}
+
+func schema_test_integration_testdata_custom_FooV3Raw(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	schema := spec.Schema{}
+	_ = schema.UnmarshalJSON(custom.FooV3Raw{}.OpenAPISchemaJSON())
+	return common.OpenAPIDefinition{Schema: schema}
 }
 
 func schema_test_integration_testdata_defaults_Defaulted(ref common.ReferenceCallback) common.OpenAPIDefinition {
@@ -1080,16 +1087,7 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 					"celField": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-validations": []interface{}{
-									map[string]interface{}{
-										"rule":    "self.length() > 0",
-										"message": "string message",
-									},
-									map[string]interface{}{
-										"rule":              "self.length() % 2 == 0",
-										"messageExpression": "self + ' hello'",
-									},
-								},
+								"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "string message", "rule": "self.length() > 0"}, map[string]interface{}{"messageExpression": "self + ' hello'", "rule": "self.length() % 2 == 0"}},
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -1103,12 +1101,7 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{
-						map[string]interface{}{
-							"rule":    "self == oldSelf",
-							"message": "foo",
-						},
-					},
+					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo", "rule": "self == oldSelf"}},
 				},
 			},
 		},
@@ -1126,12 +1119,7 @@ func schema_test_integration_testdata_valuevalidation_Foo2(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{
-						map[string]interface{}{
-							"rule":    "self == oldSelf",
-							"message": "foo2",
-						},
-					},
+					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo2", "rule": "self == oldSelf"}},
 				},
 			},
 		},
@@ -1149,12 +1137,7 @@ func schema_test_integration_testdata_valuevalidation_Foo3(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{
-						map[string]interface{}{
-							"rule":    "self == oldSelf",
-							"message": "foo3",
-						},
-					},
+					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo3", "rule": "self == oldSelf"}},
 				},
 			},
 		},
@@ -1168,12 +1151,7 @@ func schema_test_integration_testdata_valuevalidation_Foo3(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{
-						map[string]interface{}{
-							"rule":    "self == oldSelf",
-							"message": "foo3",
-						},
-					},
+					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo3", "rule": "self == oldSelf"}},
 				},
 			},
 		},
@@ -1191,12 +1169,7 @@ func schema_test_integration_testdata_valuevalidation_Foo5(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{
-						map[string]interface{}{
-							"rule":    "self == oldSelf",
-							"message": "foo5",
-						},
-					},
+					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo5", "rule": "self == oldSelf"}},
 				},
 			},
 		},

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -1087,7 +1087,16 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 					"celField": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "string message", "rule": "self.length() > 0"}, map[string]interface{}{"messageExpression": "self + ' hello'", "rule": "self.length() % 2 == 0"}},
+								"x-kubernetes-validations": []interface{}{
+									map[string]interface{}{
+										"rule":    "self.length() > 0",
+										"message": "string message",
+									},
+									map[string]interface{}{
+										"rule":              "self.length() % 2 == 0",
+										"messageExpression": "self + ' hello'",
+									},
+								},
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -1101,7 +1110,12 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo", "rule": "self == oldSelf"}},
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo",
+						},
+					},
 				},
 			},
 		},
@@ -1119,7 +1133,12 @@ func schema_test_integration_testdata_valuevalidation_Foo2(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo2", "rule": "self == oldSelf"}},
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo2",
+						},
+					},
 				},
 			},
 		},
@@ -1137,7 +1156,12 @@ func schema_test_integration_testdata_valuevalidation_Foo3(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo3", "rule": "self == oldSelf"}},
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo3",
+						},
+					},
 				},
 			},
 		},
@@ -1151,7 +1175,12 @@ func schema_test_integration_testdata_valuevalidation_Foo3(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo3", "rule": "self == oldSelf"}},
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo3",
+						},
+					},
 				},
 			},
 		},
@@ -1169,7 +1198,12 @@ func schema_test_integration_testdata_valuevalidation_Foo5(ref common.ReferenceC
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo5", "rule": "self == oldSelf"}},
+					"x-kubernetes-validations": []interface{}{
+						map[string]interface{}{
+							"rule":    "self == oldSelf",
+							"message": "foo5",
+						},
+					},
 				},
 			},
 		},

--- a/test/integration/testdata/custom/v3.go
+++ b/test/integration/testdata/custom/v3.go
@@ -17,6 +17,8 @@ limitations under the License.
 package custom
 
 import (
+	"encoding/json"
+
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -90,4 +92,24 @@ func (FooV3OneOf) OpenAPISchemaType() []string {
 }
 func (FooV3OneOf) OpenAPISchemaFormat() string {
 	return "string"
+}
+
+// This one has a raw JSON schema
+// +k8s:openapi-gen=true
+type FooV3Raw struct{}
+
+func (FooV3Raw) OpenAPISchemaJSON() json.RawMessage {
+	return json.RawMessage(`{
+		"description": "something custom",
+		"type": "object",
+		"required": ["type", "value"],
+		"properties": {
+			"type": {
+				"type": "string"
+			},
+			"value": {
+				"type": "string"
+			}
+		}
+	}`)
 }


### PR DESCRIPTION
The ability to add [OpenAPIV3Definition()](https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators#custom-openapi-type-definitions) is essential when trying to integrate existing complex types, however it requires importing this library.

For simple types, this can be avoided using:
```
    func (_ Time) OpenAPISchemaType() []string { return []string{"string"} }
    func (_ Time) OpenAPISchemaFormat() string { return "date-time" }
```

This PR proposes adding a new function that lets you return a raw spec directly
```
func (FooV3Raw) OpenAPISchemaJSON() json.RawMessage {
	return json.RawMessage(`{
		"description": "something custom",
		"type": "object",
		"required": ["type", "value"],
		"properties": {
			"type": {
				"type": "string"
			},
			"value": {
				"type": "string"
			}
		}
	}`)
}
```

TODO:
- [ ] add this to the docs README