### PR TITLE
bugfix: change log level from error to info

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -704,7 +704,7 @@ func defaultFromComments(comments []string, commentPath string, t *types.Type) (
 
 	var i interface{}
 	if id, ok := parseSymbolReference(tag, commentPath); ok {
-		klog.Errorf("%v, %v", id, commentPath)
+		klog.V(5).Infof("%v, %v", id, commentPath)
 		return nil, &id, nil
 	} else if err := json.Unmarshal([]byte(tag), &i); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal default: %v", err)


### PR DESCRIPTION
I'm not sure why the code uses `Errorf` here while the result of `parseSymbolReference` is `ok`.

I found this issue when I was using `openapi-gen.go` to generate the `/test/integration/testdata/defaults` package (to have a try) and the following error logs appeared.
```
E0322 16:21:36.249229   11020 openapi.go:707] k8s.io/kube-openapi/test/integration/testdata/defaults.ConstantValue, k8s.io/kube-openapi/test/integration/testdata/defaults
E0322 16:21:36.249997   11020 openapi.go:707] k8s.io/kube-openapi/test/integration/testdata/defaults.ConstantValue, k8s.io/kube-openapi/test/integration/testdata/defaults
E0322 16:21:36.250239   11020 openapi.go:707] k8s.io/kube-openapi/test/integration/testdata/enumtype.FruitApple, k8s.io/kube-openapi/test/integration/testdata/defaults
E0322 16:21:36.250397   11020 openapi.go:707] k8s.io/kube-openapi/test/integration/testdata/enumtype.FruitApple, k8s.io/kube-openapi/test/integration/testdata/defaults
E0322 16:21:36.250527   11020 openapi.go:707] k8s.io/kube-openapi/test/integration/testdata/defaults.ConstantValue, k8s.io/kube-openapi/test/integration/testdata/defaults

```
But the files were generated successfully.

Hope I don't have any misunderstanding here.