### PR TITLE
Drop go 1.21 from supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        go-version: [ '1.21', '1.22', '1.23', '1.24']
+        go-version: ['1.22', '1.23', '1.24']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
     # in k/k.
     - name: Run verify scripts
       run: |
-        ./hack/verify-go-directive.sh 1.21
+        ./hack/verify-go-directive.sh 1.22
   required:
     # The name of the ci jobs above change based on the golang version.
     # Use this as a stable required job that depends on the above jobs.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-openapi
 
-go 1.21
+go 1.22
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-openapi/test/integration
 
-go 1.21
+go 1.22
 
 replace k8s.io/kube-openapi => ../../
 


### PR DESCRIPTION
SInce k/k 1.29 is not supported anymore, I'd like to drop 1.21 and bump the minimum required version to 1.22. This also let's us depend on `go.yaml.in/yaml/v3` with a go.mod version set to 1.22.

/assign @liggitt @dims 