### PR TITLE
add marker comment support for annotating cluster scopedness

### DIFF
--- a/pkg/generators/markers_test.go
+++ b/pkg/generators/markers_test.go
@@ -494,6 +494,45 @@ func TestParseCommentTags(t *testing.T) {
 			},
 			expectedError: `failed to parse marker comments: concatenations to key 'cel[0]:message' must be consecutive with its assignment`,
 		},
+		{
+			name: "namespaced scope",
+			t:    structKind,
+			comments: []string{
+				`+k8s:validation:scope>Namespaced`,
+			},
+			expected: &spec.Schema{
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: map[string]interface{}{
+						"x-kubernetes-validations": []interface{}{
+							map[string]interface{}{
+								"rule":   "self.metadata.namespace.size() > 0",
+								"reason": "FieldValueRequired",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cluster scope",
+			t:    structKind,
+			comments: []string{
+				`+k8s:validation:scope>Cluster`,
+			},
+			expected: &spec.Schema{
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: map[string]interface{}{
+						"x-kubernetes-validations": []interface{}{
+							map[string]interface{}{
+								"rule":    "self.metadata.namespace.size() == 0",
+								"message": "not allowed on this type",
+								"reason":  "FieldValueForbidden",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -1092,7 +1092,7 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
-					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo", "rule": "self == oldSelf"}},
+					"x-kubernetes-validations": []interface{}{map[string]interface{}{"message": "foo", "rule": "self == oldSelf"}, map[string]interface{}{"fieldPath": ".metadata.namespace", "reason": "FieldValueRequired", "rule": "has(self.metadata.__namespace__) && self.metadata.__namespace__.size() > 0"}},
 				},
 			},
 		},

--- a/test/integration/testdata/golden.v2.json
+++ b/test/integration/testdata/golden.v2.json
@@ -1285,6 +1285,11 @@
      {
       "message": "foo",
       "rule": "self == oldSelf"
+     },
+     {
+      "fieldPath": ".metadata.namespace",
+      "reason": "FieldValueRequired",
+      "rule": "has(self.metadata.__namespace__) \u0026\u0026 self.metadata.__namespace__.size() \u003e 0"
      }
     ]
    },

--- a/test/integration/testdata/golden.v3.json
+++ b/test/integration/testdata/golden.v3.json
@@ -1247,6 +1247,11 @@
       {
        "message": "foo",
        "rule": "self == oldSelf"
+      },
+      {
+       "fieldPath": ".metadata.namespace",
+       "reason": "FieldValueRequired",
+       "rule": "has(self.metadata.__namespace__) \u0026\u0026 self.metadata.__namespace__.size() \u003e 0"
       }
      ]
     },

--- a/test/integration/testdata/valuevalidation/alpha.go
+++ b/test/integration/testdata/valuevalidation/alpha.go
@@ -14,6 +14,7 @@ import (
 // +k8s:openapi-gen=true
 // +k8s:validation:cel[0]:rule="self == oldSelf"
 // +k8s:validation:cel[0]:message="foo"
+// +k8s:validation:scope>Namespaced
 type Foo struct {
 	// +k8s:validation:maxLength=5
 	// +k8s:validation:minLength=1


### PR DESCRIPTION
Adds new marker comments to specify whether the kind is namespace or cluster scoped using e.g.:

`+k8s:validation:scope>Namespaced`