### PR TITLE
fix: use Go-syntax representation to generate description

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"k8s.io/gengo/v2"
@@ -846,9 +845,8 @@ func (g openAPITypeWriter) generateDescription(CommentLines []string) {
 	}
 
 	postDoc := strings.TrimSpace(buffer.String())
-	postDoc = strconv.Quote(postDoc)
-	if postDoc != `""` {
-		g.Do("Description: $.$,\n", postDoc)
+	if len(postDoc) > 0 {
+		g.Do("Description: $.$,\n", fmt.Sprintf("%#v", postDoc))
 	}
 }
 

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"k8s.io/gengo/v2"
@@ -844,15 +845,10 @@ func (g openAPITypeWriter) generateDescription(CommentLines []string) {
 		}
 	}
 
-	postDoc := strings.TrimLeft(buffer.String(), "\n")
-	postDoc = strings.TrimRight(postDoc, "\n")
-	postDoc = strings.Replace(postDoc, "\\\"", "\"", -1) // replace user's \" to "
-	postDoc = strings.Replace(postDoc, "\"", "\\\"", -1) // Escape "
-	postDoc = strings.Replace(postDoc, "\n", "\\n", -1)
-	postDoc = strings.Replace(postDoc, "\t", "\\t", -1)
-	postDoc = strings.Trim(postDoc, " ")
-	if postDoc != "" {
-		g.Do("Description: \"$.$\",\n", postDoc)
+	postDoc := strings.TrimSpace(buffer.String())
+	postDoc = strconv.Quote(postDoc)
+	if postDoc != `""` {
+		g.Do("Description: $.$,\n", postDoc)
 	}
 }
 

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -150,6 +150,9 @@ func TestSimple(t *testing.T) {
 			// an int member with a default
 			// +default=1
 			OmittedInt int ` + "`" + `json:"omitted,omitempty"` + "`" + `
+			// a field with an invalid escape sequence in comment
+			// ex) regexp:^.*\.yaml$
+			InvalidEscapeSequenceInComment string
 		}`
 
 	packagestest.TestAll(t, func(t *testing.T, x packagestest.Exporter) {
@@ -384,8 +387,16 @@ Type: []string{"integer"},
 Format: "int32",
 },
 },
+"InvalidEscapeSequenceInComment": {
+SchemaProps: spec.SchemaProps{
+Description: "a field with an invalid escape sequence in comment ex) regexp:^.*\\.yaml$",
+Default: "",
+Type: []string{"string"},
+Format: "",
 },
-Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension","WithStructTagExtension","WithListType","Map","StringPointer"},
+},
+},
+Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension","WithStructTagExtension","WithListType","Map","StringPointer","InvalidEscapeSequenceInComment"},
 },
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{


### PR DESCRIPTION
Generated code cannot be built if the field's comment has an invalid escape sequence (ex. `\.`). 

This PR fixes this issue by replacing current description escape logic with using Go-syntax representation (`%#v`) to properly escape characters in string.