### PR TITLE
use our own fork of go-yaml

### DIFF
--- a/cmd/openapi2smd/openapi2smd.go
+++ b/cmd/openapi2smd/openapi2smd.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
-	yaml "gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"k8s.io/kube-openapi/pkg/schemaconv"
 	"k8s.io/kube-openapi/pkg/util/proto"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/tools v0.24.0
 	google.golang.org/protobuf v1.34.2
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/gengo/v2 v2.0.0-20240826214909-a7b603a56eb7
 	k8s.io/klog/v2 v2.130.1

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/schemaconv/smd_test.go
+++ b/pkg/schemaconv/smd_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	yaml "gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
 	"k8s.io/kube-openapi/pkg/util/proto"
 	prototesting "k8s.io/kube-openapi/pkg/util/proto/testing"

--- a/pkg/util/proto/document.go
+++ b/pkg/util/proto/document.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
-	"gopkg.in/yaml.v2"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 func newSchemaError(path *Path, format string, a ...interface{}) error {


### PR DESCRIPTION

We have our own fork of go-yaml https://github.com/kubernetes-sigs/yaml/pull/76 so we can simplify the dependency graph in kubernetes if we end the path in kubernetes-sigs/yaml

```
go mod why gopkg.in/yaml.v3
# gopkg.in/yaml.v3
k8s.io/apimachinery/pkg/util/managedfields
k8s.io/kube-openapi/pkg/util/pro

```



Ref https://github.com/kubernetes-sigs/structured-merge-diff/pull/264