### PR TITLE
Patch go-json-experiment json to pass tests on go1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
     branches: [ master ]
 jobs:
   ci:
+    strategy:
+      matrix:
+        go-version: [ '1.20', '1.21', '1.22', '1.23' ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version: ${{ matrix.go-version }}
     - name: Build
       run: |
         go mod tidy && git diff --exit-code

--- a/pkg/internal/third_party/go-json-experiment/json/arshal_test.go
+++ b/pkg/internal/third_party/go-json-experiment/json/arshal_test.go
@@ -1351,7 +1351,7 @@ func TestMarshal(t *testing.T) {
 			Bytes:         []byte{},                               // not omitted since allocated slice is non-zero
 			Int:           1,                                      // not omitted since 1 is non-zero
 			Uint:          1,                                      // not omitted since 1 is non-zero
-			Float:         math.Copysign(0, -1),                   // not omitted since -0 is technically non-zero
+			Float:         math.SmallestNonzeroFloat64,            // not omitted since still slightly above zero
 			Map:           map[string]string{},                    // not omitted since allocated map is non-zero
 			StructScalars: structScalars{unexported: true},        // not omitted since unexported is non-zero
 			StructSlices:  structSlices{Ignored: true},            // not omitted since Ignored is non-zero
@@ -1367,7 +1367,7 @@ func TestMarshal(t *testing.T) {
 	"Bytes": "",
 	"Int": 1,
 	"Uint": 1,
-	"Float": -0,
+	"Float": 5e-324,
 	"Map": {},
 	"StructScalars": {
 		"Bool": false,
@@ -1571,7 +1571,7 @@ func TestMarshal(t *testing.T) {
 			PointerSlice:          addr([]string{""}),
 			PointerSliceEmpty:     addr(sliceMarshalEmpty{"value"}),
 			PointerSliceNonEmpty:  addr(sliceMarshalNonEmpty{"value"}),
-			Pointer:               &structOmitZeroEmptyAll{Float: math.Copysign(0, -1)},
+			Pointer:               &structOmitZeroEmptyAll{Float: math.SmallestNonzeroFloat64},
 			Interface:             []string{""},
 		},
 		want: `{
@@ -1616,7 +1616,7 @@ func TestMarshal(t *testing.T) {
 		"value"
 	],
 	"Pointer": {
-		"Float": -0
+		"Float": 5e-324
 	},
 	"Interface": [
 		""


### PR DESCRIPTION
Per comment https://github.com/kubernetes/kube-openapi/issues/501#issuecomment-2289891359 and https://github.com/kubernetes/kube-openapi/issues/501#issuecomment-2291112778.

Fixes https://github.com/kubernetes/kube-openapi/issues/501

This is manual patch to include the test fix from https://github.com/go-json-experiment/json/commit/c2a874acdab3b26ac88290cff3b256169f420a48. We cannot directly fast forward to that commit because it would increase our minimum supported go version to 1.21.

Tested manually via `go test`