### PR TITLE
Validate listType usage on struct fields

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -957,6 +957,14 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 	if name == "" {
 		return nil
 	}
+	if listType, err := getSingleTagsValue(m.CommentLines, "listType"); err != nil {
+		return err
+	} else if listType != "" {
+		t := resolveAliasAndPtrType(m.Type)
+		if t.Kind != types.Slice && t.Kind != types.Array {
+			return fmt.Errorf("listType marker may only be used on slice or array fields, but was used on %v", m.Name)
+		}
+	}
 	validationSchema, err := ParseCommentTags(m.Type, m.CommentLines, markerPrefix)
 	if err != nil {
 		return err

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -88,6 +88,78 @@ func assertEqual(t *testing.T, got, want string) {
 	}
 }
 
+func TestListTypeValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputFile     string
+		expectedError string
+	}{
+		{
+			name: "listType on slice",
+			inputFile: `
+				package foo
+
+				type Blah struct {
+					// +listType=atomic
+					Slice []string
+				}
+			`,
+			expectedError: "",
+		},
+		{
+			name: "listType on array",
+			inputFile: `
+				package foo
+
+				type Blah struct {
+					// +listType=atomic
+					Array [1]string
+				}
+			`,
+			expectedError: "",
+		},
+		{
+			name: "listType on string (fail)",
+			inputFile: `
+				package foo
+
+				type Blah struct {
+					// +listType=atomic
+					String string
+				}
+			`,
+			expectedError: "listType marker may only be used on slice or array fields",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			packagestest.TestAll(t, func(t *testing.T, exporter packagestest.Exporter) {
+				exported := packagestest.Export(t, exporter, []packagestest.Module{{
+					Name: "example.com/base",
+					Files: map[string]interface{}{
+						"foo/foo.go": test.inputFile,
+					},
+				}})
+				defer exported.Cleanup()
+
+				_, funcErr, _, _, _ := testOpenAPITypeWriter(t, exported.Config)
+				if test.expectedError == "" {
+					if funcErr != nil {
+						t.Errorf("Expected no error, got: %v", funcErr)
+					}
+				} else {
+					if funcErr == nil {
+						t.Errorf("Expected error containing %q, got nil", test.expectedError)
+					} else if !strings.Contains(funcErr.Error(), test.expectedError) {
+						t.Errorf("Expected error containing %q, got: %v", test.expectedError, funcErr)
+					}
+				}
+			})
+		})
+	}
+}
+
 func TestSimple(t *testing.T) {
 	inputFile := `
 		package foo


### PR DESCRIPTION
Validate listType usage on struct fields

Fixes : #554.

`kube-openapi` is updated to validate the usage of the `// +listType` marker. The tool will now generate an error if this marker is applied to any field that is not a slice or an array. This change ensures that the OpenAPI specifications for core Kubernetes types are generated with the same strictness as those for CRDs, preventing downstream tooling failures.

**Problem:**

Currently, `kube-openapi` allows the `// +listType` marker to be used on fields that are not lists or slices. This can result in the generation of an invalid OpenAPI schema. For example, a `+listType=atomic` marker was incorrectly applied to the `metav1.Status.Details` field, which is a struct, not a list type. This causes tools that consume the schema, such as `controller-gen`, to fail when generating Custom Resource Definitions (CRDs) that embed `metav1.Status`.

**Solution:**

This pull request introduces a validation check in `kube-openapi` to ensure that the `+listType` marker is only used on slice or array fields. If the marker is used on any other type of field, an error will be returned.

Unit tests have been added to verify the new validation logic, including a test case that is expected to fail when `+listType` is used on a string field.
