### PR TITLE
Increase integration tests' timeout to 1min

### DIFF
--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -42,7 +42,7 @@ const (
 	generatedOpenAPIv3FileName = "generated.v3.json"
 	goldenOpenAPIv3Filename    = "golden.v3.json"
 
-	timeoutSeconds = 20.0
+	timeoutSeconds = 60.0
 )
 
 var (


### PR DESCRIPTION
On slower platforms, like Debian's current Risc-V build machines, the 20 second timeout was not enough to run the "BeforeSuite node". Hopefully 1 minute will be enough.