### PR TITLE
Use wildcard in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,7 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directories:
-      - /
-      - /test/
+      - "**/*"
     schedule:
       interval: daily
 


### PR DESCRIPTION
Use the new wildcard feature to automatically find all the `go.mod`s