### PR TITLE
Fully ignore unknown tags in ParseCommentTags

### DIFF
--- a/pkg/generators/markers_test.go
+++ b/pkg/generators/markers_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/gengo/v2/types"
 	"k8s.io/kube-openapi/pkg/generators"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -959,6 +960,23 @@ func TestCommentTags_Validate(t *testing.T) {
 				},
 			},
 			errorMessage: `failed to validate property "name": pattern can only be used on string types`,
+		},
+		{
+			name: "ignore unknown field with unparsable value",
+			comments: []string{
+				`+k8s:validation:xyz=a=b`, // a=b is not a valid value
+			},
+			t: &types.Type{
+				Kind: types.Struct,
+				Name: types.Name{Name: "struct"},
+				Members: []types.Member{
+					{
+						Name: "name",
+						Type: types.String,
+						Tags: `json:"name"`,
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/packages/packagestest"
+
 	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/parser"
@@ -2386,7 +2387,7 @@ func TestMarkerComments(t *testing.T) {
 			// +k8s:validation:pattern="^foo$[0-9]+"
 			StringValue string
 
-			// +k8s:validation:maxitems=10
+			// +k8s:validation:maxItems=10
 			// +k8s:validation:minItems=1
 			// +k8s:validation:uniqueItems
 			ArrayValue []string


### PR DESCRIPTION
Fix `generators.ParseCommentTags` to not fail on parsing on tags that it ignores anyway.
