### PR TITLE
build: remove go 1.22 from testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        go-version: ['1.22', '1.23', '1.24', '1.25']
+        go-version: ['1.23', '1.24', '1.25']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
go.mod is at 1.23.0 already.