### PR TITLE
Bubble up buildOperations error.

### DIFF
--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -286,9 +286,9 @@ func (o *openAPI) buildOpenAPISpec(webServices []common.RouteContainer) error {
 
 			for _, route := range routes {
 				op, err := o.buildOperations(route, inPathCommonParamsMap)
-                if err != nil {
-                    return err
-                }
+				if err != nil {
+					return err
+				}
 				sortParameters(op.Parameters)
 
 				switch strings.ToUpper(route.Method()) {

--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -285,7 +285,10 @@ func (o *openAPI) buildOpenAPISpec(webServices []common.RouteContainer) error {
 			sortParameters(pathItem.Parameters)
 
 			for _, route := range routes {
-				op, _ := o.buildOperations(route, inPathCommonParamsMap)
+				op, err := o.buildOperations(route, inPathCommonParamsMap)
+                if err != nil {
+                    return err
+                }
 				sortParameters(op.Parameters)
 
 				switch strings.ToUpper(route.Method()) {


### PR DESCRIPTION
Errors encountered in `buildOperations` should not fail silently. 
I ran into an issue where `BuildOpenAPISpecFromRoutes` (https://github.com/kubernetes/kube-openapi/blob/b456828f718bab62dc3013d192665eb3d17f8fe9/pkg/builder/openapi.go#L52) would return indeterministic results due to `buildOperations` errors not being bubbled up.