### PR TITLE
bugfix: resolve non-determinism in deduplicating enum comments

### DIFF
--- a/pkg/generators/enum.go
+++ b/pkg/generators/enum.go
@@ -134,8 +134,14 @@ func (et *enumType) addIfNotPresent(value *enumValue) {
 	// If we already have an enum case with the same value, then ignore this new
 	// one. This can happen if an enum aliases one from another package and
 	// re-exports the cases.
-	for _, existing := range et.Values {
+	for i, existing := range et.Values {
 		if existing.Value == value.Value {
+
+			// Take the value of the longer comment (or some other deterministic tie breaker)
+			if len(existing.Comment) < len(value.Comment) || (len(existing.Comment) == len(value.Comment) && existing.Comment > value.Comment) {
+				et.Values[i] = value
+			}
+
 			return
 		}
 	}


### PR DESCRIPTION
649db6989aaecdd64cc4ea16b76e0d0067664001 included a bugfix for duplicated enum values, but did not account for the re-exported enum values not having identical comments. This led to non-deterministic iteration order over the enum types and an output that would change descriptions almost every time you ran it

This PR is a simple fix by applying a deterministic tie breaker (length). If length is equal, then we take the alphabetically lower godoc.