### PR TITLE
Use klog.Info for defaultFromComments instead of Error

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -704,7 +704,7 @@ func defaultFromComments(comments []string, commentPath string, t *types.Type) (
 
 	var i interface{}
 	if id, ok := parseSymbolReference(tag, commentPath); ok {
-		klog.Errorf("%v, %v", id, commentPath)
+		klog.V(5).Infof("%v, %v", id, commentPath)
 		return nil, &id, nil
 	} else if err := json.Unmarshal([]byte(tag), &i); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal default: %v", err)


### PR DESCRIPTION
I found running openapi generator produces information like the following:

```bash
$ ./hack/update-openapi.sh
Generating openapi code for 1 targets
E0411 14:46:21.484926   54800 openapi.go:707] go.company.name/slacker/meta/pkg/apis/configs/v1alpha1.ReviewersPingLate, go.company.name/slacker/meta/pkg/apis/configs/v1alpha1
```
Seems there should be Infof instead of Errorf