### PR TITLE
Update Go CI matrix: drop 1.23, add 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        go-version: ['1.23', '1.24', '1.25']
+        go-version: ['1.24', '1.25', '1.26']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
     # in k/k.
     - name: Run verify scripts
       run: |
-        ./hack/verify-go-directive.sh 1.23.0
+        ./hack/verify-go-directive.sh 1.24.0
   required:
     # The name of the ci jobs above change based on the golang version.
     # Use this as a stable required job that depends on the above jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         go-version: ['1.24', '1.25', '1.26']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-openapi
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/pkg/schemaconv/openapi.go
+++ b/pkg/schemaconv/openapi.go
@@ -140,7 +140,7 @@ func (c *convert) makeOpenAPIRef(specSchema *spec.Schema) schema.TypeRef {
 		// 	to deduplicate)
 		mapRelationship, err := getMapElementRelationship(specSchema.Extensions)
 		if err != nil {
-			c.reportError(err.Error())
+			c.reportError("%s", err.Error())
 		}
 
 		if len(mapRelationship) > 0 {
@@ -212,7 +212,7 @@ func (c *convert) parseObject(s *spec.Schema) *schema.Map {
 
 	relationship, err := getMapElementRelationship(s.Extensions)
 	if err != nil {
-		c.reportError(err.Error())
+		c.reportError("%s", err.Error())
 	}
 
 	return &schema.Map{
@@ -225,7 +225,7 @@ func (c *convert) parseObject(s *spec.Schema) *schema.Map {
 func (c *convert) parseList(s *spec.Schema) *schema.List {
 	relationship, mapKeys, err := getListElementRelationship(s.Extensions)
 	if err != nil {
-		c.reportError(err.Error())
+		c.reportError("%s", err.Error())
 	}
 	elementType := func() schema.TypeRef {
 		if s.Items != nil {

--- a/pkg/schemaconv/proto_models.go
+++ b/pkg/schemaconv/proto_models.go
@@ -72,7 +72,7 @@ func (c *convert) makeRef(model proto.Schema, preserveUnknownFields bool) schema
 		mapRelationship, err := getMapElementRelationship(model.GetExtensions())
 
 		if err != nil {
-			c.reportError(err.Error())
+			c.reportError("%s", err.Error())
 		}
 
 		// empty string means unset.
@@ -114,7 +114,7 @@ func (c *convert) VisitKind(k *proto.Kind) {
 
 	unions, err := makeUnions(k.GetExtensions())
 	if err != nil {
-		c.reportError(err.Error())
+		c.reportError("%s", err.Error())
 		return
 	}
 	// TODO: We should check that the fields and discriminator
@@ -129,14 +129,14 @@ func (c *convert) VisitKind(k *proto.Kind) {
 
 	a.Map.ElementRelationship, err = getMapElementRelationship(k.GetExtensions())
 	if err != nil {
-		c.reportError(err.Error())
+		c.reportError("%s", err.Error())
 	}
 }
 
 func (c *convert) VisitArray(a *proto.Array) {
 	relationship, mapKeys, err := getListElementRelationship(a.GetExtensions())
 	if err != nil {
-		c.reportError(err.Error())
+		c.reportError("%s", err.Error())
 	}
 
 	atom := c.top()
@@ -150,7 +150,7 @@ func (c *convert) VisitArray(a *proto.Array) {
 func (c *convert) VisitMap(m *proto.Map) {
 	relationship, err := getMapElementRelationship(m.GetExtensions())
 	if err != nil {
-		c.reportError(err.Error())
+		c.reportError("%s", err.Error())
 	}
 
 	a := c.top()

--- a/pkg/validation/validate/result.go
+++ b/pkg/validation/validate/result.go
@@ -135,13 +135,13 @@ func (r *Result) keepRelevantErrors() *Result {
 	strippedErrors := []error{}
 	for _, e := range r.Errors {
 		if strings.HasPrefix(e.Error(), "IMPORTANT!") {
-			strippedErrors = append(strippedErrors, fmt.Errorf(strings.TrimPrefix(e.Error(), "IMPORTANT!")))
+			strippedErrors = append(strippedErrors, fmt.Errorf("%s", strings.TrimPrefix(e.Error(), "IMPORTANT!")))
 		}
 	}
 	strippedWarnings := []error{}
 	for _, e := range r.Warnings {
 		if strings.HasPrefix(e.Error(), "IMPORTANT!") {
-			strippedWarnings = append(strippedWarnings, fmt.Errorf(strings.TrimPrefix(e.Error(), "IMPORTANT!")))
+			strippedWarnings = append(strippedWarnings, fmt.Errorf("%s", strings.TrimPrefix(e.Error(), "IMPORTANT!")))
 		}
 	}
 	strippedResult := new(Result)

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kube-openapi/test/integration
 
-go 1.23.0
+go 1.24.0
 
 replace k8s.io/kube-openapi => ../../
 


### PR DESCRIPTION
Drop Go 1.23 from the CI matrix and add Go 1.26

Kubernetes 1.32 is now EOL and Kubernetes 1.33 uses Go 1.24, making 1.24 the new minimum supported Go version.