### PR TITLE
Fix Method Return Types in OpenAPIDefinitionGetter and OpenAPIV3DefinitionGetter Interfaces

### DIFF
--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -59,7 +59,7 @@ type TestOutput struct {
 
 type TestExtensionV2Schema struct{}
 
-func (_ TestExtensionV2Schema) OpenAPIDefinition() *openapi.OpenAPIDefinition {
+func (_ TestExtensionV2Schema) OpenAPIDefinition() openapi.OpenAPIDefinition {
 	schema := spec.Schema{
 		VendorExtensible: spec.VendorExtensible{
 			Extensions: map[string]interface{}{
@@ -81,13 +81,13 @@ func (_ TestExtensionV2Schema) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 			},
 		},
 	}
-	return &openapi.OpenAPIDefinition{
+	return openapi.OpenAPIDefinition{
 		Schema:       schema,
 		Dependencies: []string{},
 	}
 }
 
-func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
+func (_ TestInput) OpenAPIDefinition() openapi.OpenAPIDefinition {
 	schema := spec.Schema{}
 	schema.Description = "Test input"
 	schema.Properties = map[string]spec.Schema{
@@ -121,13 +121,13 @@ func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 		},
 	}
 	schema.Extensions = spec.Extensions{"x-test": "test"}
-	return &openapi.OpenAPIDefinition{
+	return openapi.OpenAPIDefinition{
 		Schema:       schema,
 		Dependencies: []string{},
 	}
 }
 
-func (_ TestOutput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
+func (_ TestOutput) OpenAPIDefinition() openapi.OpenAPIDefinition {
 	schema := spec.Schema{}
 	schema.Description = "Test output"
 	schema.Properties = map[string]spec.Schema{
@@ -146,7 +146,7 @@ func (_ TestOutput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 			},
 		},
 	}
-	return &openapi.OpenAPIDefinition{
+	return openapi.OpenAPIDefinition{
 		Schema:       schema,
 		Dependencies: []string{},
 	}
@@ -214,9 +214,9 @@ func getConfig(fullMethods bool) (*openapi.Config, *restful.Container) {
 		},
 		GetDefinitions: func(_ openapi.ReferenceCallback) map[string]openapi.OpenAPIDefinition {
 			return map[string]openapi.OpenAPIDefinition{
-				"k8s.io/kube-openapi/pkg/builder.TestInput":             *TestInput{}.OpenAPIDefinition(),
-				"k8s.io/kube-openapi/pkg/builder.TestOutput":            *TestOutput{}.OpenAPIDefinition(),
-				"k8s.io/kube-openapi/pkg/builder.TestExtensionV2Schema": *TestExtensionV2Schema{}.OpenAPIDefinition(),
+				"k8s.io/kube-openapi/pkg/builder.TestInput":             TestInput{}.OpenAPIDefinition(),
+				"k8s.io/kube-openapi/pkg/builder.TestOutput":            TestOutput{}.OpenAPIDefinition(),
+				"k8s.io/kube-openapi/pkg/builder.TestExtensionV2Schema": TestExtensionV2Schema{}.OpenAPIDefinition(),
 			}
 		},
 		GetDefinitionName: func(name string) (string, spec.Extensions) {

--- a/pkg/builder3/openapi_test.go
+++ b/pkg/builder3/openapi_test.go
@@ -58,7 +58,7 @@ type TestOutput struct {
 	Count int `json:"count,omitempty"`
 }
 
-func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
+func (_ TestInput) OpenAPIDefinition() openapi.OpenAPIDefinition {
 	schema := spec.Schema{}
 	schema.Description = "Test input"
 	schema.Properties = map[string]spec.Schema{
@@ -118,10 +118,10 @@ func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 	}, openapi.OpenAPIDefinition{
 		// this empty embedded v2 definition should not appear in the result
 	})
-	return &def
+	return def
 }
 
-func (_ TestOutput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
+func (_ TestOutput) OpenAPIDefinition() openapi.OpenAPIDefinition {
 	schema := spec.Schema{}
 	schema.Description = "Test output"
 	schema.Properties = map[string]spec.Schema{
@@ -140,7 +140,7 @@ func (_ TestOutput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 			},
 		},
 	}
-	return &openapi.OpenAPIDefinition{
+	return openapi.OpenAPIDefinition{
 		Schema:       schema,
 		Dependencies: []string{},
 	}
@@ -203,8 +203,8 @@ func getConfig(fullMethods bool) (*openapi.OpenAPIV3Config, *restful.Container) 
 		},
 		GetDefinitions: func(_ openapi.ReferenceCallback) map[string]openapi.OpenAPIDefinition {
 			return map[string]openapi.OpenAPIDefinition{
-				"k8s.io/kube-openapi/pkg/builder3.TestInput":  *TestInput{}.OpenAPIDefinition(),
-				"k8s.io/kube-openapi/pkg/builder3.TestOutput": *TestOutput{}.OpenAPIDefinition(),
+				"k8s.io/kube-openapi/pkg/builder3.TestInput":  TestInput{}.OpenAPIDefinition(),
+				"k8s.io/kube-openapi/pkg/builder3.TestOutput": TestOutput{}.OpenAPIDefinition(),
 			}
 		},
 		GetDefinitionName: func(name string) (string, spec.Extensions) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -48,11 +48,11 @@ type GetOpenAPIDefinitions func(ReferenceCallback) map[string]OpenAPIDefinition
 // GetOpenAPITypeFormat for more information about trade-offs of using this interface or GetOpenAPITypeFormat method when
 // possible.
 type OpenAPIDefinitionGetter interface {
-	OpenAPIDefinition() *OpenAPIDefinition
+	OpenAPIDefinition() OpenAPIDefinition
 }
 
 type OpenAPIV3DefinitionGetter interface {
-	OpenAPIV3Definition() *OpenAPIDefinition
+	OpenAPIV3Definition() OpenAPIDefinition
 }
 
 type PathHandler interface {


### PR DESCRIPTION
This PR updates methods `OpenAPIDefinition()` and `OpenAPIV3Definition()` in their respective interfaces to return struct values instead of pointers.

Aside from unit tests, all actual implementations under this repo return structs directly right now, which causes a mismatch with the interface definition. This update matches the existing declarations and fix issue #514.

### Testing

- `go test` succeeded