### PR TITLE
Fix idl package test naming

### DIFF
--- a/pkg/idl/listtype_test.go
+++ b/pkg/idl/listtype_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package idl_test
+package idl
 
 // This example shows how to use the listType map attribute and how to
 // specify a key to identify elements of the list. The listMapKey

--- a/pkg/idl/maptype_test.go
+++ b/pkg/idl/maptype_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package idl_test
+package idl
 
 // This example shows how to use the mapType atomic attribute to
 // specify that this map should be treated as a whole.

--- a/pkg/idl/structtype_test.go
+++ b/pkg/idl/structtype_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package idl_test
+package idl
 
 // This example shows how to use the structType atomic attribute to
 // specify that this struct should be treated as a whole.


### PR DESCRIPTION
Discovered from https://github.com/kubernetes/kube-openapi/pull/528 and https://github.com/kubernetes/kube-openapi/actions/runs/13925483617/job/38968758746?pr=528. `Example<string>` is a reserved keyword https://go.dev/blog/examples so the examples should be in the same package as the type definition in `pkg/idl/doc.go` 