### PR TITLE
Remove Scan implementation from strfmt

### DIFF
--- a/pkg/validation/strfmt/default.go
+++ b/pkg/validation/strfmt/default.go
@@ -17,7 +17,6 @@ package strfmt
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/mail"
 	"regexp"
 	"strings"
@@ -247,29 +246,6 @@ func (b *Base64) UnmarshalText(data []byte) error { // validation is performed l
 	return nil
 }
 
-// Scan read a value from a database driver
-func (b *Base64) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		dbuf := make([]byte, base64.StdEncoding.DecodedLen(len(v)))
-		n, err := base64.StdEncoding.Decode(dbuf, v)
-		if err != nil {
-			return err
-		}
-		*b = dbuf[:n]
-	case string:
-		vv, err := base64.StdEncoding.DecodeString(v)
-		if err != nil {
-			return err
-		}
-		*b = Base64(vv)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.Base64 from: %#v", v)
-	}
-
-	return nil
-}
-
 func (b Base64) String() string {
 	return base64.StdEncoding.EncodeToString([]byte(b))
 }
@@ -324,20 +300,6 @@ func (u *URI) UnmarshalText(data []byte) error { // validation is performed late
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *URI) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = URI(string(v))
-	case string:
-		*u = URI(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.URI from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u URI) String() string {
 	return string(u)
 }
@@ -385,20 +347,6 @@ func (e Email) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (e *Email) UnmarshalText(data []byte) error { // validation is performed later on
 	*e = Email(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (e *Email) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*e = Email(string(v))
-	case string:
-		*e = Email(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.Email from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -452,20 +400,6 @@ func (h *Hostname) UnmarshalText(data []byte) error { // validation is performed
 	return nil
 }
 
-// Scan read a value from a database driver
-func (h *Hostname) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*h = Hostname(string(v))
-	case string:
-		*h = Hostname(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.Hostname from: %#v", v)
-	}
-
-	return nil
-}
-
 func (h Hostname) String() string {
 	return string(h)
 }
@@ -513,20 +447,6 @@ func (u IPv4) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *IPv4) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = IPv4(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *IPv4) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = IPv4(string(v))
-	case string:
-		*u = IPv4(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.IPv4 from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -580,20 +500,6 @@ func (u *IPv6) UnmarshalText(data []byte) error { // validation is performed lat
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *IPv6) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = IPv6(string(v))
-	case string:
-		*u = IPv6(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.IPv6 from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u IPv6) String() string {
 	return string(u)
 }
@@ -641,20 +547,6 @@ func (u CIDR) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *CIDR) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = CIDR(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *CIDR) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = CIDR(string(v))
-	case string:
-		*u = CIDR(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.CIDR from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -708,20 +600,6 @@ func (u *MAC) UnmarshalText(data []byte) error { // validation is performed late
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *MAC) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = MAC(string(v))
-	case string:
-		*u = MAC(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.IPv4 from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u MAC) String() string {
 	return string(u)
 }
@@ -769,20 +647,6 @@ func (u UUID) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *UUID) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = UUID(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *UUID) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = UUID(string(v))
-	case string:
-		*u = UUID(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.UUID from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -839,20 +703,6 @@ func (u *UUID3) UnmarshalText(data []byte) error { // validation is performed la
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *UUID3) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = UUID3(string(v))
-	case string:
-		*u = UUID3(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.UUID3 from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u UUID3) String() string {
 	return string(u)
 }
@@ -903,20 +753,6 @@ func (u UUID4) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *UUID4) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = UUID4(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *UUID4) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = UUID4(string(v))
-	case string:
-		*u = UUID4(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.UUID4 from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -973,20 +809,6 @@ func (u *UUID5) UnmarshalText(data []byte) error { // validation is performed la
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *UUID5) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = UUID5(string(v))
-	case string:
-		*u = UUID5(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.UUID5 from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u UUID5) String() string {
 	return string(u)
 }
@@ -1037,20 +859,6 @@ func (u ISBN) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *ISBN) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = ISBN(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *ISBN) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = ISBN(string(v))
-	case string:
-		*u = ISBN(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.ISBN from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -1107,20 +915,6 @@ func (u *ISBN10) UnmarshalText(data []byte) error { // validation is performed l
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *ISBN10) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = ISBN10(string(v))
-	case string:
-		*u = ISBN10(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.ISBN10 from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u ISBN10) String() string {
 	return string(u)
 }
@@ -1171,20 +965,6 @@ func (u ISBN13) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *ISBN13) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = ISBN13(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *ISBN13) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = ISBN13(string(v))
-	case string:
-		*u = ISBN13(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.ISBN13 from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -1241,20 +1021,6 @@ func (u *CreditCard) UnmarshalText(data []byte) error { // validation is perform
 	return nil
 }
 
-// Scan read a value from a database driver
-func (u *CreditCard) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = CreditCard(string(v))
-	case string:
-		*u = CreditCard(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.CreditCard from: %#v", v)
-	}
-
-	return nil
-}
-
 func (u CreditCard) String() string {
 	return string(u)
 }
@@ -1305,20 +1071,6 @@ func (u SSN) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (u *SSN) UnmarshalText(data []byte) error { // validation is performed later on
 	*u = SSN(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (u *SSN) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*u = SSN(string(v))
-	case string:
-		*u = SSN(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.SSN from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -1375,20 +1127,6 @@ func (h *HexColor) UnmarshalText(data []byte) error { // validation is performed
 	return nil
 }
 
-// Scan read a value from a database driver
-func (h *HexColor) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*h = HexColor(string(v))
-	case string:
-		*h = HexColor(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.HexColor from: %#v", v)
-	}
-
-	return nil
-}
-
 func (h HexColor) String() string {
 	return string(h)
 }
@@ -1439,20 +1177,6 @@ func (r RGBColor) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (r *RGBColor) UnmarshalText(data []byte) error { // validation is performed later on
 	*r = RGBColor(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (r *RGBColor) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*r = RGBColor(string(v))
-	case string:
-		*r = RGBColor(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.RGBColor from: %#v", v)
-	}
-
 	return nil
 }
 
@@ -1507,20 +1231,6 @@ func (r Password) MarshalText() ([]byte, error) {
 // UnmarshalText hydrates this instance from text
 func (r *Password) UnmarshalText(data []byte) error { // validation is performed later on
 	*r = Password(string(data))
-	return nil
-}
-
-// Scan read a value from a database driver
-func (r *Password) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	case []byte:
-		*r = Password(string(v))
-	case string:
-		*r = Password(v)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.Password from: %#v", v)
-	}
-
 	return nil
 }
 

--- a/pkg/validation/strfmt/duration.go
+++ b/pkg/validation/strfmt/duration.go
@@ -119,23 +119,6 @@ func ParseDuration(cand string) (time.Duration, error) {
 	return 0, fmt.Errorf("unable to parse %s as duration", cand)
 }
 
-// Scan reads a Duration value from database driver type.
-func (d *Duration) Scan(raw interface{}) error {
-	switch v := raw.(type) {
-	// TODO: case []byte: // ?
-	case int64:
-		*d = Duration(v)
-	case float64:
-		*d = Duration(int64(v))
-	case nil:
-		*d = Duration(0)
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.Duration from: %#v", v)
-	}
-
-	return nil
-}
-
 // String converts this duration to a string
 func (d Duration) String() string {
 	return time.Duration(d).String()

--- a/pkg/validation/strfmt/time.go
+++ b/pkg/validation/strfmt/time.go
@@ -16,7 +16,6 @@ package strfmt
 
 import (
 	"encoding/json"
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -111,25 +110,6 @@ func (t *DateTime) UnmarshalText(text []byte) error {
 		return err
 	}
 	*t = tt
-	return nil
-}
-
-// Scan scans a DateTime value from database driver type.
-func (t *DateTime) Scan(raw interface{}) error {
-	// TODO: case int64: and case float64: ?
-	switch v := raw.(type) {
-	case []byte:
-		return t.UnmarshalText(v)
-	case string:
-		return t.UnmarshalText([]byte(v))
-	case time.Time:
-		*t = DateTime(v)
-	case nil:
-		*t = DateTime{}
-	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.DateTime from: %#v", v)
-	}
-
 	return nil
 }
 

--- a/pkg/validation/strfmt/time_test.go
+++ b/pkg/validation/strfmt/time_test.go
@@ -75,10 +75,6 @@ func TestParseDateTime_fullCycle(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, example.time, pp)
 
-		pp = NewDateTime()
-		err = pp.Scan(mt)
-		assert.NoError(t, err)
-		assert.Equal(t, DateTime(example.time), pp)
 	}
 }
 
@@ -170,48 +166,6 @@ func TestDateTime_MarshalJSON(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, esc([]byte(example.str)), bb)
 	}
-}
-
-func TestDateTime_Scan(t *testing.T) {
-	for caseNum, example := range testCases {
-		t.Logf("Case #%d", caseNum)
-
-		pp := NewDateTime()
-		err := pp.Scan(example.in)
-		assert.NoError(t, err)
-		assert.Equal(t, DateTime(example.time), pp)
-
-		pp = NewDateTime()
-		err = pp.Scan(string(example.in))
-		assert.NoError(t, err)
-		assert.Equal(t, DateTime(example.time), pp)
-
-		pp = NewDateTime()
-		err = pp.Scan(example.time)
-		assert.NoError(t, err)
-		assert.Equal(t, DateTime(example.time), pp)
-	}
-}
-
-func TestDateTime_Scan_Failed(t *testing.T) {
-	pp := NewDateTime()
-	zero := NewDateTime()
-
-	err := pp.Scan(nil)
-	assert.NoError(t, err)
-	// Zero values differ...
-	//assert.Equal(t, zero, pp)
-	assert.Equal(t, DateTime{}, pp)
-
-	err = pp.Scan("")
-	assert.NoError(t, err)
-	assert.Equal(t, zero, pp)
-
-	err = pp.Scan(int64(0))
-	assert.Error(t, err)
-
-	err = pp.Scan(float64(0))
-	assert.Error(t, err)
 }
 
 func TestDeepCopyDateTime(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kube-openapi/issues/536

https://github.com/kubernetes/kube-openapi/pull/211 already stripped out a lot of Scan instances + `"database/sql/driver"` imports, and these incomplete implementations aren't used anywhere.