### PR TITLE
Update swagger v2 test data from Kubernetes v1.8 to v1.35

### DIFF
--- a/pkg/util/proto/openapi_test.go
+++ b/pkg/util/proto/openapi_test.go
@@ -31,12 +31,12 @@ var fakeSchema = prototesting.Fake{Path: filepath.Join("testdata", "swagger.json
 var fakeSchemaNext = prototesting.Fake{Path: filepath.Join("testdata", "swagger_next.json")}
 var fakeSchemaV300 = prototesting.FakeV3{Path: filepath.Join("testdata", "openapi_v3_0_0")}
 
-// loadV18Models loads the v1.8 swagger schema and returns proto.Models.
-func loadV18Models(t *testing.T) proto.Models {
+// loadModels loads the swagger schema and returns proto.Models.
+func loadModels(t *testing.T) proto.Models {
 	t.Helper()
 	s, err := fakeSchema.OpenAPISchema()
 	if err != nil {
-		t.Fatalf("failed to open v1.8 schema: %v", err)
+		t.Fatalf("failed to open schema: %v", err)
 	}
 	models, err := proto.NewOpenAPIData(s)
 	if err != nil {
@@ -45,13 +45,13 @@ func loadV18Models(t *testing.T) proto.Models {
 	return models
 }
 
-// loadV18DeploymentModel loads the v1.8 schema and returns the Deployment Kind.
-func loadV18DeploymentModel(t *testing.T) (proto.Models, proto.Schema, *proto.Kind) {
+// loadDeploymentModel loads the schema and returns the Deployment Kind.
+func loadDeploymentModel(t *testing.T) (proto.Models, proto.Schema, *proto.Kind) {
 	t.Helper()
-	models := loadV18Models(t)
-	schema := models.LookupModel("io.k8s.api.apps.v1beta1.Deployment")
+	models := loadModels(t)
+	schema := models.LookupModel("io.k8s.api.apps.v1.Deployment")
 	if schema == nil {
-		t.Fatal("model io.k8s.api.apps.v1beta1.Deployment not found")
+		t.Fatal("model io.k8s.api.apps.v1.Deployment not found")
 	}
 	deployment, ok := schema.(*proto.Kind)
 	if !ok || deployment == nil {
@@ -60,33 +60,33 @@ func loadV18DeploymentModel(t *testing.T) (proto.Models, proto.Schema, *proto.Ki
 	return models, schema, deployment
 }
 
-func TestV18Deployment(t *testing.T) {
+func TestDeployment(t *testing.T) {
 	t.Run("should lookup the Schema by its model name", func(t *testing.T) {
-		models := loadV18Models(t)
-		schema := models.LookupModel("io.k8s.api.apps.v1beta1.Deployment")
+		models := loadModels(t)
+		schema := models.LookupModel("io.k8s.api.apps.v1.Deployment")
 		if schema == nil {
-			t.Fatal("model io.k8s.api.apps.v1beta1.Deployment not found")
+			t.Fatal("model io.k8s.api.apps.v1.Deployment not found")
 		}
 	})
 
 	t.Run("should be a Kind", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		if deployment == nil {
 			t.Fatal("expected deployment to be non-nil")
 		}
 	})
 
 	t.Run("should have a path", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		got := deployment.GetPath().Get()
-		want := []string{"io.k8s.api.apps.v1beta1.Deployment"}
+		want := []string{"io.k8s.api.apps.v1.Deployment"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("path = %v, want %v", got, want)
 		}
 	})
 
 	t.Run("should have a kind key of type string", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		if _, ok := deployment.Fields["kind"]; !ok {
 			t.Fatal("missing 'kind' field")
 		}
@@ -98,14 +98,14 @@ func TestV18Deployment(t *testing.T) {
 			t.Errorf("kind.Type = %q, want %q", key.Type, "string")
 		}
 		got := key.GetPath().Get()
-		want := []string{"io.k8s.api.apps.v1beta1.Deployment", ".kind"}
+		want := []string{"io.k8s.api.apps.v1.Deployment", ".kind"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("kind path = %v, want %v", got, want)
 		}
 	})
 
 	t.Run("should have a apiVersion key of type string", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		if _, ok := deployment.Fields["apiVersion"]; !ok {
 			t.Fatal("missing 'apiVersion' field")
 		}
@@ -117,14 +117,14 @@ func TestV18Deployment(t *testing.T) {
 			t.Errorf("apiVersion.Type = %q, want %q", key.Type, "string")
 		}
 		got := key.GetPath().Get()
-		want := []string{"io.k8s.api.apps.v1beta1.Deployment", ".apiVersion"}
+		want := []string{"io.k8s.api.apps.v1.Deployment", ".apiVersion"}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("apiVersion path = %v, want %v", got, want)
 		}
 	})
 
 	t.Run("should have a metadata key of type Reference", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		if _, ok := deployment.Fields["metadata"]; !ok {
 			t.Fatal("missing 'metadata' field")
 		}
@@ -142,7 +142,7 @@ func TestV18Deployment(t *testing.T) {
 	})
 
 	t.Run("should have a status key of type Reference", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		if _, ok := deployment.Fields["status"]; !ok {
 			t.Fatal("missing 'status' field")
 		}
@@ -150,8 +150,8 @@ func TestV18Deployment(t *testing.T) {
 		if !ok {
 			t.Fatal("expected 'status' to be proto.Reference")
 		}
-		if key.Reference() != "io.k8s.api.apps.v1beta1.DeploymentStatus" {
-			t.Errorf("status reference = %q, want %q", key.Reference(), "io.k8s.api.apps.v1beta1.DeploymentStatus")
+		if key.Reference() != "io.k8s.api.apps.v1.DeploymentStatus" {
+			t.Errorf("status reference = %q, want %q", key.Reference(), "io.k8s.api.apps.v1.DeploymentStatus")
 		}
 		status, ok := key.SubSchema().(*proto.Kind)
 		if !ok || status == nil {
@@ -160,7 +160,7 @@ func TestV18Deployment(t *testing.T) {
 	})
 
 	t.Run("should have a valid DeploymentStatus", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		statusRef, ok := deployment.Fields["status"].(proto.Reference)
 		if !ok {
 			t.Fatal("expected 'status' to be proto.Reference")
@@ -190,11 +190,13 @@ func TestV18Deployment(t *testing.T) {
 		if !ok || conditions == nil {
 			t.Fatal("expected 'conditions' to be *proto.Array")
 		}
-		wantName := `Array of Reference to "io.k8s.api.apps.v1beta1.DeploymentCondition"`
+		wantName := `Array of Reference to "io.k8s.api.apps.v1.DeploymentCondition"`
 		if conditions.GetName() != wantName {
 			t.Errorf("conditions name = %q, want %q", conditions.GetName(), wantName)
 		}
 		wantExt := map[string]interface{}{
+			"x-kubernetes-list-map-keys":   []interface{}{"type"},
+			"x-kubernetes-list-type":       "map",
 			"x-kubernetes-patch-merge-key": "type",
 			"x-kubernetes-patch-strategy":  "merge",
 		}
@@ -205,13 +207,13 @@ func TestV18Deployment(t *testing.T) {
 		if !ok {
 			t.Fatal("expected conditions.SubType to be proto.Reference")
 		}
-		if condition.Reference() != "io.k8s.api.apps.v1beta1.DeploymentCondition" {
-			t.Errorf("condition reference = %q, want %q", condition.Reference(), "io.k8s.api.apps.v1beta1.DeploymentCondition")
+		if condition.Reference() != "io.k8s.api.apps.v1.DeploymentCondition" {
+			t.Errorf("condition reference = %q, want %q", condition.Reference(), "io.k8s.api.apps.v1.DeploymentCondition")
 		}
 	})
 
 	t.Run("should have a spec key of type Reference", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		if _, ok := deployment.Fields["spec"]; !ok {
 			t.Fatal("missing 'spec' field")
 		}
@@ -219,8 +221,8 @@ func TestV18Deployment(t *testing.T) {
 		if !ok {
 			t.Fatal("expected 'spec' to be proto.Reference")
 		}
-		if key.Reference() != "io.k8s.api.apps.v1beta1.DeploymentSpec" {
-			t.Errorf("spec reference = %q, want %q", key.Reference(), "io.k8s.api.apps.v1beta1.DeploymentSpec")
+		if key.Reference() != "io.k8s.api.apps.v1.DeploymentSpec" {
+			t.Errorf("spec reference = %q, want %q", key.Reference(), "io.k8s.api.apps.v1.DeploymentSpec")
 		}
 		spec, ok := key.SubSchema().(*proto.Kind)
 		if !ok || spec == nil {
@@ -229,7 +231,7 @@ func TestV18Deployment(t *testing.T) {
 	})
 
 	t.Run("should have a spec with no gvk", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		specRef, ok := deployment.Fields["spec"].(proto.Reference)
 		if !ok {
 			t.Fatal("expected 'spec' to be proto.Reference")
@@ -244,7 +246,7 @@ func TestV18Deployment(t *testing.T) {
 	})
 
 	t.Run("should have a spec with a PodTemplateSpec sub-field", func(t *testing.T) {
-		_, _, deployment := loadV18DeploymentModel(t)
+		_, _, deployment := loadDeploymentModel(t)
 		specRef, ok := deployment.Fields["spec"].(proto.Reference)
 		if !ok {
 			t.Fatal("expected 'spec' to be proto.Reference")
@@ -266,10 +268,10 @@ func TestV18Deployment(t *testing.T) {
 	})
 }
 
-func TestV111Deployment(t *testing.T) {
+func TestNextSchemaDeployment(t *testing.T) {
 	s, err := fakeSchemaNext.OpenAPISchema()
 	if err != nil {
-		t.Fatalf("failed to open v1.11 schema: %v", err)
+		t.Fatalf("failed to open next schema: %v", err)
 	}
 	models, err := proto.NewOpenAPIData(s)
 	if err != nil {
@@ -277,14 +279,14 @@ func TestV111Deployment(t *testing.T) {
 	}
 
 	t.Run("should lookup the Schema by its model name", func(t *testing.T) {
-		schema := models.LookupModel("io.k8s.api.apps.v1beta1.Deployment")
+		schema := models.LookupModel("io.k8s.api.apps.v1.Deployment")
 		if schema == nil {
-			t.Fatal("model io.k8s.api.apps.v1beta1.Deployment not found")
+			t.Fatal("model io.k8s.api.apps.v1.Deployment not found")
 		}
 	})
 
 	t.Run("should be a Kind", func(t *testing.T) {
-		schema := models.LookupModel("io.k8s.api.apps.v1beta1.Deployment")
+		schema := models.LookupModel("io.k8s.api.apps.v1.Deployment")
 		if schema == nil {
 			t.Fatal("model not found")
 		}
@@ -295,10 +297,10 @@ func TestV111Deployment(t *testing.T) {
 	})
 }
 
-func TestV111ControllerRevision(t *testing.T) {
+func TestNextSchemaControllerRevision(t *testing.T) {
 	s, err := fakeSchemaNext.OpenAPISchema()
 	if err != nil {
-		t.Fatalf("failed to open v1.11 schema: %v", err)
+		t.Fatalf("failed to open next schema: %v", err)
 	}
 	models, err := proto.NewOpenAPIData(s)
 	if err != nil {
@@ -306,14 +308,14 @@ func TestV111ControllerRevision(t *testing.T) {
 	}
 
 	t.Run("should lookup the Schema by its model name", func(t *testing.T) {
-		schema := models.LookupModel("io.k8s.api.apps.v1beta1.ControllerRevision")
+		schema := models.LookupModel("io.k8s.api.apps.v1.ControllerRevision")
 		if schema == nil {
-			t.Fatal("model io.k8s.api.apps.v1beta1.ControllerRevision not found")
+			t.Fatal("model io.k8s.api.apps.v1.ControllerRevision not found")
 		}
 	})
 
 	t.Run("data property should be map[string]Arbitrary", func(t *testing.T) {
-		schema := models.LookupModel("io.k8s.api.apps.v1beta1.ControllerRevision")
+		schema := models.LookupModel("io.k8s.api.apps.v1.ControllerRevision")
 		if schema == nil {
 			t.Fatal("model not found")
 		}
@@ -333,7 +335,7 @@ func TestV111ControllerRevision(t *testing.T) {
 		if data.GetName() != wantName {
 			t.Errorf("data name = %q, want %q", data.GetName(), wantName)
 		}
-		wantPath := []string{"io.k8s.api.apps.v1beta1.ControllerRevision", ".data"}
+		wantPath := []string{"io.k8s.api.apps.v1.ControllerRevision", ".data"}
 		if !reflect.DeepEqual(data.GetPath().Get(), wantPath) {
 			t.Errorf("data path = %v, want %v", data.GetPath().Get(), wantPath)
 		}

--- a/pkg/util/proto/testdata/swagger.json
+++ b/pkg/util/proto/testdata/swagger.json
@@ -1,11 +1,4295 @@
 {
   "swagger": "2.0",
   "info": {
-   "title": "Kubernetes",
-   "version": "v1.8.0"
+    "title": "Kubernetes",
+    "version": "v1.35.2"
   },
   "paths": {},
   "definitions": {
+    "io.k8s.api.apps.v1.ControllerRevision": {
+      "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Data is the serialized representation of the state."
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "revision": {
+          "description": "Revision indicates the revision of the state represented by Data.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "revision"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevision",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.ControllerRevisionList": {
+      "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of ControllerRevisions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ControllerRevision"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "ControllerRevisionList",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.Deployment": {
+      "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentSpec",
+          "description": "Specification of the desired behavior of the Deployment."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStatus",
+          "description": "Most recently observed status of the Deployment."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apps",
+          "kind": "Deployment",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.apps.v1.DeploymentCondition": {
+      "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "lastUpdateTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time this condition was updated."
+        },
+        "message": {
+          "description": "A human readable message indicating details about the transition.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the condition, one of True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of deployment condition.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DeploymentSpec": {
+      "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+      "properties": {
+        "minReadySeconds": {
+          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+          "format": "int32",
+          "type": "integer"
+        },
+        "paused": {
+          "description": "Indicates that the deployment is paused.",
+          "type": "boolean"
+        },
+        "progressDeadlineSeconds": {
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "revisionHistoryLimit": {
+          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels."
+        },
+        "strategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
+          "description": "The deployment strategy to use to replace existing pods with new ones.",
+          "x-kubernetes-patch-strategy": "retainKeys"
+        },
+        "template": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template describes the pods that will be created. The only allowed template.spec.restartPolicy value is \"Always\"."
+        }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DeploymentStatus": {
+      "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+      "properties": {
+        "availableReplicas": {
+          "description": "Total number of available non-terminating pods (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "collisionCount": {
+          "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of a deployment's current state.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the deployment controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "readyReplicas": {
+          "description": "Total number of non-terminating pods targeted by this Deployment with a Ready Condition.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "description": "Total number of non-terminating pods targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "terminatingReplicas": {
+          "description": "Total number of terminating pods targeted by this deployment. Terminating pods have a non-null .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.\n\nThis is a beta field and requires enabling DeploymentReplicaSetTerminatingReplicas feature (enabled by default).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "unavailableReplicas": {
+          "description": "Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "updatedReplicas": {
+          "description": "Total number of non-terminating pods targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.DeploymentStrategy": {
+      "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+      "properties": {
+        "rollingUpdate": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDeployment",
+          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+        },
+        "type": {
+          "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.apps.v1.RollingUpdateDeployment": {
+      "description": "Spec to control the desired behavior of rolling update.",
+      "properties": {
+        "maxSurge": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
+        },
+        "maxUnavailable": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.FieldSelectorAttributes": {
+      "description": "FieldSelectorAttributes indicates a field limited access. Webhook authors are encouraged to * ensure rawSelector and requirements are not both set * consider the requirements field if set * not try to parse or consider the rawSelector field if set. This is to avoid another CVE-2022-2880 (i.e. getting different systems to agree on how exactly to parse a query is not something we want), see https://www.oxeye.io/resources/golang-parameter-smuggling-attack for more details. For the *SubjectAccessReview endpoints of the kube-apiserver: * If rawSelector is empty and requirements are empty, the request is not limited. * If rawSelector is present and requirements are empty, the rawSelector will be parsed and limited if the parsing succeeds. * If rawSelector is empty and requirements are present, the requirements should be honored * If rawSelector is present and requirements are present, the request is invalid.",
+      "properties": {
+        "rawSelector": {
+          "description": "rawSelector is the serialization of a field selector that would be included in a query parameter. Webhook implementations are encouraged to ignore rawSelector. The kube-apiserver's *SubjectAccessReview will parse the rawSelector as long as the requirements are not present.",
+          "type": "string"
+        },
+        "requirements": {
+          "description": "requirements is the parsed interpretation of a field selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.LabelSelectorAttributes": {
+      "description": "LabelSelectorAttributes indicates a label limited access. Webhook authors are encouraged to * ensure rawSelector and requirements are not both set * consider the requirements field if set * not try to parse or consider the rawSelector field if set. This is to avoid another CVE-2022-2880 (i.e. getting different systems to agree on how exactly to parse a query is not something we want), see https://www.oxeye.io/resources/golang-parameter-smuggling-attack for more details. For the *SubjectAccessReview endpoints of the kube-apiserver: * If rawSelector is empty and requirements are empty, the request is not limited. * If rawSelector is present and requirements are empty, the rawSelector will be parsed and limited if the parsing succeeds. * If rawSelector is empty and requirements are present, the requirements should be honored * If rawSelector is present and requirements are present, the request is invalid.",
+      "properties": {
+        "rawSelector": {
+          "description": "rawSelector is the serialization of a field selector that would be included in a query parameter. Webhook implementations are encouraged to ignore rawSelector. The kube-apiserver's *SubjectAccessReview will parse the rawSelector as long as the requirements are not present.",
+          "type": "string"
+        },
+        "requirements": {
+          "description": "requirements is the parsed interpretation of a label selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
+      "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "authorization.k8s.io",
+          "kind": "LocalSubjectAccessReview",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.authorization.v1.NonResourceAttributes": {
+      "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+      "properties": {
+        "path": {
+          "description": "Path is the URL path of the request",
+          "type": "string"
+        },
+        "verb": {
+          "description": "Verb is the standard HTTP verb",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.ResourceAttributes": {
+      "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+      "properties": {
+        "fieldSelector": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.FieldSelectorAttributes",
+          "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it."
+        },
+        "group": {
+          "description": "Group is the API Group of the Resource.  \"*\" means all.",
+          "type": "string"
+        },
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.LabelSelectorAttributes",
+          "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it."
+        },
+        "name": {
+          "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Resource is one of the existing resource types.  \"*\" means all.",
+          "type": "string"
+        },
+        "subresource": {
+          "description": "Subresource is one of the existing resource types.  \"\" means none.",
+          "type": "string"
+        },
+        "verb": {
+          "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version is the API Version of the Resource.  \"*\" means all.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SubjectAccessReviewSpec": {
+      "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+      "properties": {
+        "extra": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+          "type": "object"
+        },
+        "groups": {
+          "description": "Groups is the groups you're testing for.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "nonResourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes",
+          "description": "NonResourceAttributes describes information for a non-resource access request"
+        },
+        "resourceAttributes": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes",
+          "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+        },
+        "uid": {
+          "description": "UID information about the requesting user.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is the user you're testing for. If you specify \"User\" but not \"Groups\", then is it interpreted as \"What if User were not a member of any groups",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.authorization.v1.SubjectAccessReviewStatus": {
+      "description": "SubjectAccessReviewStatus",
+      "properties": {
+        "allowed": {
+          "description": "Allowed is required. True if the action would be allowed, false otherwise.",
+          "type": "boolean"
+        },
+        "denied": {
+          "description": "Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.",
+          "type": "boolean"
+        },
+        "evaluationError": {
+          "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason is optional.  It indicates why a request was allowed or denied.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "allowed"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
+      "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "string"
+        },
+        "partition": {
+          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "readOnly": {
+          "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "boolean"
+        },
+        "volumeID": {
+          "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Affinity": {
+      "description": "Affinity is a group of affinity scheduling rules.",
+      "properties": {
+        "nodeAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity",
+          "description": "Describes node affinity scheduling rules for the pod."
+        },
+        "podAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity",
+          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
+        },
+        "podAntiAffinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity",
+          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AppArmorProfile": {
+      "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+      "properties": {
+        "localhostProfile": {
+          "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+          "type": "string"
+        },
+        "type": {
+          "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "x-kubernetes-unions": [
+        {
+          "discriminator": "type",
+          "fields-to-discriminateBy": {
+            "localhostProfile": "LocalhostProfile"
+          }
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.AzureDiskVolumeSource": {
+      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+      "properties": {
+        "cachingMode": {
+          "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+          "type": "string"
+        },
+        "diskName": {
+          "description": "diskName is the Name of the data disk in the blob storage",
+          "type": "string"
+        },
+        "diskURI": {
+          "description": "diskURI is the URI of data disk in the blob storage",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "diskName",
+        "diskURI"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.AzureFileVolumeSource": {
+      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+      "properties": {
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+          "type": "string"
+        },
+        "shareName": {
+          "description": "shareName is the azure share Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretName",
+        "shareName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CSIVolumeSource": {
+      "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+      "properties": {
+        "driver": {
+          "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+          "type": "string"
+        },
+        "nodePublishSecretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+        },
+        "readOnly": {
+          "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+          "type": "boolean"
+        },
+        "volumeAttributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Capabilities": {
+      "description": "Adds and removes POSIX capabilities from running containers.",
+      "properties": {
+        "add": {
+          "description": "Added capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "drop": {
+          "description": "Removed capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CephFSVolumeSource": {
+      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "monitors": {
+          "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "path": {
+          "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretFile": {
+          "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "monitors"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CinderVolumeSource": {
+      "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
+        },
+        "volumeID": {
+          "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ClusterTrustBundleProjection": {
+      "description": "ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.",
+      "properties": {
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as \"match nothing\".  If set but empty, interpreted as \"match everything\"."
+        },
+        "name": {
+          "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "Relative path from the volume root to write the bundle.",
+          "type": "string"
+        },
+        "signerName": {
+          "description": "Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapEnvSource": {
+      "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+      "properties": {
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapKeySelector": {
+      "description": "Selects a key from a ConfigMap.",
+      "properties": {
+        "key": {
+          "description": "The key to select.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap or its key must be defined",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.ConfigMapProjection": {
+      "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+      "properties": {
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "optional specify whether the ConfigMap or its keys must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+      "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "optional specify whether the ConfigMap or its keys must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Container": {
+      "description": "A single application container that you want to run within a pod.",
+      "properties": {
+        "args": {
+          "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "envFrom": {
+          "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "image": {
+          "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "type": "string"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
+          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated."
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+        },
+        "name": {
+          "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+          "type": "string"
+        },
+        "ports": {
+          "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "containerPort",
+            "protocol"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "containerPort",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+        },
+        "resizePolicy": {
+          "description": "Resources resize policy for the container. This field cannot be set on ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+        },
+        "restartPolicy": {
+          "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Additionally, setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+          "type": "string"
+        },
+        "restartPolicyRules": {
+          "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod's RestartPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+          "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+        },
+        "stdin": {
+          "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+          "type": "boolean"
+        },
+        "stdinOnce": {
+          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+          "type": "boolean"
+        },
+        "terminationMessagePath": {
+          "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+          "type": "string"
+        },
+        "terminationMessagePolicy": {
+          "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+          "type": "string"
+        },
+        "tty": {
+          "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+          "type": "boolean"
+        },
+        "volumeDevices": {
+          "description": "volumeDevices is the list of block devices to be used by the container.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "devicePath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "devicePath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "volumeMounts": {
+          "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "mountPath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "workingDir": {
+          "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerExtendedResourceRequest": {
+      "description": "ContainerExtendedResourceRequest has the mapping of container name, extended resource name to the device request name.",
+      "properties": {
+        "containerName": {
+          "description": "The name of the container requesting resources.",
+          "type": "string"
+        },
+        "requestName": {
+          "description": "The name of the request in the special ResourceClaim which corresponds to the extended resource.",
+          "type": "string"
+        },
+        "resourceName": {
+          "description": "The name of the extended resource in that container which gets backed by DRA.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "containerName",
+        "resourceName",
+        "requestName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerPort": {
+      "description": "ContainerPort represents a network port in a single container.",
+      "properties": {
+        "containerPort": {
+          "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "hostIP": {
+          "description": "What host IP to bind the external port to.",
+          "type": "string"
+        },
+        "hostPort": {
+          "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "name": {
+          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+          "type": "string"
+        },
+        "protocol": {
+          "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+          "type": "string"
+        }
+      },
+      "required": [
+        "containerPort"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerResizePolicy": {
+      "description": "ContainerResizePolicy represents resource resize policy for the container.",
+      "properties": {
+        "resourceName": {
+          "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+          "type": "string"
+        },
+        "restartPolicy": {
+          "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resourceName",
+        "restartPolicy"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerRestartRule": {
+      "description": "ContainerRestartRule describes how a container exit is handled.",
+      "properties": {
+        "action": {
+          "description": "Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is \"Restart\" to restart the container.",
+          "type": "string"
+        },
+        "exitCodes": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes",
+          "description": "Represents the exit codes to check on container exits."
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes": {
+      "description": "ContainerRestartRuleOnExitCodes describes the condition for handling an exited container based on its exit codes.",
+      "properties": {
+        "operator": {
+          "description": "Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+          "type": "string"
+        },
+        "values": {
+          "description": "Specifies the set of values to check for container exit codes. At most 255 elements are allowed.",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        }
+      },
+      "required": [
+        "operator"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerState": {
+      "description": "ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.",
+      "properties": {
+        "running": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateRunning",
+          "description": "Details about a running container"
+        },
+        "terminated": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateTerminated",
+          "description": "Details about a terminated container"
+        },
+        "waiting": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateWaiting",
+          "description": "Details about a waiting container"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateRunning": {
+      "description": "ContainerStateRunning is a running state of a container.",
+      "properties": {
+        "startedAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which the container was last (re-)started"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateTerminated": {
+      "description": "ContainerStateTerminated is a terminated state of a container.",
+      "properties": {
+        "containerID": {
+          "description": "Container's ID in the format '<type>://<container_id>'",
+          "type": "string"
+        },
+        "exitCode": {
+          "description": "Exit status from the last termination of the container",
+          "format": "int32",
+          "type": "integer"
+        },
+        "finishedAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which the container last terminated"
+        },
+        "message": {
+          "description": "Message regarding the last termination of the container",
+          "type": "string"
+        },
+        "reason": {
+          "description": "(brief) reason from the last termination of the container",
+          "type": "string"
+        },
+        "signal": {
+          "description": "Signal from the last termination of the container",
+          "format": "int32",
+          "type": "integer"
+        },
+        "startedAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which previous execution of the container started"
+        }
+      },
+      "required": [
+        "exitCode"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateWaiting": {
+      "description": "ContainerStateWaiting is a waiting state of a container.",
+      "properties": {
+        "message": {
+          "description": "Message regarding why the container is not yet running.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "(brief) reason the container is not yet running.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStatus": {
+      "description": "ContainerStatus contains details for the current status of this container.",
+      "properties": {
+        "allocatedResources": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "AllocatedResources represents the compute resources allocated for this container by the node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission and after successfully admitting desired pod resize.",
+          "type": "object"
+        },
+        "allocatedResourcesStatus": {
+          "description": "AllocatedResourcesStatus represents the status of various resources allocated for this Pod.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "containerID": {
+          "description": "ContainerID is the ID of the container in the format '<type>://<container_id>'. Where type is a container runtime identifier, returned from Version call of CRI API (for example \"containerd\").",
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is the name of container image that the container is running. The container image may not match the image used in the PodSpec, as it may have been resolved by the runtime. More info: https://kubernetes.io/docs/concepts/containers/images.",
+          "type": "string"
+        },
+        "imageID": {
+          "description": "ImageID is the image ID of the container's image. The image ID may not match the image ID of the image used in the PodSpec, as it may have been resolved by the runtime.",
+          "type": "string"
+        },
+        "lastState": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
+          "description": "LastTerminationState holds the last termination state of the container to help debug container crashes and restarts. This field is not populated if the container is still running and RestartCount is 0."
+        },
+        "name": {
+          "description": "Name is a DNS_LABEL representing the unique name of the container. Each container in a pod must have a unique name across all container types. Cannot be updated.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready specifies whether the container is currently passing its readiness check. The value will change as readiness probes keep executing. If no readiness probes are specified, this field defaults to true once the container is fully started (see Started field).\n\nThe value is typically used to determine whether a container is ready to accept traffic.",
+          "type": "boolean"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources represents the compute resource requests and limits that have been successfully enacted on the running container after it has been started or has been successfully resized."
+        },
+        "restartCount": {
+          "description": "RestartCount holds the number of times the container has been restarted. Kubelet makes an effort to always increment the value, but there are cases when the state may be lost due to node restarts and then the value may be reset to 0. The value is never negative.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "started": {
+          "description": "Started indicates whether the container has finished its postStart lifecycle hook and passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. In both cases, startup probes will run again. Is always true when no startupProbe is defined and container is running and has passed the postStart lifecycle hook. The null value must be treated the same as false.",
+          "type": "boolean"
+        },
+        "state": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
+          "description": "State holds details about the container's current condition."
+        },
+        "stopSignal": {
+          "description": "StopSignal reports the effective stop signal for this container",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerUser",
+          "description": "User represents user identity information initially attached to the first process of the container"
+        },
+        "volumeMounts": {
+          "description": "Status of volume mounts.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMountStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "mountPath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "required": [
+        "name",
+        "ready",
+        "restartCount",
+        "image",
+        "imageID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerUser": {
+      "description": "ContainerUser represents user identity information",
+      "properties": {
+        "linux": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LinuxContainerUser",
+          "description": "Linux holds user identity information initially attached to the first process of the containers in Linux. Note that the actual running identity can be changed if the process has enough privilege to do so."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DownwardAPIProjection": {
+      "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+      "properties": {
+        "items": {
+          "description": "Items is a list of DownwardAPIVolume file",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
+      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+      "properties": {
+        "fieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported."
+        },
+        "mode": {
+          "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "path": {
+          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+          "type": "string"
+        },
+        "resourceFieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+      "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "items": {
+          "description": "Items is a list of downward API volume file",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EmptyDirVolumeSource": {
+      "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "medium": {
+          "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+          "type": "string"
+        },
+        "sizeLimit": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EnvFromSource": {
+      "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+      "properties": {
+        "configMapRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+          "description": "The ConfigMap to select from"
+        },
+        "prefix": {
+          "description": "Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.",
+          "type": "string"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+          "description": "The Secret to select from"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EnvVar": {
+      "description": "EnvVar represents an environment variable present in a Container.",
+      "properties": {
+        "name": {
+          "description": "Name of the environment variable. May consist of any printable ASCII characters except '='.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+          "type": "string"
+        },
+        "valueFrom": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource",
+          "description": "Source for the environment variable's value. Cannot be used if value is not empty."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EnvVarSource": {
+      "description": "EnvVarSource represents a source for the value of an EnvVar.",
+      "properties": {
+        "configMapKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector",
+          "description": "Selects a key of a ConfigMap."
+        },
+        "fieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+        },
+        "fileKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FileKeySelector",
+          "description": "FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled."
+        },
+        "resourceFieldRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported."
+        },
+        "secretKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector",
+          "description": "Selects a key of a secret in the pod's namespace"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EphemeralContainer": {
+      "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
+      "properties": {
+        "args": {
+          "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "envFrom": {
+          "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "image": {
+          "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "type": "string"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
+          "description": "Lifecycle is not allowed for ephemeral containers."
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Probes are not allowed for ephemeral containers."
+        },
+        "name": {
+          "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+          "type": "string"
+        },
+        "ports": {
+          "description": "Ports are not allowed for ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "containerPort",
+            "protocol"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "containerPort",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Probes are not allowed for ephemeral containers."
+        },
+        "resizePolicy": {
+          "description": "Resources resize policy for the container.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod."
+        },
+        "restartPolicy": {
+          "description": "Restart policy for the container to manage the restart behavior of each container within a pod. You cannot set this field on ephemeral containers.",
+          "type": "string"
+        },
+        "restartPolicyRules": {
+          "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. You cannot set this field on ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+          "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext."
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Probes are not allowed for ephemeral containers."
+        },
+        "stdin": {
+          "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+          "type": "boolean"
+        },
+        "stdinOnce": {
+          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+          "type": "boolean"
+        },
+        "targetContainerName": {
+          "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.",
+          "type": "string"
+        },
+        "terminationMessagePath": {
+          "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+          "type": "string"
+        },
+        "terminationMessagePolicy": {
+          "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+          "type": "string"
+        },
+        "tty": {
+          "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+          "type": "boolean"
+        },
+        "volumeDevices": {
+          "description": "volumeDevices is the list of block devices to be used by the container.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "devicePath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "devicePath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "volumeMounts": {
+          "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "mountPath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "workingDir": {
+          "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.EphemeralVolumeSource": {
+      "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
+      "properties": {
+        "volumeClaimTemplate": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate",
+          "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.\n\nRequired, must not be nil."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ExecAction": {
+      "description": "ExecAction describes a \"run in container\" action.",
+      "properties": {
+        "command": {
+          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FCVolumeSource": {
+      "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "lun": {
+          "description": "lun is Optional: FC target lun number",
+          "format": "int32",
+          "type": "integer"
+        },
+        "readOnly": {
+          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "targetWWNs": {
+          "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "wwids": {
+          "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FileKeySelector": {
+      "description": "FileKeySelector selects a key of the env file.",
+      "properties": {
+        "key": {
+          "description": "The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist, an error will be returned during Pod creation.",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "The name of the volume mount containing the env file.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeName",
+        "path",
+        "key"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.FlexVolumeSource": {
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+      "properties": {
+        "driver": {
+          "description": "driver is the name of the driver to use for this volume.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "options is Optional: this field holds extra command options if any.",
+          "type": "object"
+        },
+        "readOnly": {
+          "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FlockerVolumeSource": {
+      "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "datasetName": {
+          "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+          "type": "string"
+        },
+        "datasetUUID": {
+          "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
+      "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "string"
+        },
+        "partition": {
+          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "format": "int32",
+          "type": "integer"
+        },
+        "pdName": {
+          "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pdName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GRPCAction": {
+      "description": "GRPCAction specifies an action involving a GRPC service.",
+      "properties": {
+        "port": {
+          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "service": {
+          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GitRepoVolumeSource": {
+      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+      "properties": {
+        "directory": {
+          "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+          "type": "string"
+        },
+        "repository": {
+          "description": "repository is the URL",
+          "type": "string"
+        },
+        "revision": {
+          "description": "revision is the commit hash for the specified revision.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GlusterfsVolumeSource": {
+      "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "endpoints": {
+          "description": "endpoints is the endpoint name that details Glusterfs topology.",
+          "type": "string"
+        },
+        "path": {
+          "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "endpoints",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HTTPGetAction": {
+      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+      "properties": {
+        "host": {
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+          "type": "string"
+        },
+        "httpHeaders": {
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "path": {
+          "description": "Path to access on the HTTP server.",
+          "type": "string"
+        },
+        "port": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        },
+        "scheme": {
+          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HTTPHeader": {
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "properties": {
+        "name": {
+          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The header field value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HostAlias": {
+      "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+      "properties": {
+        "hostnames": {
+          "description": "Hostnames for the above IP address.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "ip": {
+          "description": "IP address of the host file entry.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HostIP": {
+      "description": "HostIP represents a single IP address allocated to the host.",
+      "properties": {
+        "ip": {
+          "description": "IP is the IP address assigned to the host",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HostPathVolumeSource": {
+      "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "path": {
+          "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": "string"
+        },
+        "type": {
+          "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ISCSIVolumeSource": {
+      "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "chapAuthDiscovery": {
+          "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+          "type": "boolean"
+        },
+        "chapAuthSession": {
+          "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+          "type": "boolean"
+        },
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+          "type": "string"
+        },
+        "initiatorName": {
+          "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+          "type": "string"
+        },
+        "iqn": {
+          "description": "iqn is the target iSCSI Qualified Name.",
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+          "type": "string"
+        },
+        "lun": {
+          "description": "lun represents iSCSI Target Lun number.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "portals": {
+          "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
+        },
+        "targetPortal": {
+          "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetPortal",
+        "iqn",
+        "lun"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ImageVolumeSource": {
+      "description": "ImageVolumeSource represents a image volume resource.",
+      "properties": {
+        "pullPolicy": {
+          "description": "Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+          "type": "string"
+        },
+        "reference": {
+          "description": "Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.KeyToPath": {
+      "description": "Maps a string key to a path within a volume.",
+      "properties": {
+        "key": {
+          "description": "key is the key to project.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "path": {
+          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Lifecycle": {
+      "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+      "properties": {
+        "postStart": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LifecycleHandler",
+          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+        },
+        "preStop": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LifecycleHandler",
+          "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+        },
+        "stopSignal": {
+          "description": "StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LifecycleHandler": {
+      "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+      "properties": {
+        "exec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+          "description": "Exec specifies a command to execute in the container."
+        },
+        "httpGet": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+          "description": "HTTPGet specifies an HTTP GET request to perform."
+        },
+        "sleep": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SleepAction",
+          "description": "Sleep represents a duration that the container should sleep."
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LinuxContainerUser": {
+      "description": "LinuxContainerUser represents user identity information in Linux containers",
+      "properties": {
+        "gid": {
+          "description": "GID is the primary gid initially attached to the first process in the container",
+          "format": "int64",
+          "type": "integer"
+        },
+        "supplementalGroups": {
+          "description": "SupplementalGroups are the supplemental groups initially attached to the first process in the container",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "uid": {
+          "description": "UID is the primary uid initially attached to the first process in the container",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "uid",
+        "gid"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LocalObjectReference": {
+      "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+      "properties": {
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.NFSVolumeSource": {
+      "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "path": {
+          "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "boolean"
+        },
+        "server": {
+          "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        }
+      },
+      "required": [
+        "server",
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeAffinity": {
+      "description": "Node affinity is a group of node affinity scheduling rules.",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSelector": {
+      "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+      "properties": {
+        "nodeSelectorTerms": {
+          "description": "Required. A list of node selector terms. The terms are ORed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "nodeSelectorTerms"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.NodeSelectorRequirement": {
+      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      "properties": {
+        "key": {
+          "description": "The label key that the selector applies to.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+          "type": "string"
+        },
+        "values": {
+          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "key",
+        "operator"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSelectorTerm": {
+      "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+      "properties": {
+        "matchExpressions": {
+          "description": "A list of node selector requirements by node's labels.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "matchFields": {
+          "description": "A list of node selector requirements by node's fields.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.ObjectFieldSelector": {
+      "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+      "properties": {
+        "apiVersion": {
+          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+          "type": "string"
+        },
+        "fieldPath": {
+          "description": "Path of the field to select in the specified API version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fieldPath"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+      "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+      "properties": {
+        "accessModes": {
+          "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "dataSource": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
+          "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource."
+        },
+        "dataSourceRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedObjectReference",
+          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled."
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.VolumeResourceRequirements",
+          "description": "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+        },
+        "selector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is a label query over volumes to consider for binding."
+        },
+        "storageClassName": {
+          "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+          "type": "string"
+        },
+        "volumeAttributesClassName": {
+          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string or nil value indicates that no VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state, this field can be reset to its previous value (including nil) to cancel the modification. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+          "type": "string"
+        },
+        "volumeMode": {
+          "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+      "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
+          "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here."
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
+      "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+      "properties": {
+        "claimName": {
+          "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "claimName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
+      "description": "Represents a Photon Controller persistent disk resource.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "pdID": {
+          "description": "pdID is the ID that identifies Photon Controller persistent disk",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pdID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Pod": {
+      "description": "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
+          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodStatus",
+          "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "Pod",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.PodAffinity": {
+      "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodAffinityTerm": {
+      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+      "properties": {
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods."
+        },
+        "matchLabelKeys": {
+          "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "mismatchLabelKeys": {
+          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
+        },
+        "namespaces": {
+          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "topologyKey": {
+          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "topologyKey"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodAntiAffinity": {
+      "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+      "properties": {
+        "preferredDuringSchedulingIgnoredDuringExecution": {
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and subtracting \"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodCertificateProjection": {
+      "description": "PodCertificateProjection provides a private key and X.509 certificate in the pod filesystem.",
+      "properties": {
+        "certificateChainPath": {
+          "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+          "type": "string"
+        },
+        "credentialBundlePath": {
+          "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks. The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private key.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued certificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single atomic read that retrieves a consistent key and certificate chain.  If you project them to separate files, your application code will need to additionally check that the leaf certificate was issued to the key.",
+          "type": "string"
+        },
+        "keyPath": {
+          "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+          "type": "string"
+        },
+        "keyType": {
+          "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\", \"ECDSAP521\", and \"ED25519\".",
+          "type": "string"
+        },
+        "maxExpirationSeconds": {
+          "description": "maxExpirationSeconds is the maximum lifetime permitted for the certificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it generates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "signerName": {
+          "description": "Kubelet's generated CSRs will be addressed to this signer.",
+          "type": "string"
+        },
+        "userAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "signerName",
+        "keyType"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodCondition": {
+      "description": "PodCondition contains details for the current condition of this pod.",
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time we probed the condition."
+        },
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "Human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "reason": {
+          "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodDNSConfig": {
+      "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+      "properties": {
+        "nameservers": {
+          "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "options": {
+          "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfigOption"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "searches": {
+          "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodDNSConfigOption": {
+      "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+      "properties": {
+        "name": {
+          "description": "Name is this DNS resolver option's name. Required.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value is this DNS resolver option's value.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodExtendedResourceClaimStatus": {
+      "description": "PodExtendedResourceClaimStatus is stored in the PodStatus for the extended resource requests backed by DRA. It stores the generated name for the corresponding special ResourceClaim created by the scheduler.",
+      "properties": {
+        "requestMappings": {
+          "description": "RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request in the generated ResourceClaim.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerExtendedResourceRequest"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "requestMappings",
+        "resourceClaimName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodIP": {
+      "description": "PodIP represents a single IP address allocated to the pod.",
+      "properties": {
+        "ip": {
+          "description": "IP is the IP address assigned to the pod",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodOS": {
+      "description": "PodOS defines the OS parameters of a pod.",
+      "properties": {
+        "name": {
+          "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodReadinessGate": {
+      "description": "PodReadinessGate contains the reference to a pod condition",
+      "properties": {
+        "conditionType": {
+          "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditionType"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodResourceClaim": {
+      "description": "PodResourceClaim references exactly one ResourceClaim, either directly or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim for the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+      "properties": {
+        "name": {
+          "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+          "type": "string"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+          "type": "string"
+        },
+        "resourceClaimTemplateName": {
+          "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodResourceClaimStatus": {
+      "description": "PodResourceClaimStatus is stored in the PodStatus for each PodResourceClaim which references a ResourceClaimTemplate. It stores the generated name for the corresponding ResourceClaim.",
+      "properties": {
+        "name": {
+          "description": "Name uniquely identifies this resource claim inside the pod. This must match the name of an entry in pod.spec.resourceClaims, which implies that the string must be a DNS_LABEL.",
+          "type": "string"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSchedulingGate": {
+      "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+      "properties": {
+        "name": {
+          "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSecurityContext": {
+      "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+      "properties": {
+        "appArmorProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
+          "description": "appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "fsGroup": {
+          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxChangePolicy": {
+          "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod. It has no effect on nodes that do not support SELinux or to volumes does not support SELinux. Valid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime. This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option. This requires all Pods that share the same volume to use the same SELinux label. It is not possible to share the same volume among privileged and unprivileged Pods. Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their CSIDriver instance. Other volumes are always re-labelled recursively. \"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used. If not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes and \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "seccompProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
+          "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "supplementalGroups": {
+          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID and fsGroup (if specified).  If the SupplementalGroupsPolicy feature is enabled, the supplementalGroupsPolicy field determines whether these are in addition to or instead of any group memberships defined in the container image. If unspecified, no additional groups are added, though group memberships defined in the container image may still be used, depending on the supplementalGroupsPolicy field. Note that this field cannot be set when spec.os.name is windows.",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "supplementalGroupsPolicy": {
+          "description": "Defines how supplemental groups of the first container processes are calculated. Valid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
+        "sysctls": {
+          "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSpec": {
+      "description": "PodSpec is a description of a pod.",
+      "properties": {
+        "activeDeadlineSeconds": {
+          "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "affinity": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Affinity",
+          "description": "If specified, the pod's scheduling constraints"
+        },
+        "automountServiceAccountToken": {
+          "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+          "type": "boolean"
+        },
+        "containers": {
+          "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "dnsConfig": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfig",
+          "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy."
+        },
+        "dnsPolicy": {
+          "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+          "type": "string"
+        },
+        "enableServiceLinks": {
+          "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+          "type": "boolean"
+        },
+        "ephemeralContainers": {
+          "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralContainer"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "hostAliases": {
+          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "ip"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "hostIPC": {
+          "description": "Use the host's ipc namespace. Optional: Default to false.",
+          "type": "boolean"
+        },
+        "hostNetwork": {
+          "description": "Host networking requested for this pod. Use the host's network namespace. When using HostNetwork you should specify ports so the scheduler is aware. When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`, and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`. Default to false.",
+          "type": "boolean"
+        },
+        "hostPID": {
+          "description": "Use the host's pid namespace. Optional: Default to false.",
+          "type": "boolean"
+        },
+        "hostUsers": {
+          "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+          "type": "boolean"
+        },
+        "hostname": {
+          "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+          "type": "string"
+        },
+        "hostnameOverride": {
+          "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod. This field only specifies the pod's hostname and does not affect its DNS records. When this field is set to a non-empty string: - It takes precedence over the values set in `hostname` and `subdomain`. - The Pod's hostname will be set to this value. - `setHostnameAsFQDN` must be nil or set to false. - `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters. Requires the HostnameOverride feature gate to be enabled.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "initContainers": {
+          "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "nodeName": {
+          "description": "NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
+          "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
+        },
+        "os": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodOS",
+          "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.resources - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
+        },
+        "overhead": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+          "type": "object"
+        },
+        "preemptionPolicy": {
+          "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "priorityClassName": {
+          "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+          "type": "string"
+        },
+        "readinessGates": {
+          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodReadinessGate"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resourceClaims": {
+          "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.\n\nThis field is immutable.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaim"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for \"cpu\", \"memory\" and \"hugepages-\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the entire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature gate."
+        },
+        "restartPolicy": {
+          "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
+          "type": "string"
+        },
+        "schedulerName": {
+          "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+          "type": "string"
+        },
+        "schedulingGates": {
+          "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodSchedulingGate"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+          "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
+        },
+        "serviceAccount": {
+          "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+          "type": "string"
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+          "type": "string"
+        },
+        "setHostnameAsFQDN": {
+          "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.",
+          "type": "boolean"
+        },
+        "shareProcessNamespace": {
+          "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+          "type": "boolean"
+        },
+        "subdomain": {
+          "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+          "type": "string"
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "tolerations": {
+          "description": "If specified, the pod's tolerations.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "topologySpreadConstraints": {
+          "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "topologyKey",
+            "whenUnsatisfiable"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "topologyKey",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "volumes": {
+          "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "workloadRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WorkloadReference",
+          "description": "WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies."
+        }
+      },
+      "required": [
+        "containers"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodStatus": {
+      "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.",
+      "properties": {
+        "allocatedResources": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "AllocatedResources is the total requests allocated for this pod by the node. If pod-level requests are not set, this will be the total requests aggregated across containers in the pod.",
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "containerStatuses": {
+          "description": "Statuses of containers in this pod. Each container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "ephemeralContainerStatuses": {
+          "description": "Statuses for any ephemeral containers that have run in this pod. Each ephemeral container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "extendedResourceClaimStatus": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodExtendedResourceClaimStatus",
+          "description": "Status of extended resource claim backed by DRA."
+        },
+        "hostIP": {
+          "description": "hostIP holds the IP address of the host to which the pod is assigned. Empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns mean that HostIP will not be updated even if there is a node is assigned to pod",
+          "type": "string"
+        },
+        "hostIPs": {
+          "description": "hostIPs holds the IP addresses allocated to the host. If this field is specified, the first entry must match the hostIP field. This list is empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns means that HostIPs will not be updated even if there is a node is assigned to this pod.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HostIP"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "initContainerStatuses": {
+          "description": "Statuses of init containers in this pod. The most recent successful non-restartable init container will have ready = true, the most recently started container will have startTime set. Each init container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "message": {
+          "description": "A human readable message indicating details about why the pod is in this condition.",
+          "type": "string"
+        },
+        "nominatedNodeName": {
+          "description": "nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be scheduled right away as preemption victims receive their graceful termination periods. This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to give the resources on this node to a higher priority pod that is created after preemption. As a result, this field may be different than PodSpec.nodeName when the pod is scheduled.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "If set, this represents the .metadata.generation that the pod status was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:\n\nPending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.\n\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase",
+          "type": "string"
+        },
+        "podIP": {
+          "description": "podIP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
+          "type": "string"
+        },
+        "podIPs": {
+          "description": "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodIP"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "ip"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "qosClass": {
+          "description": "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes",
+          "type": "string"
+        },
+        "reason": {
+          "description": "A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'",
+          "type": "string"
+        },
+        "resize": {
+          "description": "Status of resources resize desired for pod's containers. It is empty if no resources resize is pending. Any changes to container resources will automatically set this to \"Proposed\" Deprecated: Resize status is moved to two pod conditions PodResizePending and PodResizeInProgress. PodResizePending will track states where the spec has been resized, but the Kubelet has not yet allocated the resources. PodResizeInProgress will track in-progress resizes, and should be present whenever allocated resources != acknowledged resources.",
+          "type": "string"
+        },
+        "resourceClaimStatuses": {
+          "description": "Status of resource claims.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaimStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources represents the compute resource requests and limits that have been applied at the pod level if pod-level requests or limits are set in PodSpec.Resources"
+        },
+        "startTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodTemplateSpec": {
+      "description": "PodTemplateSpec describes the data a pod should have when created from a template",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
+          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PortworxVolumeSource": {
+      "description": "PortworxVolumeSource represents a Portworx volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "volumeID": {
+          "description": "volumeID uniquely identifies a Portworx volume",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+      "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+      "properties": {
+        "preference": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm",
+          "description": "A node selector term, associated with the corresponding weight."
+        },
+        "weight": {
+          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "weight",
+        "preference"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Probe": {
+      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+      "properties": {
+        "exec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+          "description": "Exec specifies a command to execute in the container."
+        },
+        "failureThreshold": {
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "grpc": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GRPCAction",
+          "description": "GRPC specifies a GRPC HealthCheckRequest."
+        },
+        "httpGet": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+          "description": "HTTPGet specifies an HTTP GET request to perform."
+        },
+        "initialDelaySeconds": {
+          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "format": "int32",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "successThreshold": {
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+          "description": "TCPSocket specifies a connection to a TCP port."
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ProjectedVolumeSource": {
+      "description": "Represents a projected volume source",
+      "properties": {
+        "defaultMode": {
+          "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "sources": {
+          "description": "sources is the list of volume projections. Each entry in this list handles one source.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.QuobyteVolumeSource": {
+      "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "group": {
+          "description": "group to map volume access to Default is no group",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+          "type": "boolean"
+        },
+        "registry": {
+          "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+          "type": "string"
+        },
+        "user": {
+          "description": "user to map volume access to Defaults to serivceaccount user",
+          "type": "string"
+        },
+        "volume": {
+          "description": "volume is a string that references an already created Quobyte volume by name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "registry",
+        "volume"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.RBDVolumeSource": {
+      "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+          "type": "string"
+        },
+        "image": {
+          "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "keyring": {
+          "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "monitors": {
+          "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "pool": {
+          "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
+      "required": [
+        "monitors",
+        "image"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceClaim": {
+      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+      "properties": {
+        "name": {
+          "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+          "type": "string"
+        },
+        "request": {
+          "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceFieldSelector": {
+      "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+      "properties": {
+        "containerName": {
+          "description": "Container name: required for volumes, optional for env vars",
+          "type": "string"
+        },
+        "divisor": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+        },
+        "resource": {
+          "description": "Required: resource to select",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.ResourceHealth": {
+      "description": "ResourceHealth represents the health of a resource. It has the latest device health information. This is a part of KEP https://kep.k8s.io/4680.",
+      "properties": {
+        "health": {
+          "description": "Health of the resource. can be one of:\n - Healthy: operates as normal\n - Unhealthy: reported unhealthy. We consider this a temporary health issue\n              since we do not have a mechanism today to distinguish\n              temporary and permanent issues.\n - Unknown: The status cannot be determined.\n            For example, Device Plugin got unregistered and hasn't been re-registered since.\n\nIn future we may want to introduce the PermanentlyUnhealthy Status.",
+          "type": "string"
+        },
+        "resourceID": {
+          "description": "ResourceID is the unique identifier of the resource. See the ResourceID type for more information.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resourceID"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceRequirements": {
+      "description": "ResourceRequirements describes the compute resource requirements.",
+      "properties": {
+        "claims": {
+          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis field depends on the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceClaim"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "limits": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
+        },
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceStatus": {
+      "description": "ResourceStatus represents the status of a single resource allocated to a Pod.",
+      "properties": {
+        "name": {
+          "description": "Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec. For DRA resources, the value must be \"claim:<claim_name>/<request>\". When this status is reported about a container, the \"claim_name\" and \"request\" must match one of the claims of this container.",
+          "type": "string"
+        },
+        "resources": {
+          "description": "List of unique resources health. Each element in the list contains an unique resource ID and its health. At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node. If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share. See ResourceID type definition for a specific format it has in various use cases.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceHealth"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "resourceID"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SELinuxOptions": {
+      "description": "SELinuxOptions are the labels to be applied to the container",
+      "properties": {
+        "level": {
+          "description": "Level is SELinux level label that applies to the container.",
+          "type": "string"
+        },
+        "role": {
+          "description": "Role is a SELinux role label that applies to the container.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is a SELinux type label that applies to the container.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is a SELinux user label that applies to the container.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ScaleIOVolumeSource": {
+      "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+          "type": "string"
+        },
+        "gateway": {
+          "description": "gateway is the host address of the ScaleIO API Gateway.",
+          "type": "string"
+        },
+        "protectionDomain": {
+          "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+        },
+        "sslEnabled": {
+          "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+          "type": "boolean"
+        },
+        "storageMode": {
+          "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+          "type": "string"
+        },
+        "storagePool": {
+          "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+          "type": "string"
+        },
+        "system": {
+          "description": "system is the name of the storage system as configured in ScaleIO.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gateway",
+        "system",
+        "secretRef"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SeccompProfile": {
+      "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+      "properties": {
+        "localhostProfile": {
+          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+          "type": "string"
+        },
+        "type": {
+          "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "x-kubernetes-unions": [
+        {
+          "discriminator": "type",
+          "fields-to-discriminateBy": {
+            "localhostProfile": "LocalhostProfile"
+          }
+        }
+      ]
+    },
+    "io.k8s.api.core.v1.SecretEnvSource": {
+      "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+      "properties": {
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretKeySelector": {
+      "description": "SecretKeySelector selects a key of a Secret.",
+      "properties": {
+        "key": {
+          "description": "The key of the secret to select from.  Must be a valid secret key.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the Secret or its key must be defined",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.SecretProjection": {
+      "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+      "properties": {
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "name": {
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "optional": {
+          "description": "optional field specify whether the Secret or its key must be defined",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretVolumeSource": {
+      "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "items": {
+          "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "optional": {
+          "description": "optional field specify whether the Secret or its keys must be defined",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecurityContext": {
+      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
+        },
+        "appArmorProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
+          "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "capabilities": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
+          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "privileged": {
+          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
+        },
+        "procMount": {
+          "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
+        "readOnlyRootFilesystem": {
+          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "seccompProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
+          "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
+      "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+      "properties": {
+        "audience": {
+          "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+          "type": "string"
+        },
+        "expirationSeconds": {
+          "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "path": {
+          "description": "path is the path relative to the mount point of the file to project the token into.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SleepAction": {
+      "description": "SleepAction describes a \"sleep\" action.",
+      "properties": {
+        "seconds": {
+          "description": "Seconds is the number of seconds to sleep.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "seconds"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.StorageOSVolumeSource": {
+      "description": "Represents a StorageOS persistent volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+        },
+        "volumeName": {
+          "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+          "type": "string"
+        },
+        "volumeNamespace": {
+          "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Sysctl": {
+      "description": "Sysctl defines a kernel parameter to be set",
+      "properties": {
+        "name": {
+          "description": "Name of a property to set",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of a property to set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TCPSocketAction": {
+      "description": "TCPSocketAction describes an action based on opening a socket",
+      "properties": {
+        "host": {
+          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+          "type": "string"
+        },
+        "port": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Toleration": {
+      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+      "properties": {
+        "effect": {
+          "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
+          "type": "string"
+        },
+        "tolerationSeconds": {
+          "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "value": {
+          "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TopologySpreadConstraint": {
+      "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+      "properties": {
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain."
+        },
+        "matchLabelKeys": {
+          "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "maxSkew": {
+          "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "minDomains": {
+          "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "nodeAffinityPolicy": {
+          "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+          "type": "string"
+        },
+        "nodeTaintsPolicy": {
+          "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+          "type": "string"
+        },
+        "topologyKey": {
+          "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+          "type": "string"
+        },
+        "whenUnsatisfiable": {
+          "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "maxSkew",
+        "topologyKey",
+        "whenUnsatisfiable"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TypedLocalObjectReference": {
+      "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.TypedObjectReference": {
+      "description": "TypedObjectReference contains enough information to let you locate the typed referenced object",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Volume": {
+      "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+      "properties": {
+        "awsElasticBlockStore": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+          "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+        },
+        "azureDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
+          "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod. Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type are redirected to the disk.csi.azure.com CSI driver."
+        },
+        "azureFile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource",
+          "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod. Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type are redirected to the file.csi.azure.com CSI driver."
+        },
+        "cephfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource",
+          "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime. Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported."
+        },
+        "cinder": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource",
+          "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. Deprecated: Cinder is deprecated. All operations for the in-tree cinder type are redirected to the cinder.csi.openstack.org CSI driver. More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
+        },
+        "configMap": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource",
+          "description": "configMap represents a configMap that should populate this volume"
+        },
+        "csi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CSIVolumeSource",
+          "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers."
+        },
+        "downwardAPI": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource",
+          "description": "downwardAPI represents downward API about the pod that should populate this volume"
+        },
+        "emptyDir": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
+          "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
+        },
+        "ephemeral": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralVolumeSource",
+          "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.\n\nUse this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.\n\nA pod can use both types of ephemeral volumes and persistent volumes at the same time."
+        },
+        "fc": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
+          "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
+        },
+        "flexVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource",
+          "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead."
+        },
+        "flocker": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
+          "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running. Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported."
+        },
+        "gcePersistentDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+          "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+        },
+        "gitRepo": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource",
+          "description": "gitRepo represents a git repository at a particular revision. Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container."
+        },
+        "glusterfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource",
+          "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported."
+        },
+        "hostPath": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
+          "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+        },
+        "image": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ImageVolumeSource",
+          "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33. The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type."
+        },
+        "iscsi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource",
+          "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi"
+        },
+        "name": {
+          "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": "string"
+        },
+        "nfs": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
+          "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+        },
+        "persistentVolumeClaim": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource",
+          "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+        },
+        "photonPersistentDisk": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+          "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine. Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported."
+        },
+        "portworxVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
+          "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine. Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate is on."
+        },
+        "projected": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource",
+          "description": "projected items for all in one resources secrets, configmaps, and downward API"
+        },
+        "quobyte": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
+          "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime. Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported."
+        },
+        "rbd": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource",
+          "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported."
+        },
+        "scaleIO": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource",
+          "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes. Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported."
+        },
+        "secret": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource",
+          "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
+        },
+        "storageos": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource",
+          "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported."
+        },
+        "vsphereVolume": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+          "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine. Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type are redirected to the csi.vsphere.vmware.com CSI driver."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeDevice": {
+      "description": "volumeDevice describes a mapping of a raw block device within a container.",
+      "properties": {
+        "devicePath": {
+          "description": "devicePath is the path inside of the container that the device will be mapped to.",
+          "type": "string"
+        },
+        "name": {
+          "description": "name must match the name of a persistentVolumeClaim in the pod",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "devicePath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeMount": {
+      "description": "VolumeMount describes a mounting of a Volume within a container.",
+      "properties": {
+        "mountPath": {
+          "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+          "type": "string"
+        },
+        "mountPropagation": {
+          "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).",
+          "type": "string"
+        },
+        "name": {
+          "description": "This must match the Name of a Volume.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+          "type": "boolean"
+        },
+        "recursiveReadOnly": {
+          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled recursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+          "type": "string"
+        },
+        "subPath": {
+          "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+          "type": "string"
+        },
+        "subPathExpr": {
+          "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "mountPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeMountStatus": {
+      "description": "VolumeMountStatus shows status of volume mounts.",
+      "properties": {
+        "mountPath": {
+          "description": "MountPath corresponds to the original VolumeMount.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name corresponds to the name of the original VolumeMount.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly corresponds to the original VolumeMount.",
+          "type": "boolean"
+        },
+        "recursiveReadOnly": {
+          "description": "RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts). An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled, depending on the mount result.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "mountPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeProjection": {
+      "description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
+      "properties": {
+        "clusterTrustBundle": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ClusterTrustBundleProjection",
+          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time."
+        },
+        "configMap": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection",
+          "description": "configMap information about the configMap data to project"
+        },
+        "downwardAPI": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection",
+          "description": "downwardAPI information about the downwardAPI data to project"
+        },
+        "podCertificate": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodCertificateProjection",
+          "description": "Projects an auto-rotating credential bundle (private key and certificate chain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a PodCertificateRequest to the named signer.  Once the signer approves the request and issues a certificate chain, Kubelet writes the key and certificate chain to the pod filesystem.  The pod does not start until certificates have been issued for each podCertificate projected volume source in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated by the signer using the PodCertificateRequest.Status.BeginRefreshAt timestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath field, or separate files, indicated by the keyPath and certificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM entry is the private key (in PKCS#8 format), and the remaining PEM entries are the certificate chain issued by the signer (typically, signers will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code can read it atomically.  If you use keyPath and certificateChainPath, your application must make two separate file reads. If these coincide with a certificate rotation, it is possible that the private key and leaf certificate you read may not correspond to each other.  Your application will need to check for this condition, and re-read until they are consistent.\n\nThe named signer controls chooses the format of the certificate it issues; consult the signer implementation's documentation to learn how to use the certificates it issues."
+        },
+        "secret": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection",
+          "description": "secret information about the secret data to project"
+        },
+        "serviceAccountToken": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccountTokenProjection",
+          "description": "serviceAccountToken is information about the serviceAccountToken data to project"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeResourceRequirements": {
+      "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+      "properties": {
+        "limits": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
+        },
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
+      "description": "Represents a vSphere volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "storagePolicyID": {
+          "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+          "type": "string"
+        },
+        "storagePolicyName": {
+          "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+          "type": "string"
+        },
+        "volumePath": {
+          "description": "volumePath is the path that identifies vSphere volume vmdk",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumePath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+      "properties": {
+        "podAffinityTerm": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm",
+          "description": "Required. A pod affinity term, associated with the corresponding weight."
+        },
+        "weight": {
+          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "weight",
+        "podAffinityTerm"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
+      "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+      "properties": {
+        "gmsaCredentialSpec": {
+          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+          "type": "string"
+        },
+        "gmsaCredentialSpecName": {
+          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+          "type": "string"
+        },
+        "hostProcess": {
+          "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+          "type": "boolean"
+        },
+        "runAsUserName": {
+          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WorkloadReference": {
+      "description": "WorkloadReference identifies the Workload object and PodGroup membership that a Pod belongs to. The scheduler uses this information to apply workload-aware scheduling semantics.",
+      "properties": {
+        "name": {
+          "description": "Name defines the name of the Workload object this Pod belongs to. Workload must be in the same namespace as the Pod. If it doesn't match any existing Workload, the Pod will remain unschedulable until a Workload object is created and observed by the kube-scheduler. It must be a DNS subdomain.",
+          "type": "string"
+        },
+        "podGroup": {
+          "description": "PodGroup is the name of the PodGroup within the Workload that this Pod belongs to. If it doesn't match any existing PodGroup within the Workload, the Pod will remain unschedulable until the Workload object is recreated and observed by the kube-scheduler. It must be a DNS label.",
+          "type": "string"
+        },
+        "podGroupReplicaKey": {
+          "description": "PodGroupReplicaKey specifies the replica key of the PodGroup to which this Pod belongs. It is used to distinguish pods belonging to different replicas of the same pod group. The pod group policy is applied separately to each replica. When set, it must be a DNS label.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "podGroup"
+      ],
+      "type": "object"
+    },
     "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition": {
       "description": "CustomResourceColumnDefinition specifies a column for server side printing.",
       "properties": {
@@ -46,12 +4330,12 @@
       "description": "CustomResourceConversion describes how to convert different versions of a CR.",
       "properties": {
         "strategy": {
-          "description": "strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information\n  is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.",
+          "description": "strategy specifies how custom resources are converted between versions. Allowed values are: - `\"None\"`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `\"Webhook\"`: API Server will call to an external webhook to do the conversion. Additional information\n  is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.",
           "type": "string"
         },
         "webhook": {
           "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion",
-          "description": "webhook describes how to call the conversion webhook. Required when `strategy` is set to `Webhook`."
+          "description": "webhook describes how to call the conversion webhook. Required when `strategy` is set to `\"Webhook\"`."
         }
       },
       "required": [
@@ -71,7 +4355,8 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
           "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec",
@@ -105,6 +4390,11 @@
           "description": "message is a human-readable message indicating details about last transition.",
           "type": "string"
         },
+        "observedGeneration": {
+          "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+          "format": "int64",
+          "type": "integer"
+        },
         "reason": {
           "description": "reason is a unique, one-word, CamelCase reason for the condition's last transition.",
           "type": "string"
@@ -124,40 +4414,6 @@
       ],
       "type": "object"
     },
-    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList": {
-      "description": "CustomResourceDefinitionList is a list of CustomResourceDefinition objects.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "items list individual CustomResourceDefinition objects",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
-          },
-          "type": "array"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "required": [
-        "items"
-      ],
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apiextensions.k8s.io",
-          "kind": "CustomResourceDefinitionList",
-          "version": "v1"
-        }
-      ]
-    },
     "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames": {
       "description": "CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition",
       "properties": {
@@ -166,7 +4422,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "kind": {
           "description": "kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.",
@@ -185,7 +4442,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "singular": {
           "description": "singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.",
@@ -214,7 +4472,7 @@
           "description": "names specify the resource and kind names for the custom resource."
         },
         "preserveUnknownFields": {
-          "description": "preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.",
+          "description": "preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.",
           "type": "boolean"
         },
         "scope": {
@@ -226,7 +4484,8 @@
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
       },
       "required": [
@@ -249,14 +4508,24 @@
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the CRD controller.",
+          "format": "int64",
+          "type": "integer"
         },
         "storedVersions": {
           "description": "storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.",
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
       },
       "type": "object"
@@ -269,15 +4538,32 @@
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "deprecated": {
+          "description": "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.",
+          "type": "boolean"
+        },
+        "deprecationWarning": {
+          "description": "deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.",
+          "type": "string"
         },
         "name": {
-          "description": "name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.",
+          "description": "name is the version name, e.g. \u201cv1\u201d, \u201cv2beta1\u201d, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.",
           "type": "string"
         },
         "schema": {
           "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
           "description": "schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource."
+        },
+        "selectableFields": {
+          "description": "selectableFields specifies paths to fields that may be used as field selectors. A maximum of 8 selectable fields are allowed. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "served": {
           "description": "served is a flag enabling/disabling this version from being served via REST APIs",
@@ -383,13 +4669,15 @@
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "anyOf": {
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "default": {
           "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON",
@@ -414,7 +4702,8 @@
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "example": {
           "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
@@ -429,7 +4718,7 @@
           "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation"
         },
         "format": {
-          "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:\n\n- bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+          "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:\n\n- bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
           "type": "string"
         },
         "id": {
@@ -484,7 +4773,8 @@
           "items": {
             "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "pattern": {
           "type": "string"
@@ -505,7 +4795,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "title": {
           "type": "string"
@@ -529,7 +4820,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "x-kubernetes-list-type": {
           "description": "x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:\n\n1) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic lists will be entirely replaced when updated. This extension\n     may be used on any type of list (struct, scalar, ...).\n2) `set`:\n     Sets are lists that must not have multiple items with the same value. Each\n     value must be a scalar, an object with x-kubernetes-map-type `atomic` or an\n     array with x-kubernetes-list-type `atomic`.\n3) `map`:\n     These lists are like maps in that their elements have a non-index key\n     used to identify them. Order is preserved upon merge. The map tag\n     must only be used on a list with elements of type object.\nDefaults to atomic for arrays.",
@@ -542,6 +4834,19 @@
         "x-kubernetes-preserve-unknown-fields": {
           "description": "x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
           "type": "boolean"
+        },
+        "x-kubernetes-validations": {
+          "description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "rule"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "rule",
+          "x-kubernetes-patch-strategy": "merge"
         }
       },
       "type": "object"
@@ -554,6 +4859,19 @@
     },
     "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray": {
       "description": "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField": {
+      "description": "SelectableField specifies the JSON path of a field that may be used with field selectors.",
+      "properties": {
+        "jsonPath": {
+          "description": "jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metdata fields. Required.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "jsonPath"
+      ],
+      "type": "object"
     },
     "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference": {
       "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
@@ -579,6 +4897,39 @@
       "required": [
         "namespace",
         "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule": {
+      "description": "ValidationRule describes a validation rule written in the CEL expression language.",
+      "properties": {
+        "fieldPath": {
+          "description": "fieldPath represents the field path returned when the validation fails. It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field. e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo` If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList` It does not support list numeric index. It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info. Numeric index of array is not supported. For field name which contains special characters, use `['specialName']` to refer the field name. e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\"",
+          "type": "string"
+        },
+        "messageExpression": {
+          "description": "MessageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a rule, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the rule; the only difference is the return type. Example: \"x must be less than max (\"+string(self.max)+\")\"",
+          "type": "string"
+        },
+        "optionalOldSelf": {
+          "description": "optionalOldSelf is used to opt a transition rule into evaluation even when the object is first created, or if the old object is missing the value.\n\nWhen enabled `oldSelf` will be a CEL optional whose value will be `None` if there is no old value, or when the object is initially created.\n\nYou may check for presence of oldSelf using `oldSelf.hasValue()` and unwrap it after checking using `oldSelf.value()`. Check the CEL documentation for Optional types for more information: https://pkg.go.dev/github.com/google/cel-go/cel#OptionalTypes\n\nMay not be set unless `oldSelf` is used in `rule`.",
+          "type": "boolean"
+        },
+        "reason": {
+          "description": "reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule. The HTTP status code returned to the caller will match the reason of the reason of the first failed validation rule. The currently supported reasons are: \"FieldValueInvalid\", \"FieldValueForbidden\", \"FieldValueRequired\", \"FieldValueDuplicate\". If not set, default to use \"FieldValueInvalid\". All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.",
+          "type": "string"
+        },
+        "rule": {
+          "description": "Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {\"rule\": \"self.status.actual <= self.spec.maxDesired\"}\n\nIf the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {\"rule\": \"self.components['Widget'].priority < 10\"} - Rule scoped to a list of integers: {\"rule\": \"self.values.all(value, value >= 0 && value < 100)\"} - Rule scoped to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.\n\nUnknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an \"unknown type\". An \"unknown type\" is recursively defined as:\n  - A schema with no type and x-kubernetes-preserve-unknown-fields set to true\n  - An array where the items schema is of an \"unknown type\"\n  - An object where the additionalProperties schema is of an \"unknown type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Rule accessing a property named \"namespace\": {\"rule\": \"self.__namespace__ > 0\"}\n  - Rule accessing a property named \"x-prop\": {\"rule\": \"self.x__dash__prop > 0\"}\n  - Rule accessing a property named \"redact__d\": {\"rule\": \"self.redact__underscores__d > 0\"}\n\nEquality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\n\nIf `rule` makes use of the `oldSelf` variable it is implicitly a `transition rule`.\n\nBy default, the `oldSelf` variable is the same type as `self`. When `optionalOldSelf` is true, the `oldSelf` variable is a CEL optional\n variable whose value() is the same type as `self`.\nSee the documentation for the `optionalOldSelf` field for details.\n\nTransition rules by default are applied only on UPDATE requests and are skipped if an old value could not be found. You can opt a transition rule into unconditional evaluation by setting `optionalOldSelf` to true.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule"
       ],
       "type": "object"
     },
@@ -613,7 +4964,8 @@
           "items": {
             "type": "string"
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
       },
       "required": [
@@ -621,5997 +4973,246 @@
       ],
       "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.ControllerRevision": {
-      "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
-      "required": [
-        "revision"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "data": {
-          "description": "Data is the serialized representation of the state.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "revision": {
-          "description": "Revision indicates the revision of the state represented by Data.",
-          "type": "integer",
-          "format": "int64"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "ControllerRevision",
-          "version": "v1beta1"
-        }
-      ]
+    "io.k8s.apimachinery.pkg.api.resource.Quantity": {
+      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+      "type": "string"
     },
-    "io.k8s.api.apps.v1beta1.ControllerRevisionList": {
-      "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of ControllerRevisions",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ControllerRevision"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "ControllerRevisionList",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.Deployment": {
-      "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object metadata.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Specification of the desired behavior of the Deployment.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentSpec"
-        },
-        "status": {
-          "description": "Most recently observed status of the Deployment.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "Deployment",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentCondition": {
-      "description": "DeploymentCondition describes the state of a deployment at a certain point.",
-      "required": [
-        "type",
-        "status"
-      ],
-      "properties": {
-        "lastTransitionTime": {
-          "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "lastUpdateTime": {
-          "description": "The last time this condition was updated.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "A human readable message indicating details about the transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "The reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition, one of True, False, Unknown.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of deployment condition.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentList": {
-      "description": "DeploymentList is a list of Deployments.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of Deployments.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.Deployment"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "DeploymentList",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentRollback": {
-      "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
-      "required": [
-        "name",
-        "rollbackTo"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "Required: This must match the Name of a deployment.",
-          "type": "string"
-        },
-        "rollbackTo": {
-          "description": "The config of this deployment rollback.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollbackConfig"
-        },
-        "updatedAnnotations": {
-          "description": "The annotations to be updated to a deployment",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "DeploymentRollback",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentSpec": {
-      "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
-      "required": [
-        "template"
-      ],
-      "properties": {
-        "minReadySeconds": {
-          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-          "type": "integer",
-          "format": "int32"
-        },
-        "paused": {
-          "description": "Indicates that the deployment is paused.",
-          "type": "boolean"
-        },
-        "progressDeadlineSeconds": {
-          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "revisionHistoryLimit": {
-          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 2.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "rollbackTo": {
-          "description": "DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollbackConfig"
-        },
-        "selector": {
-          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-        },
-        "strategy": {
-          "description": "The deployment strategy to use to replace existing pods with new ones.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStrategy"
-        },
-        "template": {
-          "description": "Template describes the pods that will be created.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentStatus": {
-      "description": "DeploymentStatus is the most recently observed status of the Deployment.",
-      "properties": {
-        "availableReplicas": {
-          "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "collisionCount": {
-          "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "conditions": {
-          "description": "Represents the latest available observations of a deployment's current state.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "observedGeneration": {
-          "description": "The generation observed by the deployment controller.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "readyReplicas": {
-          "description": "Total number of ready pods targeted by this deployment.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
-          "type": "integer",
-          "format": "int32"
-        },
-        "unavailableReplicas": {
-          "description": "Total number of unavailable pods targeted by this deployment.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "updatedReplicas": {
-          "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentStrategy": {
-      "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
-      "properties": {
-        "rollingUpdate": {
-          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateDeployment"
-        },
-        "type": {
-          "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.RollbackConfig": {
-      "description": "DEPRECATED.",
-      "properties": {
-        "revision": {
-          "description": "The revision to rollback to. If set to 0, rollback to the last revision.",
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.RollingUpdateDeployment": {
-      "description": "Spec to control the desired behavior of rolling update.",
-      "properties": {
-        "maxSurge": {
-          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        },
-        "maxUnavailable": {
-          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy": {
-      "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
-      "properties": {
-        "partition": {
-          "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.Scale": {
-      "description": "Scale represents a scaling request for a resource.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ScaleSpec"
-        },
-        "status": {
-          "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ScaleStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "Scale",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.ScaleSpec": {
-      "description": "ScaleSpec describes the attributes of a scale subresource",
-      "properties": {
-        "replicas": {
-          "description": "desired number of instances for the scaled object.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.ScaleStatus": {
-      "description": "ScaleStatus represents the current status of a scale subresource.",
-      "required": [
-        "replicas"
-      ],
-      "properties": {
-        "replicas": {
-          "description": "actual number of observed instances of the scaled object.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "selector": {
-          "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "targetSelector": {
-          "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSet": {
-      "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the desired identities of pods in this set.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetSpec"
-        },
-        "status": {
-          "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "StatefulSet",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetList": {
-      "description": "StatefulSetList is a collection of StatefulSets.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSet"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "StatefulSetList",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetSpec": {
-      "description": "A StatefulSetSpec is the specification of a StatefulSet.",
-      "required": [
-        "template",
-        "serviceName"
-      ],
-      "properties": {
-        "podManagementPolicy": {
-          "description": "podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.",
-          "type": "string"
-        },
-        "replicas": {
-          "description": "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "revisionHistoryLimit": {
-          "description": "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "selector": {
-          "description": "selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-        },
-        "serviceName": {
-          "description": "serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
-          "type": "string"
-        },
-        "template": {
-          "description": "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        },
-        "updateStrategy": {
-          "description": "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy"
-        },
-        "volumeClaimTemplates": {
-          "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
-          }
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetStatus": {
-      "description": "StatefulSetStatus represents the current state of a StatefulSet.",
-      "required": [
-        "replicas"
-      ],
-      "properties": {
-        "collisionCount": {
-          "description": "collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "currentReplicas": {
-          "description": "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "currentRevision": {
-          "description": "currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
-          "type": "string"
-        },
-        "observedGeneration": {
-          "description": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "readyReplicas": {
-          "description": "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "replicas is the number of Pods created by the StatefulSet controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "updateRevision": {
-          "description": "updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
-          "type": "string"
-        },
-        "updatedReplicas": {
-          "description": "updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy": {
-      "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
-      "properties": {
-        "rollingUpdate": {
-          "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy"
-        },
-        "type": {
-          "description": "Type indicates the type of the StatefulSetUpdateStrategy.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
-      "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "LocalSubjectAccessReview",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1.NonResourceAttributes": {
-      "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
-      "properties": {
-        "path": {
-          "description": "Path is the URL path of the request",
-          "type": "string"
-        },
-        "verb": {
-          "description": "Verb is the standard HTTP verb",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1.ResourceAttributes": {
-      "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
-      "properties": {
-        "group": {
-          "description": "Group is the API Group of the Resource.  \"*\" means all.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
-          "type": "string"
-        },
-        "resource": {
-          "description": "Resource is one of the existing resource types.  \"*\" means all.",
-          "type": "string"
-        },
-        "subresource": {
-          "description": "Subresource is one of the existing resource types.  \"\" means none.",
-          "type": "string"
-        },
-        "verb": {
-          "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
-          "type": "string"
-        },
-        "version": {
-          "description": "Version is the API Version of the Resource.  \"*\" means all.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
-      "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SelfSubjectAccessReview",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec": {
-      "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "properties": {
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1.SubjectAccessReview": {
-      "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SubjectAccessReview",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1.SubjectAccessReviewSpec": {
-      "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "properties": {
-        "extra": {
-          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "groups": {
-          "description": "Groups is the groups you're testing for.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes"
-        },
-        "uid": {
-          "description": "UID information about the requesting user.",
-          "type": "string"
-        },
-        "user": {
-          "description": "User is the user you're testing for. If you specify \"User\" but not \"Groups\", then is it interpreted as \"What if User were not a member of any groups",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1.SubjectAccessReviewStatus": {
-      "description": "SubjectAccessReviewStatus",
-      "required": [
-        "allowed"
-      ],
-      "properties": {
-        "allowed": {
-          "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
-          "type": "boolean"
-        },
-        "evaluationError": {
-          "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Reason is optional.  It indicates why a request was allowed or denied.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.LocalSubjectAccessReview": {
-      "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "LocalSubjectAccessReview",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1beta1.NonResourceAttributes": {
-      "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
-      "properties": {
-        "path": {
-          "description": "Path is the URL path of the request",
-          "type": "string"
-        },
-        "verb": {
-          "description": "Verb is the standard HTTP verb",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.ResourceAttributes": {
-      "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
-      "properties": {
-        "group": {
-          "description": "Group is the API Group of the Resource.  \"*\" means all.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
-          "type": "string"
-        },
-        "resource": {
-          "description": "Resource is one of the existing resource types.  \"*\" means all.",
-          "type": "string"
-        },
-        "subresource": {
-          "description": "Subresource is one of the existing resource types.  \"\" means none.",
-          "type": "string"
-        },
-        "verb": {
-          "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
-          "type": "string"
-        },
-        "version": {
-          "description": "Version is the API Version of the Resource.  \"*\" means all.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReview": {
-      "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SelfSubjectAccessReview",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
-      "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "properties": {
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceAttributes"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.SubjectAccessReview": {
-      "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SubjectAccessReview",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec": {
-      "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "properties": {
-        "extra": {
-          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "group": {
-          "description": "Groups is the groups you're testing for.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceAttributes"
-        },
-        "uid": {
-          "description": "UID information about the requesting user.",
-          "type": "string"
-        },
-        "user": {
-          "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus": {
-      "description": "SubjectAccessReviewStatus",
-      "required": [
-        "allowed"
-      ],
-      "properties": {
-        "allowed": {
-          "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
-          "type": "boolean"
-        },
-        "evaluationError": {
-          "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Reason is optional.  It indicates why a request was allowed or denied.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
-      "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
-      "required": [
-        "volumeID"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "type": "string"
-        },
-        "partition": {
-          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
-          "type": "integer",
-          "format": "int32"
-        },
-        "readOnly": {
-          "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "type": "boolean"
-        },
-        "volumeID": {
-          "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Affinity": {
-      "description": "Affinity is a group of affinity scheduling rules.",
-      "properties": {
-        "nodeAffinity": {
-          "description": "Describes node affinity scheduling rules for the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity"
-        },
-        "podAffinity": {
-          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity"
-        },
-        "podAntiAffinity": {
-          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.AttachedVolume": {
-      "description": "AttachedVolume describes a volume attached to a node",
-      "required": [
-        "name",
-        "devicePath"
-      ],
-      "properties": {
-        "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the attached volume",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.AzureDiskVolumeSource": {
-      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-      "required": [
-        "diskName",
-        "diskURI"
-      ],
-      "properties": {
-        "cachingMode": {
-          "description": "Host Caching mode: None, Read Only, Read Write.",
-          "type": "string"
-        },
-        "diskName": {
-          "description": "The Name of the data disk in the blob storage",
-          "type": "string"
-        },
-        "diskURI": {
-          "description": "The URI the data disk in the blob storage",
-          "type": "string"
-        },
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.AzureFilePersistentVolumeSource": {
-      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-      "required": [
-        "secretName",
-        "shareName"
-      ],
-      "properties": {
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretName": {
-          "description": "the name of secret that contains Azure Storage Account Name and Key",
-          "type": "string"
-        },
-        "secretNamespace": {
-          "description": "the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
-          "type": "string"
-        },
-        "shareName": {
-          "description": "Share Name",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.AzureFileVolumeSource": {
-      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-      "required": [
-        "secretName",
-        "shareName"
-      ],
-      "properties": {
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretName": {
-          "description": "the name of secret that contains Azure Storage Account Name and Key",
-          "type": "string"
-        },
-        "shareName": {
-          "description": "Share Name",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Binding": {
-      "description": "Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.",
-      "required": [
-        "target"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "target": {
-          "description": "The target object that you want to bind to the standard object.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Binding",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.Capabilities": {
-      "description": "Adds and removes POSIX capabilities from running containers.",
-      "properties": {
-        "add": {
-          "description": "Added capabilities",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "drop": {
-          "description": "Removed capabilities",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.CephFSPersistentVolumeSource": {
-      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
-      "required": [
-        "monitors"
-      ],
-      "properties": {
-        "monitors": {
-          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "path": {
-          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "boolean"
-        },
-        "secretFile": {
-          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "secretRef": {
-          "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference"
-        },
-        "user": {
-          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.CephFSVolumeSource": {
-      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
-      "required": [
-        "monitors"
-      ],
-      "properties": {
-        "monitors": {
-          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "path": {
-          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "boolean"
-        },
-        "secretFile": {
-          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "secretRef": {
-          "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "user": {
-          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.CinderVolumeSource": {
-      "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
-      "required": [
-        "volumeID"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "type": "boolean"
-        },
-        "volumeID": {
-          "description": "volume id used to identify the volume in cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ClientIPConfig": {
-      "description": "ClientIPConfig represents the configurations of Client IP based session affinity.",
-      "properties": {
-        "timeoutSeconds": {
-          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be \u003e0 \u0026\u0026 \u003c=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ComponentCondition": {
-      "description": "Information about the condition of a component.",
-      "required": [
-        "type",
-        "status"
-      ],
-      "properties": {
-        "error": {
-          "description": "Condition error code for a component. For example, a health check error code.",
-          "type": "string"
-        },
-        "message": {
-          "description": "Message about the condition for a component. For example, information about a health check.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition for a component. Valid values for \"Healthy\": \"True\", \"False\", or \"Unknown\".",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of condition for a component. Valid value: \"Healthy\"",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ComponentStatus": {
-      "description": "ComponentStatus (and ComponentStatusList) holds the cluster validation info.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "conditions": {
-          "description": "List of component conditions observed",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ComponentStatus",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ComponentStatusList": {
-      "description": "Status of all the conditions for the component as a list of ComponentStatus objects.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of ComponentStatus objects.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentStatus"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ComponentStatusList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ConfigMap": {
-      "description": "ConfigMap holds configuration data for pods to consume.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "data": {
-          "description": "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ConfigMap",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ConfigMapEnvSource": {
-      "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
-      "properties": {
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the ConfigMap must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ConfigMapKeySelector": {
-      "description": "Selects a key from a ConfigMap.",
-      "required": [
-        "key"
-      ],
+    "io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement": {
+      "description": "FieldSelectorRequirement is a selector that contains values, a key, and an operator that relates the key and values.",
       "properties": {
         "key": {
-          "description": "The key to select.",
+          "description": "key is the field selector key that the requirement applies to.",
           "type": "string"
         },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+        "operator": {
+          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. The list of operators may grow in the future.",
           "type": "string"
         },
-        "optional": {
-          "description": "Specify whether the ConfigMap or it's key must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ConfigMapList": {
-      "description": "ConfigMapList is a resource containing a list of ConfigMap objects.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of ConfigMaps.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMap"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ConfigMapList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ConfigMapProjection": {
-      "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
-      "properties": {
-        "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the ConfigMap or it's keys must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ConfigMapVolumeSource": {
-      "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
-      "properties": {
-        "defaultMode": {
-          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the ConfigMap or it's keys must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Container": {
-      "description": "A single application container that you want to run within a pod.",
-      "required": [
-        "name",
-        "image"
-      ],
-      "properties": {
-        "args": {
-          "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
-          "type": "array",
+        "values": {
+          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.",
           "items": {
             "type": "string"
-          }
-        },
-        "command": {
-          "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "env": {
-          "description": "List of environment variables to set in the container. Cannot be updated.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
           },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "envFrom": {
-          "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
-          }
-        },
-        "image": {
-          "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images",
-          "type": "string"
-        },
-        "imagePullPolicy": {
-          "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
-          "type": "string"
-        },
-        "lifecycle": {
-          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle"
-        },
-        "livenessProbe": {
-          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "name": {
-          "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
-          "type": "string"
-        },
-        "ports": {
-          "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
-          },
-          "x-kubernetes-patch-merge-key": "containerPort",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "readinessProbe": {
-          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "resources": {
-          "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
-        "securityContext": {
-          "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://git.k8s.io/community/contributors/design-proposals/security_context.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
-        },
-        "stdin": {
-          "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
-          "type": "boolean"
-        },
-        "stdinOnce": {
-          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
-          "type": "boolean"
-        },
-        "terminationMessagePath": {
-          "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
-          "type": "string"
-        },
-        "terminationMessagePolicy": {
-          "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
-          "type": "string"
-        },
-        "tty": {
-          "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
-          "type": "boolean"
-        },
-        "volumeMounts": {
-          "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
-          },
-          "x-kubernetes-patch-merge-key": "mountPath",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "workingDir": {
-          "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerImage": {
-      "description": "Describe a container image",
-      "required": [
-        "names"
-      ],
-      "properties": {
-        "names": {
-          "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "sizeBytes": {
-          "description": "The size of the image in bytes.",
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerPort": {
-      "description": "ContainerPort represents a network port in a single container.",
-      "required": [
-        "containerPort"
-      ],
-      "properties": {
-        "containerPort": {
-          "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 \u003c x \u003c 65536.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "hostIP": {
-          "description": "What host IP to bind the external port to.",
-          "type": "string"
-        },
-        "hostPort": {
-          "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 \u003c x \u003c 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "name": {
-          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
-          "type": "string"
-        },
-        "protocol": {
-          "description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\".",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerState": {
-      "description": "ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.",
-      "properties": {
-        "running": {
-          "description": "Details about a running container",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateRunning"
-        },
-        "terminated": {
-          "description": "Details about a terminated container",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateTerminated"
-        },
-        "waiting": {
-          "description": "Details about a waiting container",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateWaiting"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerStateRunning": {
-      "description": "ContainerStateRunning is a running state of a container.",
-      "properties": {
-        "startedAt": {
-          "description": "Time at which the container was last (re-)started",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerStateTerminated": {
-      "description": "ContainerStateTerminated is a terminated state of a container.",
-      "required": [
-        "exitCode"
-      ],
-      "properties": {
-        "containerID": {
-          "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'",
-          "type": "string"
-        },
-        "exitCode": {
-          "description": "Exit status from the last termination of the container",
-          "type": "integer",
-          "format": "int32"
-        },
-        "finishedAt": {
-          "description": "Time at which the container last terminated",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "Message regarding the last termination of the container",
-          "type": "string"
-        },
-        "reason": {
-          "description": "(brief) reason from the last termination of the container",
-          "type": "string"
-        },
-        "signal": {
-          "description": "Signal from the last termination of the container",
-          "type": "integer",
-          "format": "int32"
-        },
-        "startedAt": {
-          "description": "Time at which previous execution of the container started",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerStateWaiting": {
-      "description": "ContainerStateWaiting is a waiting state of a container.",
-      "properties": {
-        "message": {
-          "description": "Message regarding why the container is not yet running.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "(brief) reason the container is not yet running.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerStatus": {
-      "description": "ContainerStatus contains details for the current status of this container.",
-      "required": [
-        "name",
-        "ready",
-        "restartCount",
-        "image",
-        "imageID"
-      ],
-      "properties": {
-        "containerID": {
-          "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'.",
-          "type": "string"
-        },
-        "image": {
-          "description": "The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images",
-          "type": "string"
-        },
-        "imageID": {
-          "description": "ImageID of the container's image.",
-          "type": "string"
-        },
-        "lastState": {
-          "description": "Details about the container's last termination condition.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState"
-        },
-        "name": {
-          "description": "This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.",
-          "type": "string"
-        },
-        "ready": {
-          "description": "Specifies whether the container has passed its readiness probe.",
-          "type": "boolean"
-        },
-        "restartCount": {
-          "description": "The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "state": {
-          "description": "Details about the container's current condition.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.DaemonEndpoint": {
-      "description": "DaemonEndpoint contains information about a single Daemon endpoint.",
-      "required": [
-        "Port"
-      ],
-      "properties": {
-        "Port": {
-          "description": "Port number of the given endpoint.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.DownwardAPIProjection": {
-      "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
-      "properties": {
-        "items": {
-          "description": "Items is a list of DownwardAPIVolume file",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
-      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
-      "required": [
-        "path"
-      ],
-      "properties": {
-        "fieldRef": {
-          "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
-        },
-        "mode": {
-          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "path": {
-          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
-          "type": "string"
-        },
-        "resourceFieldRef": {
-          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
-      "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
-      "properties": {
-        "defaultMode": {
-          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "items": {
-          "description": "Items is a list of downward API volume file",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EmptyDirVolumeSource": {
-      "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
-      "properties": {
-        "medium": {
-          "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-          "type": "string"
-        },
-        "sizeLimit": {
-          "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EndpointAddress": {
-      "description": "EndpointAddress is a tuple that describes single IP address.",
-      "required": [
-        "ip"
-      ],
-      "properties": {
-        "hostname": {
-          "description": "The Hostname of this endpoint",
-          "type": "string"
-        },
-        "ip": {
-          "description": "The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.",
-          "type": "string"
-        },
-        "nodeName": {
-          "description": "Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.",
-          "type": "string"
-        },
-        "targetRef": {
-          "description": "Reference to object providing the endpoint.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EndpointPort": {
-      "description": "EndpointPort is a tuple that describes a single port.",
-      "required": [
-        "port"
-      ],
-      "properties": {
-        "name": {
-          "description": "The name of this port (corresponds to ServicePort.Name). Must be a DNS_LABEL. Optional only if one port is defined.",
-          "type": "string"
-        },
-        "port": {
-          "description": "The port number of the endpoint.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "protocol": {
-          "description": "The IP protocol for this port. Must be UDP or TCP. Default is TCP.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EndpointSubset": {
-      "description": "EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:\n  {\n    Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n    Ports:     [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n  }\nThe resulting set of endpoints can be viewed as:\n    a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],\n    b: [ 10.10.1.1:309, 10.10.2.2:309 ]",
-      "properties": {
-        "addresses": {
-          "description": "IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
-          }
-        },
-        "notReadyAddresses": {
-          "description": "IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
-          }
-        },
-        "ports": {
-          "description": "Port numbers available on the related IP addresses.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointPort"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Endpoints": {
-      "description": "Endpoints is a collection of endpoints that implement the actual service. Example:\n  Name: \"mysvc\",\n  Subsets: [\n    {\n      Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n      Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n    },\n    {\n      Addresses: [{\"ip\": \"10.10.3.3\"}],\n      Ports: [{\"name\": \"a\", \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n    },\n ]",
-      "required": [
-        "subsets"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "subsets": {
-          "description": "The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointSubset"
-          }
+          "x-kubernetes-list-type": "atomic"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Endpoints",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.EndpointsList": {
-      "description": "EndpointsList is a list of endpoints.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of endpoints.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Endpoints"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "EndpointsList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.EnvFromSource": {
-      "description": "EnvFromSource represents the source of a set of ConfigMaps",
-      "properties": {
-        "configMapRef": {
-          "description": "The ConfigMap to select from",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
-        },
-        "prefix": {
-          "description": "An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
-          "type": "string"
-        },
-        "secretRef": {
-          "description": "The Secret to select from",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EnvVar": {
-      "description": "EnvVar represents an environment variable present in a Container.",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
-          "type": "string"
-        },
-        "value": {
-          "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
-          "type": "string"
-        },
-        "valueFrom": {
-          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EnvVarSource": {
-      "description": "EnvVarSource represents a source for the value of an EnvVar.",
-      "properties": {
-        "configMapKeyRef": {
-          "description": "Selects a key of a ConfigMap.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector"
-        },
-        "fieldRef": {
-          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
-        },
-        "resourceFieldRef": {
-          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
-        },
-        "secretKeyRef": {
-          "description": "Selects a key of a secret in the pod's namespace",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Event": {
-      "description": "Event is a report of an event somewhere in the cluster.",
-      "required": [
-        "metadata",
-        "involvedObject"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "count": {
-          "description": "The number of times this event has occurred.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "firstTimestamp": {
-          "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "involvedObject": {
-          "description": "The object that this event is about.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "lastTimestamp": {
-          "description": "The time at which the most recent occurrence of this event was recorded.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "A human-readable description of the status of this operation.",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "reason": {
-          "description": "This should be a short, machine understandable string that gives the reason for the transition into the object's current status.",
-          "type": "string"
-        },
-        "source": {
-          "description": "The component reporting this event. Should be a short machine understandable string.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.EventSource"
-        },
-        "type": {
-          "description": "Type of this event (Normal, Warning), new types could be added in the future",
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Event",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.EventList": {
-      "description": "EventList is a list of events.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of events",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Event"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "EventList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.EventSource": {
-      "description": "EventSource contains information for an event.",
-      "properties": {
-        "component": {
-          "description": "Component from which the event is generated.",
-          "type": "string"
-        },
-        "host": {
-          "description": "Node name on which the event is generated.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ExecAction": {
-      "description": "ExecAction describes a \"run in container\" action.",
-      "properties": {
-        "command": {
-          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.FCVolumeSource": {
-      "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "lun": {
-          "description": "Optional: FC target lun number",
-          "type": "integer",
-          "format": "int32"
-        },
-        "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "targetWWNs": {
-          "description": "Optional: FC target worldwide names (WWNs)",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "wwids": {
-          "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.FlexVolumeSource": {
-      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
-      "required": [
-        "driver"
-      ],
-      "properties": {
-        "driver": {
-          "description": "Driver is the name of the driver to use for this volume.",
-          "type": "string"
-        },
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
-          "type": "string"
-        },
-        "options": {
-          "description": "Optional: Extra command options if any.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.FlockerVolumeSource": {
-      "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
-      "properties": {
-        "datasetName": {
-          "description": "Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated",
-          "type": "string"
-        },
-        "datasetUUID": {
-          "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
-      "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
-      "required": [
-        "pdName"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "type": "string"
-        },
-        "partition": {
-          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "type": "integer",
-          "format": "int32"
-        },
-        "pdName": {
-          "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.GitRepoVolumeSource": {
-      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.",
-      "required": [
-        "repository"
-      ],
-      "properties": {
-        "directory": {
-          "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
-          "type": "string"
-        },
-        "repository": {
-          "description": "Repository URL",
-          "type": "string"
-        },
-        "revision": {
-          "description": "Commit hash for the specified revision.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.GlusterfsVolumeSource": {
-      "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
-      "required": [
-        "endpoints",
-        "path"
-      ],
-      "properties": {
-        "endpoints": {
-          "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
-          "type": "string"
-        },
-        "path": {
-          "description": "Path is the Glusterfs volume path. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.HTTPGetAction": {
-      "description": "HTTPGetAction describes an action based on HTTP Get requests.",
-      "required": [
-        "port"
-      ],
-      "properties": {
-        "host": {
-          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
-          "type": "string"
-        },
-        "httpHeaders": {
-          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
-          }
-        },
-        "path": {
-          "description": "Path to access on the HTTP server.",
-          "type": "string"
-        },
-        "port": {
-          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        },
-        "scheme": {
-          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.HTTPHeader": {
-      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
-      "required": [
-        "name",
-        "value"
-      ],
-      "properties": {
-        "name": {
-          "description": "The header field name",
-          "type": "string"
-        },
-        "value": {
-          "description": "The header field value",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Handler": {
-      "description": "Handler defines a specific action that should be taken",
-      "properties": {
-        "exec": {
-          "description": "One and only one of the following should be specified. Exec specifies the action to take.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
-        },
-        "httpGet": {
-          "description": "HTTPGet specifies the http request to perform.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
-        },
-        "tcpSocket": {
-          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
-          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.HostAlias": {
-      "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
-      "properties": {
-        "hostnames": {
-          "description": "Hostnames for the above IP address.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "ip": {
-          "description": "IP address of the host file entry.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.HostPathVolumeSource": {
-      "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
-      "required": [
-        "path"
-      ],
-      "properties": {
-        "path": {
-          "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ISCSIVolumeSource": {
-      "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
-      "required": [
-        "targetPortal",
-        "iqn",
-        "lun"
-      ],
-      "properties": {
-        "chapAuthDiscovery": {
-          "description": "whether support iSCSI Discovery CHAP authentication",
-          "type": "boolean"
-        },
-        "chapAuthSession": {
-          "description": "whether support iSCSI Session CHAP authentication",
-          "type": "boolean"
-        },
-        "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
-          "type": "string"
-        },
-        "initiatorName": {
-          "description": "Custom iSCSI initiator name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \u003ctarget portal\u003e:\u003cvolume name\u003e will be created for the connection.",
-          "type": "string"
-        },
-        "iqn": {
-          "description": "Target iSCSI Qualified Name.",
-          "type": "string"
-        },
-        "iscsiInterface": {
-          "description": "Optional: Defaults to 'default' (tcp). iSCSI interface name that uses an iSCSI transport.",
-          "type": "string"
-        },
-        "lun": {
-          "description": "iSCSI target lun number.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "portals": {
-          "description": "iSCSI target portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "CHAP secret for iSCSI target and initiator authentication",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "targetPortal": {
-          "description": "iSCSI target portal. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.KeyToPath": {
-      "description": "Maps a string key to a path within a volume.",
-      "required": [
-        "key",
-        "path"
-      ],
-      "properties": {
-        "key": {
-          "description": "The key to project.",
-          "type": "string"
-        },
-        "mode": {
-          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "path": {
-          "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Lifecycle": {
-      "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
-      "properties": {
-        "postStart": {
-          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Handler"
-        },
-        "preStop": {
-          "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Handler"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LimitRange": {
-      "description": "LimitRange sets resource usage limits for each kind of resource in a Namespace.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeSpec"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "LimitRange",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.LimitRangeItem": {
-      "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
-      "properties": {
-        "default": {
-          "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "defaultRequest": {
-          "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "max": {
-          "description": "Max usage constraints on this kind by resource name.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "maxLimitRequestRatio": {
-          "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "min": {
-          "description": "Min usage constraints on this kind by resource name.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "type": {
-          "description": "Type of resource that this limit applies to.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LimitRangeList": {
-      "description": "LimitRangeList is a list of LimitRange items.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is a list of LimitRange objects. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_limit_range.md",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRange"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "LimitRangeList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.LimitRangeSpec": {
-      "description": "LimitRangeSpec defines a min/max usage limit for resources that match on kind.",
-      "required": [
-        "limits"
-      ],
-      "properties": {
-        "limits": {
-          "description": "Limits is the list of LimitRangeItem objects that are enforced.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeItem"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LoadBalancerIngress": {
-      "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
-      "properties": {
-        "hostname": {
-          "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)",
-          "type": "string"
-        },
-        "ip": {
-          "description": "IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LoadBalancerStatus": {
-      "description": "LoadBalancerStatus represents the status of a load-balancer.",
-      "properties": {
-        "ingress": {
-          "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerIngress"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LocalObjectReference": {
-      "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
-      "properties": {
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LocalVolumeSource": {
-      "description": "Local represents directly-attached storage with node affinity",
-      "required": [
-        "path"
-      ],
-      "properties": {
-        "path": {
-          "description": "The full path to the volume on the node For alpha, this path must be a directory Once block as a source is supported, then this path can point to a block device",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NFSVolumeSource": {
-      "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
-      "required": [
-        "server",
-        "path"
-      ],
-      "properties": {
-        "path": {
-          "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "type": "boolean"
-        },
-        "server": {
-          "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Namespace": {
-      "description": "Namespace provides a scope for Names. Use of multiple namespaces is optional.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceSpec"
-        },
-        "status": {
-          "description": "Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Namespace",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NamespaceList": {
-      "description": "NamespaceList is a list of Namespaces.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Namespace"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "NamespaceList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NamespaceSpec": {
-      "description": "NamespaceSpec describes the attributes on a Namespace.",
-      "properties": {
-        "finalizers": {
-          "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://git.k8s.io/community/contributors/design-proposals/namespaces.md#finalizers",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NamespaceStatus": {
-      "description": "NamespaceStatus is information about the current status of a Namespace.",
-      "properties": {
-        "phase": {
-          "description": "Phase is the current lifecycle phase of the namespace. More info: https://git.k8s.io/community/contributors/design-proposals/namespaces.md#phases",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Node": {
-      "description": "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSpec"
-        },
-        "status": {
-          "description": "Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Node",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NodeAddress": {
-      "description": "NodeAddress contains information for the node's address.",
-      "required": [
-        "type",
-        "address"
-      ],
-      "properties": {
-        "address": {
-          "description": "The node address.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeAffinity": {
-      "description": "Node affinity is a group of node affinity scheduling rules.",
-      "properties": {
-        "preferredDuringSchedulingIgnoredDuringExecution": {
-          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
-          }
-        },
-        "requiredDuringSchedulingIgnoredDuringExecution": {
-          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeCondition": {
-      "description": "NodeCondition contains condition information for a node.",
-      "required": [
-        "type",
-        "status"
-      ],
-      "properties": {
-        "lastHeartbeatTime": {
-          "description": "Last time we got an update on a given condition.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "lastTransitionTime": {
-          "description": "Last time the condition transit from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "Human readable message indicating details about last transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "(brief) reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition, one of True, False, Unknown.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of node condition.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeConfigSource": {
-      "description": "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "configMapRef": {
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "NodeConfigSource",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NodeDaemonEndpoints": {
-      "description": "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
-      "properties": {
-        "kubeletEndpoint": {
-          "description": "Endpoint on which Kubelet is listening.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.DaemonEndpoint"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeList": {
-      "description": "NodeList is the whole list of all Nodes which have been registered with master.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of nodes",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Node"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "NodeList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NodeSelector": {
-      "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
-      "required": [
-        "nodeSelectorTerms"
-      ],
-      "properties": {
-        "nodeSelectorTerms": {
-          "description": "Required. A list of node selector terms. The terms are ORed.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeSelectorRequirement": {
-      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       "required": [
         "key",
         "operator"
       ],
-      "properties": {
-        "key": {
-          "description": "The label key that the selector applies to.",
-          "type": "string"
-        },
-        "operator": {
-          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-          "type": "string"
-        },
-        "values": {
-          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeSelectorTerm": {
-      "description": "A null or empty node selector term matches no objects.",
-      "required": [
-        "matchExpressions"
-      ],
-      "properties": {
-        "matchExpressions": {
-          "description": "Required. A list of node selector requirements. The requirements are ANDed.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeSpec": {
-      "description": "NodeSpec describes the attributes that a node is created with.",
-      "properties": {
-        "configSource": {
-          "description": "If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource"
-        },
-        "externalID": {
-          "description": "External ID of the node assigned by some machine database (e.g. a cloud provider). Deprecated.",
-          "type": "string"
-        },
-        "podCIDR": {
-          "description": "PodCIDR represents the pod IP range assigned to the node.",
-          "type": "string"
-        },
-        "providerID": {
-          "description": "ID of the node assigned by the cloud provider in the format: \u003cProviderName\u003e://\u003cProviderSpecificNodeID\u003e",
-          "type": "string"
-        },
-        "taints": {
-          "description": "If specified, the node's taints.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Taint"
-          }
-        },
-        "unschedulable": {
-          "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeStatus": {
-      "description": "NodeStatus is information about the current status of a node.",
-      "properties": {
-        "addresses": {
-          "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.NodeAddress"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "allocatable": {
-          "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "capacity": {
-          "description": "Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "conditions": {
-          "description": "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.NodeCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "daemonEndpoints": {
-          "description": "Endpoints of daemons running on the Node.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeDaemonEndpoints"
-        },
-        "images": {
-          "description": "List of container images on this node",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerImage"
-          }
-        },
-        "nodeInfo": {
-          "description": "Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSystemInfo"
-        },
-        "phase": {
-          "description": "NodePhase is the recently observed lifecycle phase of the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#phase The field is never populated, and now is deprecated.",
-          "type": "string"
-        },
-        "volumesAttached": {
-          "description": "List of volumes that are attached to the node.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.AttachedVolume"
-          }
-        },
-        "volumesInUse": {
-          "description": "List of attachable volumes in use (mounted) by the node.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeSystemInfo": {
-      "description": "NodeSystemInfo is a set of ids/uuids to uniquely identify the node.",
-      "required": [
-        "machineID",
-        "systemUUID",
-        "bootID",
-        "kernelVersion",
-        "osImage",
-        "containerRuntimeVersion",
-        "kubeletVersion",
-        "kubeProxyVersion",
-        "operatingSystem",
-        "architecture"
-      ],
-      "properties": {
-        "architecture": {
-          "description": "The Architecture reported by the node",
-          "type": "string"
-        },
-        "bootID": {
-          "description": "Boot ID reported by the node.",
-          "type": "string"
-        },
-        "containerRuntimeVersion": {
-          "description": "ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).",
-          "type": "string"
-        },
-        "kernelVersion": {
-          "description": "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
-          "type": "string"
-        },
-        "kubeProxyVersion": {
-          "description": "KubeProxy Version reported by the node.",
-          "type": "string"
-        },
-        "kubeletVersion": {
-          "description": "Kubelet Version reported by the node.",
-          "type": "string"
-        },
-        "machineID": {
-          "description": "MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html",
-          "type": "string"
-        },
-        "operatingSystem": {
-          "description": "The Operating System reported by the node",
-          "type": "string"
-        },
-        "osImage": {
-          "description": "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
-          "type": "string"
-        },
-        "systemUUID": {
-          "description": "SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ObjectFieldSelector": {
-      "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
-      "required": [
-        "fieldPath"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-          "type": "string"
-        },
-        "fieldPath": {
-          "description": "Path of the field to select in the specified API version.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ObjectReference": {
-      "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
-      "properties": {
-        "apiVersion": {
-          "description": "API version of the referent.",
-          "type": "string"
-        },
-        "fieldPath": {
-          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
-          "type": "string"
-        },
-        "resourceVersion": {
-          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
-          "type": "string"
-        },
-        "uid": {
-          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolume": {
-      "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec"
-        },
-        "status": {
-          "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolume",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaim": {
-      "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec"
-        },
-        "status": {
-          "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolumeClaim",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaimList": {
-      "description": "PersistentVolumeClaimList is a list of PersistentVolumeClaim items.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolumeClaimList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
-      "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
-      "properties": {
-        "accessModes": {
-          "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "resources": {
-          "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
-        "selector": {
-          "description": "A label query over volumes to consider for binding.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-        },
-        "storageClassName": {
-          "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
-          "type": "string"
-        },
-        "volumeName": {
-          "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
-      "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
-      "properties": {
-        "accessModes": {
-          "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "capacity": {
-          "description": "Represents the actual resources of the underlying volume.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "phase": {
-          "description": "Phase represents the current phase of PersistentVolumeClaim.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
-      "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
-      "required": [
-        "claimName"
-      ],
-      "properties": {
-        "claimName": {
-          "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolumeList": {
-      "description": "PersistentVolumeList is a list of PersistentVolume items.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolume"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolumeList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeSpec": {
-      "description": "PersistentVolumeSpec is the specification of a persistent volume.",
-      "properties": {
-        "accessModes": {
-          "description": "AccessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "awsElasticBlockStore": {
-          "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
-        },
-        "azureDisk": {
-          "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource"
-        },
-        "azureFile": {
-          "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFilePersistentVolumeSource"
-        },
-        "capacity": {
-          "description": "A description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "cephfs": {
-          "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSPersistentVolumeSource"
-        },
-        "cinder": {
-          "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource"
-        },
-        "claimRef": {
-          "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "fc": {
-          "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource"
-        },
-        "flexVolume": {
-          "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource"
-        },
-        "flocker": {
-          "description": "Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource"
-        },
-        "gcePersistentDisk": {
-          "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
-        },
-        "glusterfs": {
-          "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource"
-        },
-        "hostPath": {
-          "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
-        },
-        "iscsi": {
-          "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
-        },
-        "local": {
-          "description": "Local represents directly-attached storage with node affinity",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalVolumeSource"
-        },
-        "mountOptions": {
-          "description": "A list of mount options, e.g. [\"ro\", \"soft\"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nfs": {
-          "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource"
-        },
-        "persistentVolumeReclaimPolicy": {
-          "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recycling must be supported by the volume plugin underlying this persistent volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming",
-          "type": "string"
-        },
-        "photonPersistentDisk": {
-          "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
-        },
-        "portworxVolume": {
-          "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource"
-        },
-        "quobyte": {
-          "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource"
-        },
-        "rbd": {
-          "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource"
-        },
-        "scaleIO": {
-          "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource"
-        },
-        "storageClassName": {
-          "description": "Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.",
-          "type": "string"
-        },
-        "storageos": {
-          "description": "StorageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://releases.k8s.io/HEAD/examples/volumes/storageos/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSPersistentVolumeSource"
-        },
-        "vsphereVolume": {
-          "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolumeStatus": {
-      "description": "PersistentVolumeStatus is the current status of a persistent volume.",
-      "properties": {
-        "message": {
-          "description": "A human-readable message indicating details about why the volume is in this state.",
-          "type": "string"
-        },
-        "phase": {
-          "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
-      "description": "Represents a Photon Controller persistent disk resource.",
-      "required": [
-        "pdID"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "pdID": {
-          "description": "ID that identifies Photon Controller persistent disk",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Pod": {
-      "description": "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
-        },
-        "status": {
-          "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Pod",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PodAffinity": {
-      "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
-      "properties": {
-        "preferredDuringSchedulingIgnoredDuringExecution": {
-          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
-          }
-        },
-        "requiredDuringSchedulingIgnoredDuringExecution": {
-          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodAffinityTerm": {
-      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e tches that of any node on which a pod of the set of pods is running",
-      "properties": {
-        "labelSelector": {
-          "description": "A label query over a set of resources, in this case pods.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-        },
-        "namespaces": {
-          "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "topologyKey": {
-          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. For PreferredDuringScheduling pod anti-affinity, empty topologyKey is interpreted as \"all topologies\" (\"all topologies\" here means all the topologyKeys indicated by scheduler command-line argument --failure-domains); for affinity and for RequiredDuringScheduling pod anti-affinity, empty topologyKey is not allowed.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodAntiAffinity": {
-      "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
-      "properties": {
-        "preferredDuringSchedulingIgnoredDuringExecution": {
-          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
-          }
-        },
-        "requiredDuringSchedulingIgnoredDuringExecution": {
-          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodCondition": {
-      "description": "PodCondition contains details for the current condition of this pod.",
-      "required": [
-        "type",
-        "status"
-      ],
-      "properties": {
-        "lastProbeTime": {
-          "description": "Last time we probed the condition.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "lastTransitionTime": {
-          "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "Human-readable message indicating details about last transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type is the type of the condition. Currently only Ready. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodList": {
-      "description": "PodList is a list of Pods.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of pods. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PodList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PodSecurityContext": {
-      "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
-      "properties": {
-        "fsGroup": {
-          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "runAsNonRoot": {
-          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-          "type": "boolean"
-        },
-        "runAsUser": {
-          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "seLinuxOptions": {
-          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions"
-        },
-        "supplementalGroups": {
-          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
-          "type": "array",
-          "items": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodSpec": {
-      "description": "PodSpec is a description of a pod.",
-      "required": [
-        "containers"
-      ],
-      "properties": {
-        "activeDeadlineSeconds": {
-          "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "affinity": {
-          "description": "If specified, the pod's scheduling constraints",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
-        },
-        "automountServiceAccountToken": {
-          "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
-          "type": "boolean"
-        },
-        "containers": {
-          "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "dnsPolicy": {
-          "description": "Set DNS policy for containers within the pod. One of 'ClusterFirstWithHostNet', 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\". To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
-          "type": "string"
-        },
-        "hostAliases": {
-          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
-          },
-          "x-kubernetes-patch-merge-key": "ip",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "hostIPC": {
-          "description": "Use the host's ipc namespace. Optional: Default to false.",
-          "type": "boolean"
-        },
-        "hostNetwork": {
-          "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
-          "type": "boolean"
-        },
-        "hostPID": {
-          "description": "Use the host's pid namespace. Optional: Default to false.",
-          "type": "boolean"
-        },
-        "hostname": {
-          "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
-          "type": "string"
-        },
-        "imagePullSecrets": {
-          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "initContainers": {
-          "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "nodeName": {
-          "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
-          "type": "string"
-        },
-        "nodeSelector": {
-          "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "priority": {
-          "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "priorityClassName": {
-          "description": "If specified, indicates the pod's priority. \"SYSTEM\" is a special keyword which indicates the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
-          "type": "string"
-        },
-        "restartPolicy": {
-          "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
-          "type": "string"
-        },
-        "schedulerName": {
-          "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
-          "type": "string"
-        },
-        "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
-        },
-        "serviceAccount": {
-          "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
-          "type": "string"
-        },
-        "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-          "type": "string"
-        },
-        "subdomain": {
-          "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all.",
-          "type": "string"
-        },
-        "terminationGracePeriodSeconds": {
-          "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "tolerations": {
-          "description": "If specified, the pod's tolerations.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
-          }
-        },
-        "volumes": {
-          "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge,retainKeys"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodStatus": {
-      "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system.",
-      "properties": {
-        "conditions": {
-          "description": "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PodCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "containerStatuses": {
-          "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
-          }
-        },
-        "hostIP": {
-          "description": "IP address of the host to which the pod is assigned. Empty if not yet scheduled.",
-          "type": "string"
-        },
-        "initContainerStatuses": {
-          "description": "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
-          }
-        },
-        "message": {
-          "description": "A human readable message indicating details about why the pod is in this condition.",
-          "type": "string"
-        },
-        "phase": {
-          "description": "Current condition of the pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase",
-          "type": "string"
-        },
-        "podIP": {
-          "description": "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
-          "type": "string"
-        },
-        "qosClass": {
-          "description": "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md",
-          "type": "string"
-        },
-        "reason": {
-          "description": "A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'",
-          "type": "string"
-        },
-        "startTime": {
-          "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodTemplate": {
-      "description": "PodTemplate describes a template for creating copies of a predefined pod.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "template": {
-          "description": "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PodTemplate",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PodTemplateList": {
-      "description": "PodTemplateList is a list of PodTemplates.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of pod templates",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplate"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PodTemplateList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PodTemplateSpec": {
-      "description": "PodTemplateSpec describes the data a pod should have when created from a template",
-      "properties": {
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PortworxVolumeSource": {
-      "description": "PortworxVolumeSource represents a Portworx volume resource.",
-      "required": [
-        "volumeID"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "volumeID": {
-          "description": "VolumeID uniquely identifies a Portworx volume",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PreferredSchedulingTerm": {
-      "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-      "required": [
-        "weight",
-        "preference"
-      ],
-      "properties": {
-        "preference": {
-          "description": "A node selector term, associated with the corresponding weight.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
-        },
-        "weight": {
-          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Probe": {
-      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
-      "properties": {
-        "exec": {
-          "description": "One and only one of the following should be specified. Exec specifies the action to take.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
-        },
-        "failureThreshold": {
-          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "httpGet": {
-          "description": "HTTPGet specifies the http request to perform.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
-        },
-        "initialDelaySeconds": {
-          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "type": "integer",
-          "format": "int32"
-        },
-        "periodSeconds": {
-          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "successThreshold": {
-          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "tcpSocket": {
-          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
-          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
-        },
-        "timeoutSeconds": {
-          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ProjectedVolumeSource": {
-      "description": "Represents a projected volume source",
-      "required": [
-        "sources"
-      ],
-      "properties": {
-        "defaultMode": {
-          "description": "Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "sources": {
-          "description": "list of volume projections",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.QuobyteVolumeSource": {
-      "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
-      "required": [
-        "registry",
-        "volume"
-      ],
-      "properties": {
-        "group": {
-          "description": "Group to map volume access to Default is no group",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
-          "type": "boolean"
-        },
-        "registry": {
-          "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
-          "type": "string"
-        },
-        "user": {
-          "description": "User to map volume access to Defaults to serivceaccount user",
-          "type": "string"
-        },
-        "volume": {
-          "description": "Volume is a string that references an already created Quobyte volume by name.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.RBDVolumeSource": {
-      "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
-      "required": [
-        "monitors",
-        "image"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
-          "type": "string"
-        },
-        "image": {
-          "description": "The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "keyring": {
-          "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "monitors": {
-          "description": "A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "pool": {
-          "description": "The rados pool name. Default is rbd. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "user": {
-          "description": "The rados user name. Default is admin. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ReplicationController": {
-      "description": "ReplicationController represents the configuration of a replication controller.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerSpec"
-        },
-        "status": {
-          "description": "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ReplicationController",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ReplicationControllerCondition": {
-      "description": "ReplicationControllerCondition describes the state of a replication controller at a certain point.",
-      "required": [
-        "type",
-        "status"
-      ],
-      "properties": {
-        "lastTransitionTime": {
-          "description": "The last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "A human readable message indicating details about the transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "The reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition, one of True, False, Unknown.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of replication controller condition.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ReplicationControllerList": {
-      "description": "ReplicationControllerList is a collection of replication controllers.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationController"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ReplicationControllerList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ReplicationControllerSpec": {
-      "description": "ReplicationControllerSpec is the specification of a replication controller.",
-      "properties": {
-        "minReadySeconds": {
-          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
-          "type": "integer",
-          "format": "int32"
-        },
-        "selector": {
-          "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "template": {
-          "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ReplicationControllerStatus": {
-      "description": "ReplicationControllerStatus represents the current status of a replication controller.",
-      "required": [
-        "replicas"
-      ],
-      "properties": {
-        "availableReplicas": {
-          "description": "The number of available replicas (ready for at least minReadySeconds) for this replication controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "conditions": {
-          "description": "Represents the latest available observations of a replication controller's current state.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "fullyLabeledReplicas": {
-          "description": "The number of pods that have labels matching the labels of the pod template of the replication controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "observedGeneration": {
-          "description": "ObservedGeneration reflects the generation of the most recently observed replication controller.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "readyReplicas": {
-          "description": "The number of ready replicas for this replication controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ResourceFieldSelector": {
-      "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
-      "required": [
-        "resource"
-      ],
-      "properties": {
-        "containerName": {
-          "description": "Container name: required for volumes, optional for env vars",
-          "type": "string"
-        },
-        "divisor": {
-          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-        },
-        "resource": {
-          "description": "Required: resource to select",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ResourceQuota": {
-      "description": "ResourceQuota sets aggregate quota restrictions enforced per namespace",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaSpec"
-        },
-        "status": {
-          "description": "Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ResourceQuota",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ResourceQuotaList": {
-      "description": "ResourceQuotaList is a list of ResourceQuota items.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is a list of ResourceQuota objects. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuota"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ResourceQuotaList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ResourceQuotaSpec": {
-      "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
-      "properties": {
-        "hard": {
-          "description": "Hard is the set of desired hard limits for each named resource. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "scopes": {
-          "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ResourceQuotaStatus": {
-      "description": "ResourceQuotaStatus defines the enforced hard limits and observed use.",
-      "properties": {
-        "hard": {
-          "description": "Hard is the set of enforced hard limits for each named resource. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "used": {
-          "description": "Used is the current observed total usage of the resource in the namespace.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ResourceRequirements": {
-      "description": "ResourceRequirements describes the compute resource requirements.",
-      "properties": {
-        "limits": {
-          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "requests": {
-          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SELinuxOptions": {
-      "description": "SELinuxOptions are the labels to be applied to the container",
-      "properties": {
-        "level": {
-          "description": "Level is SELinux level label that applies to the container.",
-          "type": "string"
-        },
-        "role": {
-          "description": "Role is a SELinux role label that applies to the container.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type is a SELinux type label that applies to the container.",
-          "type": "string"
-        },
-        "user": {
-          "description": "User is a SELinux user label that applies to the container.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ScaleIOVolumeSource": {
-      "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
-      "required": [
-        "gateway",
-        "system",
-        "secretRef"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "gateway": {
-          "description": "The host address of the ScaleIO API Gateway.",
-          "type": "string"
-        },
-        "protectionDomain": {
-          "description": "The name of the Protection Domain for the configured storage (defaults to \"default\").",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "sslEnabled": {
-          "description": "Flag to enable/disable SSL communication with Gateway, default false",
-          "type": "boolean"
-        },
-        "storageMode": {
-          "description": "Indicates whether the storage for a volume should be thick or thin (defaults to \"thin\").",
-          "type": "string"
-        },
-        "storagePool": {
-          "description": "The Storage Pool associated with the protection domain (defaults to \"default\").",
-          "type": "string"
-        },
-        "system": {
-          "description": "The name of the storage system as configured in ScaleIO.",
-          "type": "string"
-        },
-        "volumeName": {
-          "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Secret": {
-      "description": "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "data": {
-          "description": "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "format": "byte"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "stringData": {
-          "description": "stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "description": "Used to facilitate programmatic handling of secret data.",
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Secret",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.SecretEnvSource": {
-      "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
-      "properties": {
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the Secret must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SecretKeySelector": {
-      "description": "SecretKeySelector selects a key of a Secret.",
-      "required": [
-        "key"
-      ],
-      "properties": {
-        "key": {
-          "description": "The key of the secret to select from.  Must be a valid secret key.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the Secret or it's key must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SecretList": {
-      "description": "SecretList is a list of Secret.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "SecretList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.SecretProjection": {
-      "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
-      "properties": {
-        "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the Secret or its key must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SecretReference": {
-      "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
-      "properties": {
-        "name": {
-          "description": "Name is unique within a namespace to reference a secret resource.",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace defines the space within which the secret name must be unique.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SecretVolumeSource": {
-      "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
-      "properties": {
-        "defaultMode": {
-          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
-        },
-        "optional": {
-          "description": "Specify whether the Secret or it's keys must be defined",
-          "type": "boolean"
-        },
-        "secretName": {
-          "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SecurityContext": {
-      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
-      "properties": {
-        "allowPrivilegeEscalation": {
-          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than it's parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
-          "type": "boolean"
-        },
-        "capabilities": {
-          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities"
-        },
-        "privileged": {
-          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
-          "type": "boolean"
-        },
-        "readOnlyRootFilesystem": {
-          "description": "Whether this container has a read-only root filesystem. Default is false.",
-          "type": "boolean"
-        },
-        "runAsNonRoot": {
-          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-          "type": "boolean"
-        },
-        "runAsUser": {
-          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "seLinuxOptions": {
-          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Service": {
-      "description": "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceSpec"
-        },
-        "status": {
-          "description": "Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Service",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServiceAccount": {
-      "description": "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "automountServiceAccountToken": {
-          "description": "AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.",
-          "type": "boolean"
-        },
-        "imagePullSecrets": {
-          "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "secrets": {
-          "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ServiceAccount",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServiceAccountList": {
-      "description": "ServiceAccountList is a list of ServiceAccount objects",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccount"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ServiceAccountList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServiceList": {
-      "description": "ServiceList holds a list of services.",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of services",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Service"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ServiceList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServicePort": {
-      "description": "ServicePort contains information on service's port.",
-      "required": [
-        "port"
-      ],
-      "properties": {
-        "name": {
-          "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. This maps to the 'Name' field in EndpointPort objects. Optional if only one ServicePort is defined on this service.",
-          "type": "string"
-        },
-        "nodePort": {
-          "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
-          "type": "integer",
-          "format": "int32"
-        },
-        "port": {
-          "description": "The port that will be exposed by this service.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "protocol": {
-          "description": "The IP protocol for this port. Supports \"TCP\" and \"UDP\". Default is TCP.",
-          "type": "string"
-        },
-        "targetPort": {
-          "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ServiceSpec": {
-      "description": "ServiceSpec describes the attributes that a user creates on a service.",
-      "properties": {
-        "clusterIP": {
-          "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "string"
-        },
-        "externalIPs": {
-          "description": "externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "externalName": {
-          "description": "externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires Type to be ExternalName.",
-          "type": "string"
-        },
-        "externalTrafficPolicy": {
-          "description": "externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. \"Local\" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. \"Cluster\" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.",
-          "type": "string"
-        },
-        "healthCheckNodePort": {
-          "description": "healthCheckNodePort specifies the healthcheck nodePort for the service. If not specified, HealthCheckNodePort is created by the service api backend with the allocated nodePort. Will use user-specified nodePort value if specified by the client. Only effects when Type is set to LoadBalancer and ExternalTrafficPolicy is set to Local.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "loadBalancerIP": {
-          "description": "Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.",
-          "type": "string"
-        },
-        "loadBalancerSourceRanges": {
-          "description": "If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.\" More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "ports": {
-          "description": "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ServicePort"
-          },
-          "x-kubernetes-patch-merge-key": "port",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "publishNotReadyAddresses": {
-          "description": "publishNotReadyAddresses, when set to true, indicates that DNS implementations must publish the notReadyAddresses of subsets for the Endpoints associated with the Service. The default value is false. The primary use case for setting this field is to use a StatefulSet's Headless Service to propagate SRV records for its Pods without respect to their readiness for purpose of peer discovery. This field will replace the service.alpha.kubernetes.io/tolerate-unready-endpoints when that annotation is deprecated and all clients have been converted to use this field.",
-          "type": "boolean"
-        },
-        "selector": {
-          "description": "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "sessionAffinity": {
-          "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "string"
-        },
-        "sessionAffinityConfig": {
-          "description": "sessionAffinityConfig contains the configurations of session affinity.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SessionAffinityConfig"
-        },
-        "type": {
-          "description": "type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. \"ExternalName\" maps to the specified externalName. \"ClusterIP\" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object. If clusterIP is \"None\", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a stable IP. \"NodePort\" builds on ClusterIP and allocates a port on every node which routes to the clusterIP. \"LoadBalancer\" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ServiceStatus": {
-      "description": "ServiceStatus represents the current status of a service.",
-      "properties": {
-        "loadBalancer": {
-          "description": "LoadBalancer contains the current status of the load-balancer, if one is present.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SessionAffinityConfig": {
-      "description": "SessionAffinityConfig represents the configurations of session affinity.",
-      "properties": {
-        "clientIP": {
-          "description": "clientIP contains the configurations of Client IP based session affinity.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ClientIPConfig"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
-      "description": "Represents a StorageOS persistent volume resource.",
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "volumeName": {
-          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
-          "type": "string"
-        },
-        "volumeNamespace": {
-          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.StorageOSVolumeSource": {
-      "description": "Represents a StorageOS persistent volume resource.",
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "volumeName": {
-          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
-          "type": "string"
-        },
-        "volumeNamespace": {
-          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.TCPSocketAction": {
-      "description": "TCPSocketAction describes an action based on opening a socket",
-      "required": [
-        "port"
-      ],
-      "properties": {
-        "host": {
-          "description": "Optional: Host name to connect to, defaults to the pod IP.",
-          "type": "string"
-        },
-        "port": {
-          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Taint": {
-      "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
-      "required": [
-        "key",
-        "effect"
-      ],
-      "properties": {
-        "effect": {
-          "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
-          "type": "string"
-        },
-        "key": {
-          "description": "Required. The taint key to be applied to a node.",
-          "type": "string"
-        },
-        "timeAdded": {
-          "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "value": {
-          "description": "Required. The taint value corresponding to the taint key.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Toleration": {
-      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
-      "properties": {
-        "effect": {
-          "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
-          "type": "string"
-        },
-        "key": {
-          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-          "type": "string"
-        },
-        "operator": {
-          "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
-          "type": "string"
-        },
-        "tolerationSeconds": {
-          "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "value": {
-          "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Volume": {
-      "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "awsElasticBlockStore": {
-          "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
-        },
-        "azureDisk": {
-          "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource"
-        },
-        "azureFile": {
-          "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource"
-        },
-        "cephfs": {
-          "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource"
-        },
-        "cinder": {
-          "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource"
-        },
-        "configMap": {
-          "description": "ConfigMap represents a configMap that should populate this volume",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource"
-        },
-        "downwardAPI": {
-          "description": "DownwardAPI represents downward API about the pod that should populate this volume",
-          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource"
-        },
-        "emptyDir": {
-          "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-          "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource"
-        },
-        "fc": {
-          "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource"
-        },
-        "flexVolume": {
-          "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource"
-        },
-        "flocker": {
-          "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource"
-        },
-        "gcePersistentDisk": {
-          "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
-        },
-        "gitRepo": {
-          "description": "GitRepo represents a git repository at a particular revision.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource"
-        },
-        "glusterfs": {
-          "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource"
-        },
-        "hostPath": {
-          "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
-        },
-        "iscsi": {
-          "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
-        },
-        "name": {
-          "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "nfs": {
-          "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource"
-        },
-        "persistentVolumeClaim": {
-          "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource"
-        },
-        "photonPersistentDisk": {
-          "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
-        },
-        "portworxVolume": {
-          "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource"
-        },
-        "projected": {
-          "description": "Items for all in one resources secrets, configmaps, and downward API",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource"
-        },
-        "quobyte": {
-          "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource"
-        },
-        "rbd": {
-          "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource"
-        },
-        "scaleIO": {
-          "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource"
-        },
-        "secret": {
-          "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource"
-        },
-        "storageos": {
-          "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource"
-        },
-        "vsphereVolume": {
-          "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.VolumeMount": {
-      "description": "VolumeMount describes a mounting of a Volume within a container.",
-      "required": [
-        "name",
-        "mountPath"
-      ],
-      "properties": {
-        "mountPath": {
-          "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
-          "type": "string"
-        },
-        "name": {
-          "description": "This must match the Name of a Volume.",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
-          "type": "boolean"
-        },
-        "subPath": {
-          "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.VolumeProjection": {
-      "description": "Projection that may be projected along with other supported volume types",
-      "properties": {
-        "configMap": {
-          "description": "information about the configMap data to project",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection"
-        },
-        "downwardAPI": {
-          "description": "information about the downwardAPI data to project",
-          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection"
-        },
-        "secret": {
-          "description": "information about the secret data to project",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
-      "description": "Represents a vSphere volume resource.",
-      "required": [
-        "volumePath"
-      ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "storagePolicyID": {
-          "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
-          "type": "string"
-        },
-        "storagePolicyName": {
-          "description": "Storage Policy Based Management (SPBM) profile name.",
-          "type": "string"
-        },
-        "volumePath": {
-          "description": "Path that identifies vSphere volume vmdk",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
-      "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-      "required": [
-        "weight",
-        "podAffinityTerm"
-      ],
-      "properties": {
-        "podAffinityTerm": {
-          "description": "Required. A pod affinity term, associated with the corresponding weight.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
-        },
-        "weight": {
-          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.api.resource.Quantity": {
-      "type": "string"
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
-      "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
-      "required": [
-        "name",
-        "versions",
-        "serverAddressByClientCIDRs"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "name is the name of the group.",
-          "type": "string"
-        },
-        "preferredVersion": {
-          "description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
-        },
-        "serverAddressByClientCIDRs": {
-          "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
-          }
-        },
-        "versions": {
-          "description": "versions are the versions supported in this group.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIGroup",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
-      "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
-      "required": [
-        "groups"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "groups": {
-          "description": "groups is a list of APIGroup.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIGroupList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
-      "description": "APIResource specifies the name of a resource and whether it is namespaced.",
-      "required": [
-        "name",
-        "singularName",
-        "namespaced",
-        "kind",
-        "verbs"
-      ],
-      "properties": {
-        "categories": {
-          "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "kind": {
-          "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
-          "type": "string"
-        },
-        "name": {
-          "description": "name is the plural name of the resource.",
-          "type": "string"
-        },
-        "namespaced": {
-          "description": "namespaced indicates if a resource is namespaced or not.",
-          "type": "boolean"
-        },
-        "shortNames": {
-          "description": "shortNames is a list of suggested short names of the resource.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "singularName": {
-          "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
-          "type": "string"
-        },
-        "verbs": {
-          "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
-      "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
-      "required": [
-        "groupVersion",
-        "resources"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "groupVersion": {
-          "description": "groupVersion is the group and version this APIResourceList is for.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "resources": {
-          "description": "resources contains the name of the resources and if they are namespaced.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIResourceList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions": {
-      "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
-      "required": [
-        "versions",
-        "serverAddressByClientCIDRs"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "serverAddressByClientCIDRs": {
-          "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
-          }
-        },
-        "versions": {
-          "description": "versions are the api versions that are available.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIVersions",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
-      "description": "DeleteOptions may be provided when deleting an API object.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "gracePeriodSeconds": {
-          "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "orphanDependents": {
-          "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
-          "type": "boolean"
-        },
-        "preconditions": {
-          "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
-        },
-        "propagationPolicy": {
-          "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.",
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "admission.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "apps",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "apps",
-          "kind": "DeleteOptions",
-          "version": "v1beta2"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "DeleteOptions",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "batch",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "batch",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "batch",
-          "kind": "DeleteOptions",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "certificates.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "extensions",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "federation",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "imagepolicy.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "networking.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "policy",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "scheduling.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "settings.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
-      "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
-      "required": [
-        "groupVersion",
-        "version"
-      ],
-      "properties": {
-        "groupVersion": {
-          "description": "groupVersion specifies the API group and version in the form \"group/version\"",
-          "type": "string"
-        },
-        "version": {
-          "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializer": {
-      "description": "Initializer is information about an initializer that has not yet completed.",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "name of the process that is responsible for initializing this object.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializers": {
-      "description": "Initializers tracks the progress of initialization.",
-      "required": [
-        "pending"
-      ],
-      "properties": {
-        "pending": {
-          "description": "Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializer"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "result": {
-          "description": "If result is set with the Failure field, the object will be persisted to storage and then deleted, ensuring that other clients can observe the deletion.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
-        }
-      }
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
       "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
       "properties": {
         "matchExpressions": {
           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "matchLabels": {
-          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+          "type": "object"
         }
-      }
+      },
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
       "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-      "required": [
-        "key",
-        "operator"
-      ],
       "properties": {
         "key": {
           "description": "key is the label key that the selector applies to.",
-          "type": "string",
-          "x-kubernetes-patch-merge-key": "key",
-          "x-kubernetes-patch-strategy": "merge"
+          "type": "string"
         },
         "operator": {
-          "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
+          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
           "type": "string"
         },
         "values": {
           "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "required": [
+        "key",
+        "operator"
+      ],
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
       "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
       "properties": {
+        "continue": {
+          "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+          "type": "string"
+        },
+        "remainingItemCount": {
+          "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+          "format": "int64",
+          "type": "integer"
+        },
         "resourceVersion": {
-          "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+          "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
           "type": "string"
         },
         "selfLink": {
-          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+      "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+          "type": "string"
+        },
+        "fieldsType": {
+          "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+          "type": "string"
+        },
+        "fieldsV1": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1",
+          "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type."
+        },
+        "manager": {
+          "description": "Manager is an identifier of the workflow managing these fields.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+          "type": "string"
+        },
+        "subresource": {
+          "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over."
+        }
+      },
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
       "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
       "properties": {
         "annotations": {
-          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
-        },
-        "clusterName": {
-          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
-          "type": "string"
+          },
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+          "type": "object"
         },
         "creationTimestamp": {
-          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "deletionGracePeriodSeconds": {
           "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "deletionTimestamp": {
-          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "finalizers": {
-          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
-          "type": "array",
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
           "items": {
             "type": "string"
           },
+          "type": "array",
+          "x-kubernetes-list-type": "set",
           "x-kubernetes-patch-strategy": "merge"
         },
         "generateName": {
-          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency",
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
           "type": "string"
         },
         "generation": {
           "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "initializers": {
-          "description": "An initializer is a controller which enforces some system invariant at object creation time. This field is a list of initializers that have not yet acted on this object. If nil or empty, this object has been completely initialized. Otherwise, the object is considered uninitialized and is hidden (in list/watch and get calls) from clients that haven't explicitly asked to observe uninitialized objects.\n\nWhen an object is created, the system will populate this list with the current set of initializers. Only privileged users may set or modify this list. Once it is empty, it may not be modified further by any user.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializers"
+          "format": "int64",
+          "type": "integer"
         },
         "labels": {
-          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+          "type": "object"
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "name": {
-          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
           "type": "string"
         },
         "ownerReferences": {
           "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "uid"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "uid",
           "x-kubernetes-patch-strategy": "merge"
         },
         "resourceVersion": {
-          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
           "type": "string"
         },
         "selfLink": {
-          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
           "type": "string"
         },
         "uid": {
-          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
-      "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
-      "required": [
-        "apiVersion",
-        "kind",
-        "name",
-        "uid"
-      ],
+      "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
       "properties": {
         "apiVersion": {
           "description": "API version of the referent.",
           "type": "string"
         },
         "blockOwnerDeletion": {
-          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
           "type": "boolean"
         },
         "controller": {
@@ -6619,372 +5220,40 @@
           "type": "boolean"
         },
         "kind": {
-          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "name": {
-          "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
           "type": "string"
         },
         "uid": {
-          "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
-      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
-      "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
-      "properties": {
-        "uid": {
-          "description": "Specifies the target UID.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
-      "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
-      "required": [
-        "clientCIDR",
-        "serverAddress"
-      ],
-      "properties": {
-        "clientCIDR": {
-          "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
-          "type": "string"
-        },
-        "serverAddress": {
-          "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
-      "description": "Status is a return value for calls that don't return other objects.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "code": {
-          "description": "Suggested HTTP return code for this status, 0 if not set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "details": {
-          "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "message": {
-          "description": "A human-readable description of the status of this operation.",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        },
-        "reason": {
-          "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
           "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Status",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
-      "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
-      "properties": {
-        "field": {
-          "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
-          "type": "string"
-        },
-        "message": {
-          "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
-      "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
-      "properties": {
-        "causes": {
-          "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
-          }
-        },
-        "group": {
-          "description": "The group attribute of the resource associated with the status StatusReason.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
-          "type": "string"
-        },
-        "retryAfterSeconds": {
-          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "uid": {
-          "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-          "type": "string"
-        }
-      }
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
-      "description": "Event represents a single event to a watched resource.",
-      "required": [
-        "type",
-        "object"
-      ],
-      "properties": {
-        "object": {
-          "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
-        },
-        "type": {
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "admission.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "apps",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "apps",
-          "kind": "WatchEvent",
-          "version": "v1beta2"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "WatchEvent",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "batch",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "batch",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "batch",
-          "kind": "WatchEvent",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "certificates.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "extensions",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "federation",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "imagepolicy.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "networking.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "policy",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "scheduling.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "settings.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        }
-      ]
+      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+      "format": "date-time",
+      "type": "string"
     },
     "io.k8s.apimachinery.pkg.runtime.RawExtension": {
-      "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
-      "required": [
-        "Raw"
-      ],
-      "properties": {
-        "Raw": {
-          "description": "Raw is the underlying serialization of this object.",
-          "type": "string",
-          "format": "byte"
-        }
-      }
+      "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.Object `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// External package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// On the wire, the JSON will look something like this:\n\n\t{\n\t\t\"kind\":\"MyAPIObject\",\n\t\t\"apiVersion\":\"v1\",\n\t\t\"myPlugin\": {\n\t\t\t\"kind\":\"PluginA\",\n\t\t\t\"aOption\":\"foo\",\n\t\t},\n\t}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
-      "type": "string",
-      "format": "int-or-string"
-    },
-    "io.k8s.apimachinery.pkg.version.Info": {
-      "description": "Info contains versioning information. how we'll want to distribute that information.",
-      "required": [
-        "major",
-        "minor",
-        "gitVersion",
-        "gitCommit",
-        "gitTreeState",
-        "buildDate",
-        "goVersion",
-        "compiler",
-        "platform"
-      ],
-      "properties": {
-        "buildDate": {
-          "type": "string"
-        },
-        "compiler": {
-          "type": "string"
-        },
-        "gitCommit": {
-          "type": "string"
-        },
-        "gitTreeState": {
-          "type": "string"
-        },
-        "gitVersion": {
-          "type": "string"
-        },
-        "goVersion": {
-          "type": "string"
-        },
-        "major": {
-          "type": "string"
-        },
-        "minor": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
+      "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+      "format": "int-or-string",
+      "type": "string"
     }
-  },
-  "securityDefinitions": {
-   "BearerToken": {
-    "description": "Bearer Token authentication",
-    "type": "apiKey",
-    "name": "authorization",
-    "in": "header"
-   }
-  },
-  "security": [
-   {
-    "BearerToken": []
-   }
-  ]
- }
+  }
+}

--- a/pkg/util/proto/testdata/swagger_next.json
+++ b/pkg/util/proto/testdata/swagger_next.json
@@ -2,19 +2,15 @@
   "swagger": "2.0",
   "info": {
     "title": "Kubernetes",
-    "version": "v1.8.0"
+    "version": "v1.35.2"
   },
   "paths": {},
   "definitions": {
-    "io.k8s.api.apps.v1beta1.ControllerRevision": {
+    "io.k8s.api.apps.v1.ControllerRevision": {
       "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
-      "type": "object",
-      "required": [
-        "revision"
-      ],
       "properties": {
         "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
           "type": "string"
         },
         "data": {
@@ -22,110 +18,109 @@
           "type": "object"
         },
         "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "revision": {
           "description": "Revision indicates the revision of the state represented by Data.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         }
       },
+      "required": [
+        "revision"
+      ],
+      "type": "object",
       "x-kubernetes-group-version-kind": [
         {
           "group": "apps",
           "kind": "ControllerRevision",
-          "version": "v1beta1"
+          "version": "v1"
         }
       ]
     },
-    "io.k8s.api.apps.v1beta1.ControllerRevisionList": {
+    "io.k8s.api.apps.v1.ControllerRevisionList": {
       "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
       "properties": {
         "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
           "type": "string"
         },
         "items": {
           "description": "Items is the list of ControllerRevisions",
-          "type": "array",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ControllerRevision"
-          }
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ControllerRevision"
+          },
+          "type": "array"
         },
         "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "metadata": {
-          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
+      "required": [
+        "items"
+      ],
+      "type": "object",
       "x-kubernetes-group-version-kind": [
         {
           "group": "apps",
           "kind": "ControllerRevisionList",
-          "version": "v1beta1"
+          "version": "v1"
         }
       ]
     },
-    "io.k8s.api.apps.v1beta1.Deployment": {
+    "io.k8s.api.apps.v1.Deployment": {
       "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
-      "type": "object",
       "properties": {
         "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
           "type": "string"
         },
         "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "metadata": {
-          "description": "Standard object metadata.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "description": "Specification of the desired behavior of the Deployment.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentSpec"
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentSpec",
+          "description": "Specification of the desired behavior of the Deployment."
         },
         "status": {
-          "description": "Most recently observed status of the Deployment.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStatus"
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStatus",
+          "description": "Most recently observed status of the Deployment."
         }
       },
+      "type": "object",
       "x-kubernetes-group-version-kind": [
         {
           "group": "apps",
           "kind": "Deployment",
-          "version": "v1beta1"
+          "version": "v1"
         }
       ]
     },
-    "io.k8s.api.apps.v1beta1.DeploymentCondition": {
+    "io.k8s.api.apps.v1.DeploymentCondition": {
       "description": "DeploymentCondition describes the state of a deployment at a certain point.",
-      "type": "object",
-      "required": [
-        "type",
-        "status"
-      ],
       "properties": {
         "lastTransitionTime": {
-          "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
         },
         "lastUpdateTime": {
-          "description": "The last time this condition was updated.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "The last time this condition was updated."
         },
         "message": {
           "description": "A human readable message indicating details about the transition.",
@@ -143,501 +138,211 @@
           "description": "Type of deployment condition.",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentList": {
-      "description": "DeploymentList is a list of Deployments.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of Deployments.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.Deployment"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "DeploymentList",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.DeploymentRollback": {
-      "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
-      "type": "object",
       "required": [
-        "name",
-        "rollbackTo"
+        "type",
+        "status"
       ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "Required: This must match the Name of a deployment.",
-          "type": "string"
-        },
-        "rollbackTo": {
-          "description": "The config of this deployment rollback.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollbackConfig"
-        },
-        "updatedAnnotations": {
-          "description": "The annotations to be updated to a deployment",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "DeploymentRollback",
-          "version": "v1beta1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.DeploymentSpec": {
+    "io.k8s.api.apps.v1.DeploymentSpec": {
       "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
-      "type": "object",
-      "required": [
-        "template"
-      ],
       "properties": {
         "minReadySeconds": {
           "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "paused": {
           "description": "Indicates that the deployment is paused.",
           "type": "boolean"
         },
         "progressDeadlineSeconds": {
-          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
-          "type": "integer",
-          "format": "int32"
+          "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.",
+          "format": "int32",
+          "type": "integer"
         },
         "replicas": {
           "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "revisionHistoryLimit": {
-          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 2.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "rollbackTo": {
-          "description": "DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollbackConfig"
+          "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.",
+          "format": "int32",
+          "type": "integer"
         },
         "selector": {
-          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels."
         },
         "strategy": {
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
           "description": "The deployment strategy to use to replace existing pods with new ones.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentStrategy"
+          "x-kubernetes-patch-strategy": "retainKeys"
         },
         "template": {
-          "description": "Template describes the pods that will be created.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
+          "description": "Template describes the pods that will be created. The only allowed template.spec.restartPolicy value is \"Always\"."
         }
-      }
+      },
+      "required": [
+        "selector",
+        "template"
+      ],
+      "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.DeploymentStatus": {
+    "io.k8s.api.apps.v1.DeploymentStatus": {
       "description": "DeploymentStatus is the most recently observed status of the Deployment.",
-      "type": "object",
       "properties": {
         "availableReplicas": {
-          "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Total number of available non-terminating pods (ready for at least minReadySeconds) targeted by this deployment.",
+          "format": "int32",
+          "type": "integer"
         },
         "collisionCount": {
           "description": "Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "conditions": {
           "description": "Represents the latest available observations of a deployment's current state.",
-          "type": "array",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.DeploymentCondition"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentCondition"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },
         "observedGeneration": {
           "description": "The generation observed by the deployment controller.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "readyReplicas": {
-          "description": "Total number of ready pods targeted by this deployment.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Total number of non-terminating pods targeted by this Deployment with a Ready Condition.",
+          "format": "int32",
+          "type": "integer"
         },
         "replicas": {
-          "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
-          "type": "integer",
-          "format": "int32"
+          "description": "Total number of non-terminating pods targeted by this deployment (their labels match the selector).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "terminatingReplicas": {
+          "description": "Total number of terminating pods targeted by this deployment. Terminating pods have a non-null .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.\n\nThis is a beta field and requires enabling DeploymentReplicaSetTerminatingReplicas feature (enabled by default).",
+          "format": "int32",
+          "type": "integer"
         },
         "unavailableReplicas": {
-          "description": "Total number of unavailable pods targeted by this deployment.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.",
+          "format": "int32",
+          "type": "integer"
         },
         "updatedReplicas": {
-          "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Total number of non-terminating pods targeted by this deployment that have the desired template spec.",
+          "format": "int32",
+          "type": "integer"
         }
-      }
+      },
+      "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.DeploymentStrategy": {
+    "io.k8s.api.apps.v1.DeploymentStrategy": {
       "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
-      "type": "object",
       "properties": {
         "rollingUpdate": {
-          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateDeployment"
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDeployment",
+          "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
         },
         "type": {
           "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.RollbackConfig": {
-      "description": "DEPRECATED.",
-      "type": "object",
-      "properties": {
-        "revision": {
-          "description": "The revision to rollback to. If set to 0, rollback to the last revision.",
-          "type": "integer",
-          "format": "int64"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.RollingUpdateDeployment": {
+    "io.k8s.api.apps.v1.RollingUpdateDeployment": {
       "description": "Spec to control the desired behavior of rolling update.",
-      "type": "object",
       "properties": {
         "maxSurge": {
-          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
         },
         "maxUnavailable": {
-          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy": {
-      "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
-      "type": "object",
-      "properties": {
-        "partition": {
-          "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.Scale": {
-      "description": "Scale represents a scaling request for a resource.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ScaleSpec"
-        },
-        "status": {
-          "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.ScaleStatus"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "Scale",
-          "version": "v1beta1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.ScaleSpec": {
-      "description": "ScaleSpec describes the attributes of a scale subresource",
-      "type": "object",
+    "io.k8s.api.authorization.v1.FieldSelectorAttributes": {
+      "description": "FieldSelectorAttributes indicates a field limited access. Webhook authors are encouraged to * ensure rawSelector and requirements are not both set * consider the requirements field if set * not try to parse or consider the rawSelector field if set. This is to avoid another CVE-2022-2880 (i.e. getting different systems to agree on how exactly to parse a query is not something we want), see https://www.oxeye.io/resources/golang-parameter-smuggling-attack for more details. For the *SubjectAccessReview endpoints of the kube-apiserver: * If rawSelector is empty and requirements are empty, the request is not limited. * If rawSelector is present and requirements are empty, the rawSelector will be parsed and limited if the parsing succeeds. * If rawSelector is empty and requirements are present, the requirements should be honored * If rawSelector is present and requirements are present, the request is invalid.",
       "properties": {
-        "replicas": {
-          "description": "desired number of instances for the scaled object.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.ScaleStatus": {
-      "description": "ScaleStatus represents the current status of a scale subresource.",
-      "type": "object",
-      "required": [
-        "replicas"
-      ],
-      "properties": {
-        "replicas": {
-          "description": "actual number of observed instances of the scaled object.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "selector": {
-          "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "targetSelector": {
-          "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSet": {
-      "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "rawSelector": {
+          "description": "rawSelector is the serialization of a field selector that would be included in a query parameter. Webhook implementations are encouraged to ignore rawSelector. The kube-apiserver's *SubjectAccessReview will parse the rawSelector as long as the requirements are not present.",
           "type": "string"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the desired identities of pods in this set.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetSpec"
-        },
-        "status": {
-          "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "StatefulSet",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetList": {
-      "description": "StatefulSetList is a collection of StatefulSets.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "type": "array",
+        "requirements": {
+          "description": "requirements is the parsed interpretation of a field selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSet"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "apps",
-          "kind": "StatefulSetList",
-          "version": "v1beta1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.apps.v1beta1.StatefulSetSpec": {
-      "description": "A StatefulSetSpec is the specification of a StatefulSet.",
-      "type": "object",
-      "required": [
-        "template",
-        "serviceName"
-      ],
+    "io.k8s.api.authorization.v1.LabelSelectorAttributes": {
+      "description": "LabelSelectorAttributes indicates a label limited access. Webhook authors are encouraged to * ensure rawSelector and requirements are not both set * consider the requirements field if set * not try to parse or consider the rawSelector field if set. This is to avoid another CVE-2022-2880 (i.e. getting different systems to agree on how exactly to parse a query is not something we want), see https://www.oxeye.io/resources/golang-parameter-smuggling-attack for more details. For the *SubjectAccessReview endpoints of the kube-apiserver: * If rawSelector is empty and requirements are empty, the request is not limited. * If rawSelector is present and requirements are empty, the rawSelector will be parsed and limited if the parsing succeeds. * If rawSelector is empty and requirements are present, the requirements should be honored * If rawSelector is present and requirements are present, the request is invalid.",
       "properties": {
-        "podManagementPolicy": {
-          "description": "podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.",
+        "rawSelector": {
+          "description": "rawSelector is the serialization of a field selector that would be included in a query parameter. Webhook implementations are encouraged to ignore rawSelector. The kube-apiserver's *SubjectAccessReview will parse the rawSelector as long as the requirements are not present.",
           "type": "string"
         },
-        "replicas": {
-          "description": "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "revisionHistoryLimit": {
-          "description": "revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "selector": {
-          "description": "selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
-        },
-        "serviceName": {
-          "description": "serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
-          "type": "string"
-        },
-        "template": {
-          "description": "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        },
-        "updateStrategy": {
-          "description": "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy"
-        },
-        "volumeClaimTemplates": {
-          "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
-          "type": "array",
+        "requirements": {
+          "description": "requirements is the parsed interpretation of a label selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
-          }
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetStatus": {
-      "description": "StatefulSetStatus represents the current state of a StatefulSet.",
-      "type": "object",
-      "required": [
-        "replicas"
-      ],
-      "properties": {
-        "collisionCount": {
-          "description": "collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "currentReplicas": {
-          "description": "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "currentRevision": {
-          "description": "currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).",
-          "type": "string"
-        },
-        "observedGeneration": {
-          "description": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "readyReplicas": {
-          "description": "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "replicas is the number of Pods created by the StatefulSet controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "updateRevision": {
-          "description": "updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)",
-          "type": "string"
-        },
-        "updatedReplicas": {
-          "description": "updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy": {
-      "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
-      "type": "object",
-      "properties": {
-        "rollingUpdate": {
-          "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
-          "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy"
-        },
-        "type": {
-          "description": "Type indicates the type of the StatefulSetUpdateStrategy.",
-          "type": "string"
-        }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
       "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
-      "type": "object",
-      "required": [
-        "spec"
-      ],
       "properties": {
         "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
           "type": "string"
         },
         "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec"
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
+          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
         },
         "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "description": "Status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
       "x-kubernetes-group-version-kind": [
         {
           "group": "authorization.k8s.io",
@@ -648,7 +353,6 @@
     },
     "io.k8s.api.authorization.v1.NonResourceAttributes": {
       "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
-      "type": "object",
       "properties": {
         "path": {
           "description": "Path is the URL path of the request",
@@ -658,15 +362,23 @@
           "description": "Verb is the standard HTTP verb",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.authorization.v1.ResourceAttributes": {
       "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
-      "type": "object",
       "properties": {
+        "fieldSelector": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.FieldSelectorAttributes",
+          "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it."
+        },
         "group": {
           "description": "Group is the API Group of the Resource.  \"*\" means all.",
           "type": "string"
+        },
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.LabelSelectorAttributes",
+          "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it."
         },
         "name": {
           "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
@@ -692,120 +404,37 @@
           "description": "Version is the API Version of the Resource.  \"*\" means all.",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
-      "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
-      "type": "object",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SelfSubjectAccessReview",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec": {
-      "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "type": "object",
-      "properties": {
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1.SubjectAccessReview": {
-      "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
-      "type": "object",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SubjectAccessReview",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectAccessReviewSpec": {
       "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "type": "object",
       "properties": {
         "extra": {
-          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
-          "type": "object",
           "additionalProperties": {
-            "type": "array",
             "items": {
               "type": "string"
-            }
-          }
+            },
+            "type": "array"
+          },
+          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+          "type": "object"
         },
         "groups": {
           "description": "Groups is the groups you're testing for.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes"
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes",
+          "description": "NonResourceAttributes describes information for a non-resource access request"
         },
         "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes"
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes",
+          "description": "ResourceAuthorizationAttributes describes information for a resource access request"
         },
         "uid": {
           "description": "UID information about the requesting user.",
@@ -815,17 +444,18 @@
           "description": "User is the user you're testing for. If you specify \"User\" but not \"Groups\", then is it interpreted as \"What if User were not a member of any groups",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectAccessReviewStatus": {
       "description": "SubjectAccessReviewStatus",
-      "type": "object",
-      "required": [
-        "allowed"
-      ],
       "properties": {
         "allowed": {
-          "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
+          "description": "Allowed is required. True if the action would be allowed, false otherwise.",
+          "type": "boolean"
+        },
+        "denied": {
+          "description": "Denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.",
           "type": "boolean"
         },
         "evaluationError": {
@@ -836,819 +466,409 @@
           "description": "Reason is optional.  It indicates why a request was allowed or denied.",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.LocalSubjectAccessReview": {
-      "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
-      "type": "object",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "LocalSubjectAccessReview",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1beta1.NonResourceAttributes": {
-      "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
-      "type": "object",
-      "properties": {
-        "path": {
-          "description": "Path is the URL path of the request",
-          "type": "string"
-        },
-        "verb": {
-          "description": "Verb is the standard HTTP verb",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.ResourceAttributes": {
-      "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
-      "type": "object",
-      "properties": {
-        "group": {
-          "description": "Group is the API Group of the Resource.  \"*\" means all.",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
-          "type": "string"
-        },
-        "resource": {
-          "description": "Resource is one of the existing resource types.  \"*\" means all.",
-          "type": "string"
-        },
-        "subresource": {
-          "description": "Subresource is one of the existing resource types.  \"\" means none.",
-          "type": "string"
-        },
-        "verb": {
-          "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
-          "type": "string"
-        },
-        "version": {
-          "description": "Version is the API Version of the Resource.  \"*\" means all.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReview": {
-      "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
-      "type": "object",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SelfSubjectAccessReview",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
-      "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "type": "object",
-      "properties": {
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceAttributes"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.SubjectAccessReview": {
-      "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
-      "type": "object",
-      "required": [
-        "spec"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec holds information about the request being evaluated",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec"
-        },
-        "status": {
-          "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "authorization.k8s.io",
-          "kind": "SubjectAccessReview",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec": {
-      "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-      "type": "object",
-      "properties": {
-        "extra": {
-          "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "group": {
-          "description": "Groups is the groups you're testing for.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nonResourceAttributes": {
-          "description": "NonResourceAttributes describes information for a non-resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.NonResourceAttributes"
-        },
-        "resourceAttributes": {
-          "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-          "$ref": "#/definitions/io.k8s.api.authorization.v1beta1.ResourceAttributes"
-        },
-        "uid": {
-          "description": "UID information about the requesting user.",
-          "type": "string"
-        },
-        "user": {
-          "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus": {
-      "description": "SubjectAccessReviewStatus",
-      "type": "object",
       "required": [
         "allowed"
       ],
-      "properties": {
-        "allowed": {
-          "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
-          "type": "boolean"
-        },
-        "evaluationError": {
-          "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Reason is optional.  It indicates why a request was allowed or denied.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
       "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "volumeID"
-      ],
       "properties": {
         "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
           "type": "string"
         },
         "partition": {
-          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
-          "type": "integer",
-          "format": "int32"
+          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+          "format": "int32",
+          "type": "integer"
         },
         "readOnly": {
-          "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
           "type": "boolean"
         },
         "volumeID": {
-          "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.Affinity": {
       "description": "Affinity is a group of affinity scheduling rules.",
-      "type": "object",
       "properties": {
         "nodeAffinity": {
-          "description": "Describes node affinity scheduling rules for the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity"
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity",
+          "description": "Describes node affinity scheduling rules for the pod."
         },
         "podAffinity": {
-          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity",
+          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
         },
         "podAntiAffinity": {
-          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity",
+          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
         }
-      }
+      },
+      "type": "object"
     },
-    "io.k8s.api.core.v1.AttachedVolume": {
-      "description": "AttachedVolume describes a volume attached to a node",
-      "type": "object",
-      "required": [
-        "name",
-        "devicePath"
-      ],
+    "io.k8s.api.core.v1.AppArmorProfile": {
+      "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
       "properties": {
-        "devicePath": {
-          "description": "DevicePath represents the device path where the volume should be available",
+        "localhostProfile": {
+          "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
           "type": "string"
         },
-        "name": {
-          "description": "Name of the attached volume",
+        "type": {
+          "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "x-kubernetes-unions": [
+        {
+          "discriminator": "type",
+          "fields-to-discriminateBy": {
+            "localhostProfile": "LocalhostProfile"
+          }
+        }
+      ]
     },
     "io.k8s.api.core.v1.AzureDiskVolumeSource": {
       "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-      "type": "object",
+      "properties": {
+        "cachingMode": {
+          "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+          "type": "string"
+        },
+        "diskName": {
+          "description": "diskName is the Name of the data disk in the blob storage",
+          "type": "string"
+        },
+        "diskURI": {
+          "description": "diskURI is the URI of data disk in the blob storage",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        }
+      },
       "required": [
         "diskName",
         "diskURI"
       ],
-      "properties": {
-        "cachingMode": {
-          "description": "Host Caching mode: None, Read Only, Read Write.",
-          "type": "string"
-        },
-        "diskName": {
-          "description": "The Name of the data disk in the blob storage",
-          "type": "string"
-        },
-        "diskURI": {
-          "description": "The URI the data disk in the blob storage",
-          "type": "string"
-        },
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Expected values Shared: mulitple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.AzureFilePersistentVolumeSource": {
-      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-      "type": "object",
-      "required": [
-        "secretName",
-        "shareName"
-      ],
-      "properties": {
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretName": {
-          "description": "the name of secret that contains Azure Storage Account Name and Key",
-          "type": "string"
-        },
-        "secretNamespace": {
-          "description": "the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod",
-          "type": "string"
-        },
-        "shareName": {
-          "description": "Share Name",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.AzureFileVolumeSource": {
       "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-      "type": "object",
+      "properties": {
+        "readOnly": {
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+          "type": "string"
+        },
+        "shareName": {
+          "description": "shareName is the azure share Name",
+          "type": "string"
+        }
+      },
       "required": [
         "secretName",
         "shareName"
       ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CSIVolumeSource": {
+      "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
       "properties": {
+        "driver": {
+          "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+          "type": "string"
+        },
+        "nodePublishSecretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+        },
         "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
           "type": "boolean"
         },
-        "secretName": {
-          "description": "the name of secret that contains Azure Storage Account Name and Key",
-          "type": "string"
-        },
-        "shareName": {
-          "description": "Share Name",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Binding": {
-      "description": "Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.",
-      "type": "object",
-      "required": [
-        "target"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "target": {
-          "description": "The target object that you want to bind to the standard object.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
+        "volumeAttributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+          "type": "object"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Binding",
-          "version": "v1"
-        }
-      ]
+      "required": [
+        "driver"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.Capabilities": {
       "description": "Adds and removes POSIX capabilities from running containers.",
-      "type": "object",
       "properties": {
         "add": {
           "description": "Added capabilities",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "drop": {
           "description": "Removed capabilities",
-          "type": "array",
           "items": {
             "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.CephFSPersistentVolumeSource": {
-      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "monitors"
-      ],
-      "properties": {
-        "monitors": {
-          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          },
           "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "path": {
-          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "boolean"
-        },
-        "secretFile": {
-          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "secretRef": {
-          "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference"
-        },
-        "user": {
-          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "string"
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.CephFSVolumeSource": {
       "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "monitors"
-      ],
       "properties": {
         "monitors": {
-          "description": "Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "type": "array",
+          "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "path": {
-          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+          "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
           "type": "string"
         },
         "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
           "type": "boolean"
         },
         "secretFile": {
-          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
           "type": "string"
         },
         "secretRef": {
-          "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
         },
         "user": {
-          "description": "Optional: User is the rados user name, default is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it",
+          "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "monitors"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.CinderVolumeSource": {
       "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "volumeID"
-      ],
       "properties": {
         "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
           "type": "string"
         },
         "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
           "type": "boolean"
         },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
+        },
         "volumeID": {
-          "description": "volume id used to identify the volume in cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
+          "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.core.v1.ClientIPConfig": {
-      "description": "ClientIPConfig represents the configurations of Client IP based session affinity.",
-      "type": "object",
-      "properties": {
-        "timeoutSeconds": {
-          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be \u003e0 \u0026\u0026 \u003c=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ComponentCondition": {
-      "description": "Information about the condition of a component.",
-      "type": "object",
+      },
       "required": [
-        "type",
-        "status"
+        "volumeID"
       ],
-      "properties": {
-        "error": {
-          "description": "Condition error code for a component. For example, a health check error code.",
-          "type": "string"
-        },
-        "message": {
-          "description": "Message about the condition for a component. For example, information about a health check.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition for a component. Valid values for \"Healthy\": \"True\", \"False\", or \"Unknown\".",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of condition for a component. Valid value: \"Healthy\"",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
-    "io.k8s.api.core.v1.ComponentStatus": {
-      "description": "ComponentStatus (and ComponentStatusList) holds the cluster validation info.",
-      "type": "object",
+    "io.k8s.api.core.v1.ClusterTrustBundleProjection": {
+      "description": "ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as \"match nothing\".  If set but empty, interpreted as \"match everything\"."
+        },
+        "name": {
+          "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.",
           "type": "string"
         },
-        "conditions": {
-          "description": "List of component conditions observed",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
+        "optional": {
+          "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.",
+          "type": "boolean"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "path": {
+          "description": "Relative path from the volume root to write the bundle.",
           "type": "string"
         },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        "signerName": {
+          "description": "Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.",
+          "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ComponentStatus",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ComponentStatusList": {
-      "description": "Status of all the conditions for the component as a list of ComponentStatus objects.",
-      "type": "object",
       "required": [
-        "items"
+        "path"
       ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of ComponentStatus objects.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentStatus"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ComponentStatusList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ConfigMap": {
-      "description": "ConfigMap holds configuration data for pods to consume.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "data": {
-          "description": "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ConfigMap",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
     "io.k8s.api.core.v1.ConfigMapEnvSource": {
       "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
-      "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "optional": {
           "description": "Specify whether the ConfigMap must be defined",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ConfigMapKeySelector": {
       "description": "Selects a key from a ConfigMap.",
-      "type": "object",
-      "required": [
-        "key"
-      ],
       "properties": {
         "key": {
           "description": "The key to select.",
           "type": "string"
         },
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "optional": {
-          "description": "Specify whether the ConfigMap or it's key must be defined",
+          "description": "Specify whether the ConfigMap or its key must be defined",
           "type": "boolean"
         }
-      }
-    },
-    "io.k8s.api.core.v1.ConfigMapList": {
-      "description": "ConfigMapList is a resource containing a list of ConfigMap objects.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of ConfigMaps.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMap"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ConfigMapList",
-          "version": "v1"
-        }
-      ]
+      "required": [
+        "key"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.ConfigMapProjection": {
       "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
-      "type": "object",
       "properties": {
         "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "optional": {
-          "description": "Specify whether the ConfigMap or it's keys must be defined",
+          "description": "optional specify whether the ConfigMap or its keys must be defined",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ConfigMapVolumeSource": {
       "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
-      "type": "object",
       "properties": {
         "defaultMode": {
-          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
+          "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
         },
         "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "optional": {
-          "description": "Specify whether the ConfigMap or it's keys must be defined",
+          "description": "optional specify whether the ConfigMap or its keys must be defined",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.Container": {
       "description": "A single application container that you want to run within a pod.",
-      "type": "object",
-      "required": [
-        "name",
-        "image"
-      ],
       "properties": {
         "args": {
-          "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
-          "type": "array",
+          "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "command": {
-          "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
-          "type": "array",
+          "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "env": {
           "description": "List of environment variables to set in the container. Cannot be updated.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge"
         },
         "envFrom": {
-          "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
-          "type": "array",
+          "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "image": {
-          "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+          "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
           "type": "string"
         },
         "imagePullPolicy": {
@@ -1656,37 +876,66 @@
           "type": "string"
         },
         "lifecycle": {
-          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle"
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
+          "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated."
         },
         "livenessProbe": {
-          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
         },
         "name": {
           "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
           "type": "string"
         },
         "ports": {
-          "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
-          "type": "array",
+          "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "containerPort",
+            "protocol"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "containerPort",
           "x-kubernetes-patch-strategy": "merge"
         },
         "readinessProbe": {
-          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Probe"
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+        },
+        "resizePolicy": {
+          "description": "Resources resize policy for the container. This field cannot be set on ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
-          "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+        },
+        "restartPolicy": {
+          "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Additionally, setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+          "type": "string"
+        },
+        "restartPolicyRules": {
+          "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod's RestartPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "securityContext": {
-          "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://git.k8s.io/community/contributors/design-proposals/security_context.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+          "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
         },
         "stdin": {
           "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
@@ -1708,12 +957,29 @@
           "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
           "type": "boolean"
         },
+        "volumeDevices": {
+          "description": "volumeDevices is the list of block devices to be used by the container.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "devicePath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "devicePath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
         "volumeMounts": {
           "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "mountPath"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "mountPath",
           "x-kubernetes-patch-strategy": "merge"
         },
@@ -1721,107 +987,166 @@
           "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.core.v1.ContainerImage": {
-      "description": "Describe a container image",
-      "type": "object",
+      },
       "required": [
-        "names"
+        "name"
       ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerExtendedResourceRequest": {
+      "description": "ContainerExtendedResourceRequest has the mapping of container name, extended resource name to the device request name.",
       "properties": {
-        "names": {
-          "description": "Names by which this image is known. e.g. [\"gcr.io/google_containers/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "containerName": {
+          "description": "The name of the container requesting resources.",
+          "type": "string"
         },
-        "sizeBytes": {
-          "description": "The size of the image in bytes.",
-          "type": "integer",
-          "format": "int64"
+        "requestName": {
+          "description": "The name of the request in the special ResourceClaim which corresponds to the extended resource.",
+          "type": "string"
+        },
+        "resourceName": {
+          "description": "The name of the extended resource in that container which gets backed by DRA.",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "containerName",
+        "resourceName",
+        "requestName"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.ContainerPort": {
       "description": "ContainerPort represents a network port in a single container.",
-      "type": "object",
-      "required": [
-        "containerPort"
-      ],
       "properties": {
         "containerPort": {
-          "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 \u003c x \u003c 65536.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+          "format": "int32",
+          "type": "integer"
         },
         "hostIP": {
           "description": "What host IP to bind the external port to.",
           "type": "string"
         },
         "hostPort": {
-          "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 \u003c x \u003c 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+          "format": "int32",
+          "type": "integer"
         },
         "name": {
           "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
           "type": "string"
         },
         "protocol": {
-          "description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\".",
+          "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "containerPort"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerResizePolicy": {
+      "description": "ContainerResizePolicy represents resource resize policy for the container.",
+      "properties": {
+        "resourceName": {
+          "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+          "type": "string"
+        },
+        "restartPolicy": {
+          "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resourceName",
+        "restartPolicy"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerRestartRule": {
+      "description": "ContainerRestartRule describes how a container exit is handled.",
+      "properties": {
+        "action": {
+          "description": "Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is \"Restart\" to restart the container.",
+          "type": "string"
+        },
+        "exitCodes": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes",
+          "description": "Represents the exit codes to check on container exits."
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes": {
+      "description": "ContainerRestartRuleOnExitCodes describes the condition for handling an exited container based on its exit codes.",
+      "properties": {
+        "operator": {
+          "description": "Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+          "type": "string"
+        },
+        "values": {
+          "description": "Specifies the set of values to check for container exit codes. At most 255 elements are allowed.",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        }
+      },
+      "required": [
+        "operator"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.ContainerState": {
       "description": "ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.",
-      "type": "object",
       "properties": {
         "running": {
-          "description": "Details about a running container",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateRunning"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateRunning",
+          "description": "Details about a running container"
         },
         "terminated": {
-          "description": "Details about a terminated container",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateTerminated"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateTerminated",
+          "description": "Details about a terminated container"
         },
         "waiting": {
-          "description": "Details about a waiting container",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateWaiting"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateWaiting",
+          "description": "Details about a waiting container"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ContainerStateRunning": {
       "description": "ContainerStateRunning is a running state of a container.",
-      "type": "object",
       "properties": {
         "startedAt": {
-          "description": "Time at which the container was last (re-)started",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which the container was last (re-)started"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ContainerStateTerminated": {
       "description": "ContainerStateTerminated is a terminated state of a container.",
-      "type": "object",
-      "required": [
-        "exitCode"
-      ],
       "properties": {
         "containerID": {
-          "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'",
+          "description": "Container's ID in the format '<type>://<container_id>'",
           "type": "string"
         },
         "exitCode": {
           "description": "Exit status from the last termination of the container",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "finishedAt": {
-          "description": "Time at which the container last terminated",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which the container last terminated"
         },
         "message": {
           "description": "Message regarding the last termination of the container",
@@ -1833,18 +1158,21 @@
         },
         "signal": {
           "description": "Signal from the last termination of the container",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "startedAt": {
-          "description": "Time at which previous execution of the container started",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time at which previous execution of the container started"
         }
-      }
+      },
+      "required": [
+        "exitCode"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.ContainerStateWaiting": {
       "description": "ContainerStateWaiting is a waiting state of a container.",
-      "type": "object",
       "properties": {
         "message": {
           "description": "Message regarding why the container is not yet running.",
@@ -1854,11 +1182,95 @@
           "description": "(brief) reason the container is not yet running.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ContainerStatus": {
       "description": "ContainerStatus contains details for the current status of this container.",
-      "type": "object",
+      "properties": {
+        "allocatedResources": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "AllocatedResources represents the compute resources allocated for this container by the node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission and after successfully admitting desired pod resize.",
+          "type": "object"
+        },
+        "allocatedResourcesStatus": {
+          "description": "AllocatedResourcesStatus represents the status of various resources allocated for this Pod.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "containerID": {
+          "description": "ContainerID is the ID of the container in the format '<type>://<container_id>'. Where type is a container runtime identifier, returned from Version call of CRI API (for example \"containerd\").",
+          "type": "string"
+        },
+        "image": {
+          "description": "Image is the name of container image that the container is running. The container image may not match the image used in the PodSpec, as it may have been resolved by the runtime. More info: https://kubernetes.io/docs/concepts/containers/images.",
+          "type": "string"
+        },
+        "imageID": {
+          "description": "ImageID is the image ID of the container's image. The image ID may not match the image ID of the image used in the PodSpec, as it may have been resolved by the runtime.",
+          "type": "string"
+        },
+        "lastState": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
+          "description": "LastTerminationState holds the last termination state of the container to help debug container crashes and restarts. This field is not populated if the container is still running and RestartCount is 0."
+        },
+        "name": {
+          "description": "Name is a DNS_LABEL representing the unique name of the container. Each container in a pod must have a unique name across all container types. Cannot be updated.",
+          "type": "string"
+        },
+        "ready": {
+          "description": "Ready specifies whether the container is currently passing its readiness check. The value will change as readiness probes keep executing. If no readiness probes are specified, this field defaults to true once the container is fully started (see Started field).\n\nThe value is typically used to determine whether a container is ready to accept traffic.",
+          "type": "boolean"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources represents the compute resource requests and limits that have been successfully enacted on the running container after it has been started or has been successfully resized."
+        },
+        "restartCount": {
+          "description": "RestartCount holds the number of times the container has been restarted. Kubelet makes an effort to always increment the value, but there are cases when the state may be lost due to node restarts and then the value may be reset to 0. The value is never negative.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "started": {
+          "description": "Started indicates whether the container has finished its postStart lifecycle hook and passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. In both cases, startup probes will run again. Is always true when no startupProbe is defined and container is running and has passed the postStart lifecycle hook. The null value must be treated the same as false.",
+          "type": "boolean"
+        },
+        "state": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
+          "description": "State holds details about the container's current condition."
+        },
+        "stopSignal": {
+          "description": "StopSignal reports the effective stop signal for this container",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerUser",
+          "description": "User represents user identity information initially attached to the first process of the container"
+        },
+        "volumeMounts": {
+          "description": "Status of volume mounts.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMountStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "mountPath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
       "required": [
         "name",
         "ready",
@@ -1866,610 +1278,548 @@
         "image",
         "imageID"
       ],
-      "properties": {
-        "containerID": {
-          "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'.",
-          "type": "string"
-        },
-        "image": {
-          "description": "The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images",
-          "type": "string"
-        },
-        "imageID": {
-          "description": "ImageID of the container's image.",
-          "type": "string"
-        },
-        "lastState": {
-          "description": "Details about the container's last termination condition.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState"
-        },
-        "name": {
-          "description": "This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.",
-          "type": "string"
-        },
-        "ready": {
-          "description": "Specifies whether the container has passed its readiness probe.",
-          "type": "boolean"
-        },
-        "restartCount": {
-          "description": "The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "state": {
-          "description": "Details about the container's current condition.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState"
-        }
-      }
+      "type": "object"
     },
-    "io.k8s.api.core.v1.DaemonEndpoint": {
-      "description": "DaemonEndpoint contains information about a single Daemon endpoint.",
-      "type": "object",
-      "required": [
-        "Port"
-      ],
+    "io.k8s.api.core.v1.ContainerUser": {
+      "description": "ContainerUser represents user identity information",
       "properties": {
-        "Port": {
-          "description": "Port number of the given endpoint.",
-          "type": "integer",
-          "format": "int32"
+        "linux": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LinuxContainerUser",
+          "description": "Linux holds user identity information initially attached to the first process of the containers in Linux. Note that the actual running identity can be changed if the process has enough privilege to do so."
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.DownwardAPIProjection": {
       "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
-      "type": "object",
       "properties": {
         "items": {
           "description": "Items is a list of DownwardAPIVolume file",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
       "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
-      "type": "object",
-      "required": [
-        "path"
-      ],
       "properties": {
         "fieldRef": {
-          "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported."
         },
         "mode": {
-          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
         },
         "path": {
           "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
           "type": "string"
         },
         "resourceFieldRef": {
-          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
         }
-      }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
       "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
-      "type": "object",
       "properties": {
         "defaultMode": {
-          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
         },
         "items": {
           "description": "Items is a list of downward API volume file",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.EmptyDirVolumeSource": {
       "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
-      "type": "object",
       "properties": {
         "medium": {
-          "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+          "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
           "type": "string"
         },
         "sizeLimit": {
-          "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EndpointAddress": {
-      "description": "EndpointAddress is a tuple that describes single IP address.",
-      "type": "object",
-      "required": [
-        "ip"
-      ],
-      "properties": {
-        "hostname": {
-          "description": "The Hostname of this endpoint",
-          "type": "string"
-        },
-        "ip": {
-          "description": "The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.",
-          "type": "string"
-        },
-        "nodeName": {
-          "description": "Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.",
-          "type": "string"
-        },
-        "targetRef": {
-          "description": "Reference to object providing the endpoint.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EndpointPort": {
-      "description": "EndpointPort is a tuple that describes a single port.",
-      "type": "object",
-      "required": [
-        "port"
-      ],
-      "properties": {
-        "name": {
-          "description": "The name of this port (corresponds to ServicePort.Name). Must be a DNS_LABEL. Optional only if one port is defined.",
-          "type": "string"
-        },
-        "port": {
-          "description": "The port number of the endpoint.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "protocol": {
-          "description": "The IP protocol for this port. Must be UDP or TCP. Default is TCP.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.EndpointSubset": {
-      "description": "EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:\n  {\n    Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n    Ports:     [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n  }\nThe resulting set of endpoints can be viewed as:\n    a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],\n    b: [ 10.10.1.1:309, 10.10.2.2:309 ]",
-      "type": "object",
-      "properties": {
-        "addresses": {
-          "description": "IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
-          }
-        },
-        "notReadyAddresses": {
-          "description": "IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
-          }
-        },
-        "ports": {
-          "description": "Port numbers available on the related IP addresses.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointPort"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Endpoints": {
-      "description": "Endpoints is a collection of endpoints that implement the actual service. Example:\n  Name: \"mysvc\",\n  Subsets: [\n    {\n      Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n      Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n    },\n    {\n      Addresses: [{\"ip\": \"10.10.3.3\"}],\n      Ports: [{\"name\": \"a\", \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n    },\n ]",
-      "type": "object",
-      "required": [
-        "subsets"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "subsets": {
-          "description": "The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointSubset"
-          }
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Endpoints",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.EndpointsList": {
-      "description": "EndpointsList is a list of endpoints.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of endpoints.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Endpoints"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "EndpointsList",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
     "io.k8s.api.core.v1.EnvFromSource": {
-      "description": "EnvFromSource represents the source of a set of ConfigMaps",
-      "type": "object",
+      "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
       "properties": {
         "configMapRef": {
-          "description": "The ConfigMap to select from",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+          "description": "The ConfigMap to select from"
         },
         "prefix": {
-          "description": "An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+          "description": "Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.",
           "type": "string"
         },
         "secretRef": {
-          "description": "The Secret to select from",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+          "description": "The Secret to select from"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.EnvVar": {
       "description": "EnvVar represents an environment variable present in a Container.",
-      "type": "object",
-      "required": [
-        "name"
-      ],
       "properties": {
         "name": {
-          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+          "description": "Name of the environment variable. May consist of any printable ASCII characters except '='.",
           "type": "string"
         },
         "value": {
-          "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+          "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
           "type": "string"
         },
         "valueFrom": {
-          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource",
+          "description": "Source for the environment variable's value. Cannot be used if value is not empty."
         }
-      }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.EnvVarSource": {
       "description": "EnvVarSource represents a source for the value of an EnvVar.",
-      "type": "object",
       "properties": {
         "configMapKeyRef": {
-          "description": "Selects a key of a ConfigMap.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector",
+          "description": "Selects a key of a ConfigMap."
         },
         "fieldRef": {
-          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+        },
+        "fileKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FileKeySelector",
+          "description": "FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled."
         },
         "resourceFieldRef": {
-          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported."
         },
         "secretKeyRef": {
-          "description": "Selects a key of a secret in the pod's namespace",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Event": {
-      "description": "Event is a report of an event somewhere in the cluster.",
-      "type": "object",
-      "required": [
-        "metadata",
-        "involvedObject"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "count": {
-          "description": "The number of times this event has occurred.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "firstTimestamp": {
-          "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "involvedObject": {
-          "description": "The object that this event is about.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "lastTimestamp": {
-          "description": "The time at which the most recent occurrence of this event was recorded.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "A human-readable description of the status of this operation.",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "reason": {
-          "description": "This should be a short, machine understandable string that gives the reason for the transition into the object's current status.",
-          "type": "string"
-        },
-        "source": {
-          "description": "The component reporting this event. Should be a short machine understandable string.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.EventSource"
-        },
-        "type": {
-          "description": "Type of this event (Normal, Warning), new types could be added in the future",
-          "type": "string"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector",
+          "description": "Selects a key of a secret in the pod's namespace"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Event",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.core.v1.EventList": {
-      "description": "EventList is a list of events.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
+    "io.k8s.api.core.v1.EphemeralContainer": {
+      "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of events",
-          "type": "array",
+        "args": {
+          "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Event"
-          }
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "command": {
+          "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "envFrom": {
+          "description": "List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "image": {
+          "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
           "type": "string"
         },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        "imagePullPolicy": {
+          "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "type": "string"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
+          "description": "Lifecycle is not allowed for ephemeral containers."
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Probes are not allowed for ephemeral containers."
+        },
+        "name": {
+          "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+          "type": "string"
+        },
+        "ports": {
+          "description": "Ports are not allowed for ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "containerPort",
+            "protocol"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "containerPort",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Probes are not allowed for ephemeral containers."
+        },
+        "resizePolicy": {
+          "description": "Resources resize policy for the container.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod."
+        },
+        "restartPolicy": {
+          "description": "Restart policy for the container to manage the restart behavior of each container within a pod. You cannot set this field on ephemeral containers.",
+          "type": "string"
+        },
+        "restartPolicyRules": {
+          "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. You cannot set this field on ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "securityContext": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+          "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext."
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+          "description": "Probes are not allowed for ephemeral containers."
+        },
+        "stdin": {
+          "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+          "type": "boolean"
+        },
+        "stdinOnce": {
+          "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+          "type": "boolean"
+        },
+        "targetContainerName": {
+          "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.",
+          "type": "string"
+        },
+        "terminationMessagePath": {
+          "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+          "type": "string"
+        },
+        "terminationMessagePolicy": {
+          "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+          "type": "string"
+        },
+        "tty": {
+          "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+          "type": "boolean"
+        },
+        "volumeDevices": {
+          "description": "volumeDevices is the list of block devices to be used by the container.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "devicePath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "devicePath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "volumeMounts": {
+          "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "mountPath"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "workingDir": {
+          "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+          "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "EventList",
-          "version": "v1"
-        }
-      ]
+      "required": [
+        "name"
+      ],
+      "type": "object"
     },
-    "io.k8s.api.core.v1.EventSource": {
-      "description": "EventSource contains information for an event.",
-      "type": "object",
+    "io.k8s.api.core.v1.EphemeralVolumeSource": {
+      "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
       "properties": {
-        "component": {
-          "description": "Component from which the event is generated.",
-          "type": "string"
-        },
-        "host": {
-          "description": "Node name on which the event is generated.",
-          "type": "string"
+        "volumeClaimTemplate": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate",
+          "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.\n\nRequired, must not be nil."
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ExecAction": {
       "description": "ExecAction describes a \"run in container\" action.",
-      "type": "object",
       "properties": {
         "command": {
           "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.FCVolumeSource": {
       "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
-      "type": "object",
       "properties": {
         "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
           "type": "string"
         },
         "lun": {
-          "description": "Optional: FC target lun number",
-          "type": "integer",
-          "format": "int32"
+          "description": "lun is Optional: FC target lun number",
+          "format": "int32",
+          "type": "integer"
         },
         "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
           "type": "boolean"
         },
         "targetWWNs": {
-          "description": "Optional: FC target worldwide names (WWNs)",
-          "type": "array",
+          "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "wwids": {
-          "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
-          "type": "array",
+          "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.FileKeySelector": {
+      "description": "FileKeySelector selects a key of the env file.",
+      "properties": {
+        "key": {
+          "description": "The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist, an error will be returned during Pod creation.",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "The name of the volume mount containing the env file.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeName",
+        "path",
+        "key"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.FlexVolumeSource": {
-      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
-      "type": "object",
-      "required": [
-        "driver"
-      ],
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
       "properties": {
         "driver": {
-          "description": "Driver is the name of the driver to use for this volume.",
+          "description": "driver is the name of the driver to use for this volume.",
           "type": "string"
         },
         "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
           "type": "string"
         },
         "options": {
-          "description": "Optional: Extra command options if any.",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "options is Optional: this field holds extra command options if any.",
+          "type": "object"
         },
         "readOnly": {
-          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
           "type": "boolean"
         },
         "secretRef": {
-          "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
         }
-      }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.FlockerVolumeSource": {
       "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
       "properties": {
         "datasetName": {
-          "description": "Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated",
+          "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
           "type": "string"
         },
         "datasetUUID": {
-          "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+          "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
       "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "pdName"
-      ],
       "properties": {
         "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
           "type": "string"
         },
         "partition": {
-          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "type": "integer",
-          "format": "int32"
+          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "format": "int32",
+          "type": "integer"
         },
         "pdName": {
-          "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
           "type": "string"
         },
         "readOnly": {
-          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
           "type": "boolean"
         }
-      }
+      },
+      "required": [
+        "pdName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.GRPCAction": {
+      "description": "GRPCAction specifies an action involving a GRPC service.",
+      "properties": {
+        "port": {
+          "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "service": {
+          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.GitRepoVolumeSource": {
-      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "repository"
-      ],
+      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
       "properties": {
         "directory": {
-          "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+          "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
           "type": "string"
         },
         "repository": {
-          "description": "Repository URL",
+          "description": "repository is the URL",
           "type": "string"
         },
         "revision": {
-          "description": "Commit hash for the specified revision.",
+          "description": "revision is the commit hash for the specified revision.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "repository"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.GlusterfsVolumeSource": {
       "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
+      "properties": {
+        "endpoints": {
+          "description": "endpoints is the endpoint name that details Glusterfs topology.",
+          "type": "string"
+        },
+        "path": {
+          "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "boolean"
+        }
+      },
       "required": [
         "endpoints",
         "path"
       ],
-      "properties": {
-        "endpoints": {
-          "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
-          "type": "string"
-        },
-        "path": {
-          "description": "Path is the Glusterfs volume path. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod",
-          "type": "boolean"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.HTTPGetAction": {
       "description": "HTTPGetAction describes an action based on HTTP Get requests.",
-      "type": "object",
-      "required": [
-        "port"
-      ],
       "properties": {
         "host": {
           "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
@@ -2477,673 +1827,336 @@
         },
         "httpHeaders": {
           "description": "Custom headers to set in the request. HTTP allows repeated headers.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "path": {
           "description": "Path to access on the HTTP server.",
           "type": "string"
         },
         "port": {
-          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
         },
         "scheme": {
           "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "port"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.HTTPHeader": {
       "description": "HTTPHeader describes a custom header to be used in HTTP probes",
-      "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
       "properties": {
         "name": {
-          "description": "The header field name",
+          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
           "type": "string"
         },
         "value": {
           "description": "The header field value",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.core.v1.Handler": {
-      "description": "Handler defines a specific action that should be taken",
-      "type": "object",
-      "properties": {
-        "exec": {
-          "description": "One and only one of the following should be specified. Exec specifies the action to take.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
-        },
-        "httpGet": {
-          "description": "HTTPGet specifies the http request to perform.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
-        },
-        "tcpSocket": {
-          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
-          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
-        }
-      }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.HostAlias": {
       "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
-      "type": "object",
       "properties": {
         "hostnames": {
           "description": "Hostnames for the above IP address.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "ip": {
           "description": "IP address of the host file entry.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.HostIP": {
+      "description": "HostIP represents a single IP address allocated to the host.",
+      "properties": {
+        "ip": {
+          "description": "IP is the IP address assigned to the host",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.HostPathVolumeSource": {
       "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
-      "required": [
-        "path"
-      ],
       "properties": {
         "path": {
-          "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
           "type": "string"
         },
         "type": {
-          "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.ISCSIVolumeSource": {
       "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
-      "type": "object",
+      "properties": {
+        "chapAuthDiscovery": {
+          "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+          "type": "boolean"
+        },
+        "chapAuthSession": {
+          "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+          "type": "boolean"
+        },
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+          "type": "string"
+        },
+        "initiatorName": {
+          "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+          "type": "string"
+        },
+        "iqn": {
+          "description": "iqn is the target iSCSI Qualified Name.",
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+          "type": "string"
+        },
+        "lun": {
+          "description": "lun represents iSCSI Target Lun number.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "portals": {
+          "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
+        },
+        "targetPortal": {
+          "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "type": "string"
+        }
+      },
       "required": [
         "targetPortal",
         "iqn",
         "lun"
       ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ImageVolumeSource": {
+      "description": "ImageVolumeSource represents a image volume resource.",
       "properties": {
-        "chapAuthDiscovery": {
-          "description": "whether support iSCSI Discovery CHAP authentication",
-          "type": "boolean"
-        },
-        "chapAuthSession": {
-          "description": "whether support iSCSI Session CHAP authentication",
-          "type": "boolean"
-        },
-        "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+        "pullPolicy": {
+          "description": "Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
           "type": "string"
         },
-        "initiatorName": {
-          "description": "Custom iSCSI initiator name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface \u003ctarget portal\u003e:\u003cvolume name\u003e will be created for the connection.",
-          "type": "string"
-        },
-        "iqn": {
-          "description": "Target iSCSI Qualified Name.",
-          "type": "string"
-        },
-        "iscsiInterface": {
-          "description": "Optional: Defaults to 'default' (tcp). iSCSI interface name that uses an iSCSI transport.",
-          "type": "string"
-        },
-        "lun": {
-          "description": "iSCSI target lun number.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "portals": {
-          "description": "iSCSI target portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "CHAP secret for iSCSI target and initiator authentication",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "targetPortal": {
-          "description": "iSCSI target portal. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+        "reference": {
+          "description": "Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.KeyToPath": {
       "description": "Maps a string key to a path within a volume.",
-      "type": "object",
+      "properties": {
+        "key": {
+          "description": "key is the key to project.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "path": {
+          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+          "type": "string"
+        }
+      },
       "required": [
         "key",
         "path"
       ],
-      "properties": {
-        "key": {
-          "description": "The key to project.",
-          "type": "string"
-        },
-        "mode": {
-          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "path": {
-          "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.Lifecycle": {
       "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
-      "type": "object",
       "properties": {
         "postStart": {
-          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Handler"
+          "$ref": "#/definitions/io.k8s.api.core.v1.LifecycleHandler",
+          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
         },
         "preStop": {
-          "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Handler"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LimitRange": {
-      "description": "LimitRange sets resource usage limits for each kind of resource in a Namespace.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LifecycleHandler",
+          "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+        },
+        "stopSignal": {
+          "description": "StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name",
           "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeSpec"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "LimitRange",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.core.v1.LimitRangeItem": {
-      "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
-      "type": "object",
+    "io.k8s.api.core.v1.LifecycleHandler": {
+      "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
       "properties": {
-        "default": {
-          "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
+        "exec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+          "description": "Exec specifies a command to execute in the container."
         },
-        "defaultRequest": {
-          "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
+        "httpGet": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+          "description": "HTTPGet specifies an HTTP GET request to perform."
         },
-        "max": {
-          "description": "Max usage constraints on this kind by resource name.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
+        "sleep": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SleepAction",
+          "description": "Sleep represents a duration that the container should sleep."
         },
-        "maxLimitRequestRatio": {
-          "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "min": {
-          "description": "Min usage constraints on this kind by resource name.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "type": {
-          "description": "Type of resource that this limit applies to.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LimitRangeList": {
-      "description": "LimitRangeList is a list of LimitRange items.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is a list of LimitRange objects. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_limit_range.md",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRange"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        "tcpSocket": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified."
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "LimitRangeList",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.core.v1.LimitRangeSpec": {
-      "description": "LimitRangeSpec defines a min/max usage limit for resources that match on kind.",
-      "type": "object",
-      "required": [
-        "limits"
-      ],
+    "io.k8s.api.core.v1.LinuxContainerUser": {
+      "description": "LinuxContainerUser represents user identity information in Linux containers",
       "properties": {
-        "limits": {
-          "description": "Limits is the list of LimitRangeItem objects that are enforced.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeItem"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LoadBalancerIngress": {
-      "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
-      "type": "object",
-      "properties": {
-        "hostname": {
-          "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)",
-          "type": "string"
+        "gid": {
+          "description": "GID is the primary gid initially attached to the first process in the container",
+          "format": "int64",
+          "type": "integer"
         },
-        "ip": {
-          "description": "IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.LoadBalancerStatus": {
-      "description": "LoadBalancerStatus represents the status of a load-balancer.",
-      "type": "object",
-      "properties": {
-        "ingress": {
-          "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
-          "type": "array",
+        "supplementalGroups": {
+          "description": "SupplementalGroups are the supplemental groups initially attached to the first process in the container",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerIngress"
-          }
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "uid": {
+          "description": "UID is the primary uid initially attached to the first process in the container",
+          "format": "int64",
+          "type": "integer"
         }
-      }
+      },
+      "required": [
+        "uid",
+        "gid"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.LocalObjectReference": {
       "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
-      "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.core.v1.LocalVolumeSource": {
-      "description": "Local represents directly-attached storage with node affinity",
+      },
       "type": "object",
-      "required": [
-        "path"
-      ],
-      "properties": {
-        "path": {
-          "description": "The full path to the volume on the node For alpha, this path must be a directory Once block as a source is supported, then this path can point to a block device",
-          "type": "string"
-        }
-      }
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.NFSVolumeSource": {
       "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
+      "properties": {
+        "path": {
+          "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "boolean"
+        },
+        "server": {
+          "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        }
+      },
       "required": [
         "server",
         "path"
       ],
-      "properties": {
-        "path": {
-          "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "type": "boolean"
-        },
-        "server": {
-          "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Namespace": {
-      "description": "Namespace provides a scope for Names. Use of multiple namespaces is optional.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceSpec"
-        },
-        "status": {
-          "description": "Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Namespace",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NamespaceList": {
-      "description": "NamespaceList is a list of Namespaces.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Namespace"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "NamespaceList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NamespaceSpec": {
-      "description": "NamespaceSpec describes the attributes on a Namespace.",
-      "type": "object",
-      "properties": {
-        "finalizers": {
-          "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://git.k8s.io/community/contributors/design-proposals/namespaces.md#finalizers",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NamespaceStatus": {
-      "description": "NamespaceStatus is information about the current status of a Namespace.",
-      "type": "object",
-      "properties": {
-        "phase": {
-          "description": "Phase is the current lifecycle phase of the namespace. More info: https://git.k8s.io/community/contributors/design-proposals/namespaces.md#phases",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Node": {
-      "description": "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSpec"
-        },
-        "status": {
-          "description": "Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Node",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NodeAddress": {
-      "description": "NodeAddress contains information for the node's address.",
-      "type": "object",
-      "required": [
-        "type",
-        "address"
-      ],
-      "properties": {
-        "address": {
-          "description": "The node address.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.NodeAffinity": {
       "description": "Node affinity is a group of node affinity scheduling rules.",
-      "type": "object",
       "properties": {
         "preferredDuringSchedulingIgnoredDuringExecution": {
           "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "requiredDuringSchedulingIgnoredDuringExecution": {
-          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeCondition": {
-      "description": "NodeCondition contains condition information for a node.",
-      "type": "object",
-      "required": [
-        "type",
-        "status"
-      ],
-      "properties": {
-        "lastHeartbeatTime": {
-          "description": "Last time we got an update on a given condition.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "lastTransitionTime": {
-          "description": "Last time the condition transit from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "Human readable message indicating details about last transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "(brief) reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition, one of True, False, Unknown.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of node condition.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeConfigSource": {
-      "description": "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "configMapRef": {
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node."
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "NodeConfigSource",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.NodeDaemonEndpoints": {
-      "description": "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
-      "type": "object",
-      "properties": {
-        "kubeletEndpoint": {
-          "description": "Endpoint on which Kubelet is listening.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.DaemonEndpoint"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeList": {
-      "description": "NodeList is the whole list of all Nodes which have been registered with master.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of nodes",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Node"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "NodeList",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
     "io.k8s.api.core.v1.NodeSelector": {
       "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
-      "type": "object",
-      "required": [
-        "nodeSelectorTerms"
-      ],
       "properties": {
         "nodeSelectorTerms": {
           "description": "Required. A list of node selector terms. The terms are ORed.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "required": [
+        "nodeSelectorTerms"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.NodeSelectorRequirement": {
       "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-      "type": "object",
-      "required": [
-        "key",
-        "operator"
-      ],
       "properties": {
         "key": {
           "description": "The label key that the selector applies to.",
@@ -3155,197 +2168,44 @@
         },
         "values": {
           "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "required": [
+        "key",
+        "operator"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.NodeSelectorTerm": {
-      "description": "A null or empty node selector term matches no objects.",
-      "type": "object",
-      "required": [
-        "matchExpressions"
-      ],
+      "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
       "properties": {
         "matchExpressions": {
-          "description": "Required. A list of node selector requirements. The requirements are ANDed.",
-          "type": "array",
+          "description": "A list of node selector requirements by node's labels.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeSpec": {
-      "description": "NodeSpec describes the attributes that a node is created with.",
-      "type": "object",
-      "properties": {
-        "configSource": {
-          "description": "If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource"
-        },
-        "externalID": {
-          "description": "External ID of the node assigned by some machine database (e.g. a cloud provider). Deprecated.",
-          "type": "string"
-        },
-        "podCIDR": {
-          "description": "PodCIDR represents the pod IP range assigned to the node.",
-          "type": "string"
-        },
-        "providerID": {
-          "description": "ID of the node assigned by the cloud provider in the format: \u003cProviderName\u003e://\u003cProviderSpecificNodeID\u003e",
-          "type": "string"
-        },
-        "taints": {
-          "description": "If specified, the node's taints.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Taint"
-          }
-        },
-        "unschedulable": {
-          "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.NodeStatus": {
-      "description": "NodeStatus is information about the current status of a node.",
-      "type": "object",
-      "properties": {
-        "addresses": {
-          "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.NodeAddress"
           },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "allocatable": {
-          "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "capacity": {
-          "description": "Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "conditions": {
-          "description": "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition",
           "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "matchFields": {
+          "description": "A list of node selector requirements by node's fields.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.NodeCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
           },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "daemonEndpoints": {
-          "description": "Endpoints of daemons running on the Node.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeDaemonEndpoints"
-        },
-        "images": {
-          "description": "List of container images on this node",
           "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerImage"
-          }
-        },
-        "nodeInfo": {
-          "description": "Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSystemInfo"
-        },
-        "phase": {
-          "description": "NodePhase is the recently observed lifecycle phase of the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#phase The field is never populated, and now is deprecated.",
-          "type": "string"
-        },
-        "volumesAttached": {
-          "description": "List of volumes that are attached to the node.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.AttachedVolume"
-          }
-        },
-        "volumesInUse": {
-          "description": "List of attachable volumes in use (mounted) by the node.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "x-kubernetes-list-type": "atomic"
         }
-      }
-    },
-    "io.k8s.api.core.v1.NodeSystemInfo": {
-      "description": "NodeSystemInfo is a set of ids/uuids to uniquely identify the node.",
+      },
       "type": "object",
-      "required": [
-        "machineID",
-        "systemUUID",
-        "bootID",
-        "kernelVersion",
-        "osImage",
-        "containerRuntimeVersion",
-        "kubeletVersion",
-        "kubeProxyVersion",
-        "operatingSystem",
-        "architecture"
-      ],
-      "properties": {
-        "architecture": {
-          "description": "The Architecture reported by the node",
-          "type": "string"
-        },
-        "bootID": {
-          "description": "Boot ID reported by the node.",
-          "type": "string"
-        },
-        "containerRuntimeVersion": {
-          "description": "ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).",
-          "type": "string"
-        },
-        "kernelVersion": {
-          "description": "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
-          "type": "string"
-        },
-        "kubeProxyVersion": {
-          "description": "KubeProxy Version reported by the node.",
-          "type": "string"
-        },
-        "kubeletVersion": {
-          "description": "Kubelet Version reported by the node.",
-          "type": "string"
-        },
-        "machineID": {
-          "description": "MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html",
-          "type": "string"
-        },
-        "operatingSystem": {
-          "description": "The Operating System reported by the node",
-          "type": "string"
-        },
-        "osImage": {
-          "description": "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
-          "type": "string"
-        },
-        "systemUUID": {
-          "description": "SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html",
-          "type": "string"
-        }
-      }
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.ObjectFieldSelector": {
       "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
-      "type": "object",
-      "required": [
-        "fieldPath"
-      ],
       "properties": {
         "apiVersion": {
           "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
@@ -3355,431 +2215,135 @@
           "description": "Path of the field to select in the specified API version.",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.core.v1.ObjectReference": {
-      "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "API version of the referent.",
-          "type": "string"
-        },
-        "fieldPath": {
-          "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "namespace": {
-          "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
-          "type": "string"
-        },
-        "resourceVersion": {
-          "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
-          "type": "string"
-        },
-        "uid": {
-          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolume": {
-      "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec"
-        },
-        "status": {
-          "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeStatus"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolume",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaim": {
-      "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec"
-        },
-        "status": {
-          "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimStatus"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolumeClaim",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeClaimList": {
-      "description": "PersistentVolumeClaimList is a list of PersistentVolumeClaim items.",
-      "type": "object",
       "required": [
-        "items"
+        "fieldPath"
       ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolumeClaimList",
-          "version": "v1"
-        }
-      ]
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
       "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
-      "type": "object",
       "properties": {
         "accessModes": {
-          "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-          "type": "array",
+          "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "dataSource": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
+          "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource."
+        },
+        "dataSourceRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedObjectReference",
+          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled."
         },
         "resources": {
-          "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+          "$ref": "#/definitions/io.k8s.api.core.v1.VolumeResourceRequirements",
+          "description": "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
         },
         "selector": {
-          "description": "A label query over volumes to consider for binding.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "selector is a label query over volumes to consider for binding."
         },
         "storageClassName": {
-          "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+          "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+          "type": "string"
+        },
+        "volumeAttributesClassName": {
+          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string or nil value indicates that no VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state, this field can be reset to its previous value (including nil) to cancel the modification. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+          "type": "string"
+        },
+        "volumeMode": {
+          "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
           "type": "string"
         },
         "volumeName": {
-          "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
-      "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
-      "type": "object",
+    "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+      "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
       "properties": {
-        "accessModes": {
-          "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation."
         },
-        "capacity": {
-          "description": "Represents the actual resources of the underlying volume.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "phase": {
-          "description": "Phase represents the current phase of PersistentVolumeClaim.",
-          "type": "string"
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
+          "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here."
         }
-      }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
       "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
-      "type": "object",
-      "required": [
-        "claimName"
-      ],
       "properties": {
         "claimName": {
-          "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+          "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
           "type": "string"
         },
         "readOnly": {
-          "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+          "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
           "type": "boolean"
         }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolumeList": {
-      "description": "PersistentVolumeList is a list of PersistentVolume items.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolume"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PersistentVolumeList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PersistentVolumeSpec": {
-      "description": "PersistentVolumeSpec is the specification of a persistent volume.",
-      "type": "object",
-      "properties": {
-        "accessModes": {
-          "description": "AccessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "awsElasticBlockStore": {
-          "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
-        },
-        "azureDisk": {
-          "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource"
-        },
-        "azureFile": {
-          "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFilePersistentVolumeSource"
-        },
-        "capacity": {
-          "description": "A description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "cephfs": {
-          "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSPersistentVolumeSource"
-        },
-        "cinder": {
-          "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource"
-        },
-        "claimRef": {
-          "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "fc": {
-          "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource"
-        },
-        "flexVolume": {
-          "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource"
-        },
-        "flocker": {
-          "description": "Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource"
-        },
-        "gcePersistentDisk": {
-          "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
-        },
-        "glusterfs": {
-          "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource"
-        },
-        "hostPath": {
-          "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
-        },
-        "iscsi": {
-          "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
-        },
-        "local": {
-          "description": "Local represents directly-attached storage with node affinity",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalVolumeSource"
-        },
-        "mountOptions": {
-          "description": "A list of mount options, e.g. [\"ro\", \"soft\"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nfs": {
-          "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource"
-        },
-        "persistentVolumeReclaimPolicy": {
-          "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recycling must be supported by the volume plugin underlying this persistent volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming",
-          "type": "string"
-        },
-        "photonPersistentDisk": {
-          "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
-        },
-        "portworxVolume": {
-          "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource"
-        },
-        "quobyte": {
-          "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource"
-        },
-        "rbd": {
-          "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource"
-        },
-        "scaleIO": {
-          "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource"
-        },
-        "storageClassName": {
-          "description": "Name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.",
-          "type": "string"
-        },
-        "storageos": {
-          "description": "StorageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://releases.k8s.io/HEAD/examples/volumes/storageos/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSPersistentVolumeSource"
-        },
-        "vsphereVolume": {
-          "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PersistentVolumeStatus": {
-      "description": "PersistentVolumeStatus is the current status of a persistent volume.",
-      "type": "object",
-      "properties": {
-        "message": {
-          "description": "A human-readable message indicating details about why the volume is in this state.",
-          "type": "string"
-        },
-        "phase": {
-          "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.",
-          "type": "string"
-        }
-      }
+      "required": [
+        "claimName"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
       "description": "Represents a Photon Controller persistent disk resource.",
-      "type": "object",
-      "required": [
-        "pdID"
-      ],
       "properties": {
         "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
           "type": "string"
         },
         "pdID": {
-          "description": "ID that identifies Photon Controller persistent disk",
+          "description": "pdID is the ID that identifies Photon Controller persistent disk",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "pdID"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.Pod": {
       "description": "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
-      "type": "object",
       "properties": {
         "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
           "type": "string"
         },
         "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
+          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodStatus"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodStatus",
+          "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "type": "object",
       "x-kubernetes-group-version-kind": [
         {
           "group": "",
@@ -3790,84 +2354,154 @@
     },
     "io.k8s.api.core.v1.PodAffinity": {
       "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
-      "type": "object",
       "properties": {
         "preferredDuringSchedulingIgnoredDuringExecution": {
           "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "requiredDuringSchedulingIgnoredDuringExecution": {
           "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodAffinityTerm": {
-      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e tches that of any node on which a pod of the set of pods is running",
-      "type": "object",
+      "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
       "properties": {
         "labelSelector": {
-          "description": "A label query over a set of resources, in this case pods.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods."
         },
-        "namespaces": {
-          "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
-          "type": "array",
+        "matchLabelKeys": {
+          "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "mismatchLabelKeys": {
+          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
+        },
+        "namespaces": {
+          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "topologyKey": {
-          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. For PreferredDuringScheduling pod anti-affinity, empty topologyKey is interpreted as \"all topologies\" (\"all topologies\" here means all the topologyKeys indicated by scheduler command-line argument --failure-domains); for affinity and for RequiredDuringScheduling pod anti-affinity, empty topologyKey is not allowed.",
+          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "topologyKey"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodAntiAffinity": {
       "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
-      "type": "object",
       "properties": {
         "preferredDuringSchedulingIgnoredDuringExecution": {
-          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-          "type": "array",
+          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and subtracting \"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "requiredDuringSchedulingIgnoredDuringExecution": {
           "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodCertificateProjection": {
+      "description": "PodCertificateProjection provides a private key and X.509 certificate in the pod filesystem.",
+      "properties": {
+        "certificateChainPath": {
+          "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+          "type": "string"
+        },
+        "credentialBundlePath": {
+          "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks. The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private key.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued certificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single atomic read that retrieves a consistent key and certificate chain.  If you project them to separate files, your application code will need to additionally check that the leaf certificate was issued to the key.",
+          "type": "string"
+        },
+        "keyPath": {
+          "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+          "type": "string"
+        },
+        "keyType": {
+          "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\", \"ECDSAP521\", and \"ED25519\".",
+          "type": "string"
+        },
+        "maxExpirationSeconds": {
+          "description": "maxExpirationSeconds is the maximum lifetime permitted for the certificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it generates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "signerName": {
+          "description": "Kubelet's generated CSRs will be addressed to this signer.",
+          "type": "string"
+        },
+        "userAnnotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "signerName",
+        "keyType"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodCondition": {
       "description": "PodCondition contains details for the current condition of this pod.",
-      "type": "object",
-      "required": [
-        "type",
-        "status"
-      ],
       "properties": {
         "lastProbeTime": {
-          "description": "Last time we probed the condition.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time we probed the condition."
         },
         "lastTransitionTime": {
-          "description": "Last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
           "description": "Human-readable message indicating details about last transition.",
           "type": "string"
+        },
+        "observedGeneration": {
+          "description": "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+          "format": "int64",
+          "type": "integer"
         },
         "reason": {
           "description": "Unique, one-word, CamelCase reason for the condition's last transition.",
@@ -3878,93 +2512,253 @@
           "type": "string"
         },
         "type": {
-          "description": "Type is the type of the condition. Currently only Ready. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+          "description": "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
           "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodList": {
-      "description": "PodList is a list of Pods.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of pods. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PodList",
-          "version": "v1"
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodDNSConfig": {
+      "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+      "properties": {
+        "nameservers": {
+          "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "options": {
+          "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfigOption"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "searches": {
+          "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      ]
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodDNSConfigOption": {
+      "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+      "properties": {
+        "name": {
+          "description": "Name is this DNS resolver option's name. Required.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value is this DNS resolver option's value.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodExtendedResourceClaimStatus": {
+      "description": "PodExtendedResourceClaimStatus is stored in the PodStatus for the extended resource requests backed by DRA. It stores the generated name for the corresponding special ResourceClaim created by the scheduler.",
+      "properties": {
+        "requestMappings": {
+          "description": "RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request in the generated ResourceClaim.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerExtendedResourceRequest"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "requestMappings",
+        "resourceClaimName"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodIP": {
+      "description": "PodIP represents a single IP address allocated to the pod.",
+      "properties": {
+        "ip": {
+          "description": "IP is the IP address assigned to the pod",
+          "type": "string"
+        }
+      },
+      "required": [
+        "ip"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodOS": {
+      "description": "PodOS defines the OS parameters of a pod.",
+      "properties": {
+        "name": {
+          "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodReadinessGate": {
+      "description": "PodReadinessGate contains the reference to a pod condition",
+      "properties": {
+        "conditionType": {
+          "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditionType"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodResourceClaim": {
+      "description": "PodResourceClaim references exactly one ResourceClaim, either directly or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim for the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+      "properties": {
+        "name": {
+          "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+          "type": "string"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+          "type": "string"
+        },
+        "resourceClaimTemplateName": {
+          "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodResourceClaimStatus": {
+      "description": "PodResourceClaimStatus is stored in the PodStatus for each PodResourceClaim which references a ResourceClaimTemplate. It stores the generated name for the corresponding ResourceClaim.",
+      "properties": {
+        "name": {
+          "description": "Name uniquely identifies this resource claim inside the pod. This must match the name of an entry in pod.spec.resourceClaims, which implies that the string must be a DNS_LABEL.",
+          "type": "string"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSchedulingGate": {
+      "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+      "properties": {
+        "name": {
+          "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodSecurityContext": {
       "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
-      "type": "object",
       "properties": {
+        "appArmorProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
+          "description": "appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
+        },
         "fsGroup": {
-          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
-          "type": "integer",
-          "format": "int64"
+          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
         },
         "runAsNonRoot": {
           "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
           "type": "boolean"
         },
         "runAsUser": {
-          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
-          "type": "integer",
-          "format": "int64"
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxChangePolicy": {
+          "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod. It has no effect on nodes that do not support SELinux or to volumes does not support SELinux. Valid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime. This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option. This requires all Pods that share the same volume to use the same SELinux label. It is not possible to share the same volume among privileged and unprivileged Pods. Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their CSIDriver instance. Other volumes are always re-labelled recursively. \"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used. If not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes and \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
         },
         "seLinuxOptions": {
-          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows."
+        },
+        "seccompProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
+          "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
         },
         "supplementalGroups": {
-          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
-          "type": "array",
+          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID and fsGroup (if specified).  If the SupplementalGroupsPolicy feature is enabled, the supplementalGroupsPolicy field determines whether these are in addition to or instead of any group memberships defined in the container image. If unspecified, no additional groups are added, though group memberships defined in the container image may still be used, depending on the supplementalGroupsPolicy field. Note that this field cannot be set when spec.os.name is windows.",
           "items": {
-            "type": "integer",
-            "format": "int64"
-          }
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "supplementalGroupsPolicy": {
+          "description": "Defines how supplemental groups of the first container processes are calculated. Valid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
+        "sysctls": {
+          "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux."
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodSpec": {
       "description": "PodSpec is a description of a pod.",
-      "type": "object",
-      "required": [
-        "containers"
-      ],
       "properties": {
         "activeDeadlineSeconds": {
           "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "affinity": {
-          "description": "If specified, the pod's scheduling constraints",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+          "$ref": "#/definitions/io.k8s.api.core.v1.Affinity",
+          "description": "If specified, the pod's scheduling constraints"
         },
         "automountServiceAccountToken": {
           "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
@@ -3972,23 +2766,52 @@
         },
         "containers": {
           "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Container"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge"
         },
+        "dnsConfig": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfig",
+          "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy."
+        },
         "dnsPolicy": {
-          "description": "Set DNS policy for containers within the pod. One of 'ClusterFirstWithHostNet', 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\". To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+          "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
           "type": "string"
         },
-        "hostAliases": {
-          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+        "enableServiceLinks": {
+          "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+          "type": "boolean"
+        },
+        "ephemeralContainers": {
+          "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralContainer"
+          },
           "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "hostAliases": {
+          "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "ip"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "ip",
           "x-kubernetes-patch-strategy": "merge"
         },
@@ -3997,736 +2820,664 @@
           "type": "boolean"
         },
         "hostNetwork": {
-          "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+          "description": "Host networking requested for this pod. Use the host's network namespace. When using HostNetwork you should specify ports so the scheduler is aware. When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`, and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`. Default to false.",
           "type": "boolean"
         },
         "hostPID": {
           "description": "Use the host's pid namespace. Optional: Default to false.",
           "type": "boolean"
         },
+        "hostUsers": {
+          "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+          "type": "boolean"
+        },
         "hostname": {
           "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
           "type": "string"
         },
+        "hostnameOverride": {
+          "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod. This field only specifies the pod's hostname and does not affect its DNS records. When this field is set to a non-empty string: - It takes precedence over the values set in `hostname` and `subdomain`. - The Pod's hostname will be set to this value. - `setHostnameAsFQDN` must be nil or set to false. - `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters. Requires the HostnameOverride feature gate to be enabled.",
+          "type": "string"
+        },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
-          "type": "array",
+          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge"
         },
         "initContainers": {
-          "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
-          "type": "array",
+          "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Container"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge"
         },
         "nodeName": {
-          "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+          "description": "NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
           "type": "string"
         },
         "nodeSelector": {
-          "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
+        },
+        "os": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodOS",
+          "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.resources - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
+        },
+        "overhead": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+          "type": "object"
+        },
+        "preemptionPolicy": {
+          "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+          "type": "string"
         },
         "priority": {
           "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "priorityClassName": {
-          "description": "If specified, indicates the pod's priority. \"SYSTEM\" is a special keyword which indicates the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+          "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
           "type": "string"
         },
+        "readinessGates": {
+          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodReadinessGate"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resourceClaims": {
+          "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.\n\nThis field is immutable.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaim"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for \"cpu\", \"memory\" and \"hugepages-\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the entire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature gate."
+        },
         "restartPolicy": {
-          "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+          "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
           "type": "string"
         },
         "schedulerName": {
           "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
           "type": "string"
         },
+        "schedulingGates": {
+          "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodSchedulingGate"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
         "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+          "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
         },
         "serviceAccount": {
-          "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+          "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
           "type": "string"
         },
         "serviceAccountName": {
           "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
           "type": "string"
         },
+        "setHostnameAsFQDN": {
+          "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.",
+          "type": "boolean"
+        },
+        "shareProcessNamespace": {
+          "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+          "type": "boolean"
+        },
         "subdomain": {
-          "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all.",
+          "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
           "type": "string"
         },
         "terminationGracePeriodSeconds": {
-          "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
-          "type": "integer",
-          "format": "int64"
+          "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+          "format": "int64",
+          "type": "integer"
         },
         "tolerations": {
           "description": "If specified, the pod's tolerations.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "topologySpreadConstraints": {
+          "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "topologyKey",
+            "whenUnsatisfiable"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "topologyKey",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "volumes": {
           "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "workloadRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WorkloadReference",
+          "description": "WorkloadRef provides a reference to the Workload object that this Pod belongs to. This field is used by the scheduler to identify the PodGroup and apply the correct group scheduling policies. The Workload object referenced by this field may not exist at the time the Pod is created. This field is immutable, but a Workload object with the same name may be recreated with different policies. Doing this during pod scheduling may result in the placement not conforming to the expected policies."
         }
-      }
+      },
+      "required": [
+        "containers"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodStatus": {
-      "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system.",
-      "type": "object",
+      "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.",
       "properties": {
+        "allocatedResources": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "AllocatedResources is the total requests allocated for this pod by the node. If pod-level requests are not set, this will be the total requests aggregated across containers in the pod.",
+          "type": "object"
+        },
         "conditions": {
           "description": "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.PodCondition"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },
         "containerStatuses": {
-          "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
-          "type": "array",
+          "description": "Statuses of containers in this pod. Each container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "ephemeralContainerStatuses": {
+          "description": "Statuses for any ephemeral containers that have run in this pod. Each ephemeral container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "extendedResourceClaimStatus": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodExtendedResourceClaimStatus",
+          "description": "Status of extended resource claim backed by DRA."
         },
         "hostIP": {
-          "description": "IP address of the host to which the pod is assigned. Empty if not yet scheduled.",
+          "description": "hostIP holds the IP address of the host to which the pod is assigned. Empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns mean that HostIP will not be updated even if there is a node is assigned to pod",
           "type": "string"
         },
-        "initContainerStatuses": {
-          "description": "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
+        "hostIPs": {
+          "description": "hostIPs holds the IP addresses allocated to the host. If this field is specified, the first entry must match the hostIP field. This list is empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns means that HostIPs will not be updated even if there is a node is assigned to this pod.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.HostIP"
+          },
           "type": "array",
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "initContainerStatuses": {
+          "description": "Statuses of init containers in this pod. The most recent successful non-restartable init container will have ready = true, the most recently started container will have startTime set. Each init container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "message": {
           "description": "A human readable message indicating details about why the pod is in this condition.",
           "type": "string"
         },
+        "nominatedNodeName": {
+          "description": "nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be scheduled right away as preemption victims receive their graceful termination periods. This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to give the resources on this node to a higher priority pod that is created after preemption. As a result, this field may be different than PodSpec.nodeName when the pod is scheduled.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "If set, this represents the .metadata.generation that the pod status was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
+          "format": "int64",
+          "type": "integer"
+        },
         "phase": {
-          "description": "Current condition of the pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase",
+          "description": "The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:\n\nPending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.\n\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase",
           "type": "string"
         },
         "podIP": {
-          "description": "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
+          "description": "podIP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
           "type": "string"
         },
+        "podIPs": {
+          "description": "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodIP"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "ip"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
         "qosClass": {
-          "description": "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md",
+          "description": "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes",
           "type": "string"
         },
         "reason": {
           "description": "A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'",
           "type": "string"
         },
-        "startTime": {
-          "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.PodTemplate": {
-      "description": "PodTemplate describes a template for creating copies of a predefined pod.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "resize": {
+          "description": "Status of resources resize desired for pod's containers. It is empty if no resources resize is pending. Any changes to container resources will automatically set this to \"Proposed\" Deprecated: Resize status is moved to two pod conditions PodResizePending and PodResizeInProgress. PodResizePending will track states where the spec has been resized, but the Kubelet has not yet allocated the resources. PodResizeInProgress will track in-progress resizes, and should be present whenever allocated resources != acknowledged resources.",
           "type": "string"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "template": {
-          "description": "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PodTemplate",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.PodTemplateList": {
-      "description": "PodTemplateList is a list of PodTemplates.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of pod templates",
-          "type": "array",
+        "resourceClaimStatuses": {
+          "description": "Status of resource claims.",
           "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplate"
-          }
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaimStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
+        "resources": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+          "description": "Resources represents the compute resource requests and limits that have been applied at the pod level if pod-level requests or limits are set in PodSpec.Resources"
         },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        "startTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "PodTemplateList",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
     "io.k8s.api.core.v1.PodTemplateSpec": {
       "description": "PodTemplateSpec describes the data a pod should have when created from a template",
-      "type": "object",
       "properties": {
         "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
+          "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.PortworxVolumeSource": {
       "description": "PortworxVolumeSource represents a Portworx volume resource.",
-      "type": "object",
-      "required": [
-        "volumeID"
-      ],
       "properties": {
         "fsType": {
-          "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
           "type": "string"
         },
         "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
           "type": "boolean"
         },
         "volumeID": {
-          "description": "VolumeID uniquely identifies a Portworx volume",
+          "description": "volumeID uniquely identifies a Portworx volume",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.PreferredSchedulingTerm": {
       "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-      "type": "object",
+      "properties": {
+        "preference": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm",
+          "description": "A node selector term, associated with the corresponding weight."
+        },
+        "weight": {
+          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
       "required": [
         "weight",
         "preference"
       ],
-      "properties": {
-        "preference": {
-          "description": "A node selector term, associated with the corresponding weight.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
-        },
-        "weight": {
-          "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.Probe": {
       "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
-      "type": "object",
       "properties": {
         "exec": {
-          "description": "One and only one of the following should be specified. Exec specifies the action to take.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+          "description": "Exec specifies a command to execute in the container."
         },
         "failureThreshold": {
           "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
+        },
+        "grpc": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.GRPCAction",
+          "description": "GRPC specifies a GRPC HealthCheckRequest."
         },
         "httpGet": {
-          "description": "HTTPGet specifies the http request to perform.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+          "description": "HTTPGet specifies an HTTP GET request to perform."
         },
         "initialDelaySeconds": {
           "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "periodSeconds": {
           "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         },
         "successThreshold": {
-          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
-          "type": "integer",
-          "format": "int32"
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+          "format": "int32",
+          "type": "integer"
         },
         "tcpSocket": {
-          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
-          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+          "description": "TCPSocket specifies a connection to a TCP port."
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+          "format": "int64",
+          "type": "integer"
         },
         "timeoutSeconds": {
           "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-          "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "type": "integer"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ProjectedVolumeSource": {
       "description": "Represents a projected volume source",
-      "type": "object",
-      "required": [
-        "sources"
-      ],
       "properties": {
         "defaultMode": {
-          "description": "Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
+          "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
         },
         "sources": {
-          "description": "list of volume projections",
-          "type": "array",
+          "description": "sources is the list of volume projections. Each entry in this list handles one source.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.QuobyteVolumeSource": {
       "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
-      "type": "object",
+      "properties": {
+        "group": {
+          "description": "group to map volume access to Default is no group",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+          "type": "boolean"
+        },
+        "registry": {
+          "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+          "type": "string"
+        },
+        "user": {
+          "description": "user to map volume access to Defaults to serivceaccount user",
+          "type": "string"
+        },
+        "volume": {
+          "description": "volume is a string that references an already created Quobyte volume by name.",
+          "type": "string"
+        }
+      },
       "required": [
         "registry",
         "volume"
       ],
-      "properties": {
-        "group": {
-          "description": "Group to map volume access to Default is no group",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
-          "type": "boolean"
-        },
-        "registry": {
-          "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
-          "type": "string"
-        },
-        "user": {
-          "description": "User to map volume access to Defaults to serivceaccount user",
-          "type": "string"
-        },
-        "volume": {
-          "description": "Volume is a string that references an already created Quobyte volume by name.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.RBDVolumeSource": {
       "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
-      "type": "object",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+          "type": "string"
+        },
+        "image": {
+          "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "keyring": {
+          "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "monitors": {
+          "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "pool": {
+          "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+        },
+        "user": {
+          "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        }
+      },
       "required": [
         "monitors",
         "image"
       ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
-          "type": "string"
-        },
-        "image": {
-          "description": "The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "keyring": {
-          "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "monitors": {
-          "description": "A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "pool": {
-          "description": "The rados pool name. Default is rbd. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "user": {
-          "description": "The rados user name. Default is admin. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
-    "io.k8s.api.core.v1.ReplicationController": {
-      "description": "ReplicationController represents the configuration of a replication controller.",
-      "type": "object",
+    "io.k8s.api.core.v1.ResourceClaim": {
+      "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "name": {
+          "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
           "type": "string"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "request": {
+          "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
           "type": "string"
-        },
-        "metadata": {
-          "description": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerSpec"
-        },
-        "status": {
-          "description": "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerStatus"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ReplicationController",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ReplicationControllerCondition": {
-      "description": "ReplicationControllerCondition describes the state of a replication controller at a certain point.",
-      "type": "object",
       "required": [
-        "type",
-        "status"
+        "name"
       ],
-      "properties": {
-        "lastTransitionTime": {
-          "description": "The last time the condition transitioned from one status to another.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "message": {
-          "description": "A human readable message indicating details about the transition.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "The reason for the condition's last transition.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the condition, one of True, False, Unknown.",
-          "type": "string"
-        },
-        "type": {
-          "description": "Type of replication controller condition.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ReplicationControllerList": {
-      "description": "ReplicationControllerList is a collection of replication controllers.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationController"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ReplicationControllerList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ReplicationControllerSpec": {
-      "description": "ReplicationControllerSpec is the specification of a replication controller.",
-      "type": "object",
-      "properties": {
-        "minReadySeconds": {
-          "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
-          "type": "integer",
-          "format": "int32"
-        },
-        "selector": {
-          "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "template": {
-          "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ReplicationControllerStatus": {
-      "description": "ReplicationControllerStatus represents the current status of a replication controller.",
-      "type": "object",
-      "required": [
-        "replicas"
-      ],
-      "properties": {
-        "availableReplicas": {
-          "description": "The number of available replicas (ready for at least minReadySeconds) for this replication controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "conditions": {
-          "description": "Represents the latest available observations of a replication controller's current state.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerCondition"
-          },
-          "x-kubernetes-patch-merge-key": "type",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "fullyLabeledReplicas": {
-          "description": "The number of pods that have labels matching the labels of the pod template of the replication controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "observedGeneration": {
-          "description": "ObservedGeneration reflects the generation of the most recently observed replication controller.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "readyReplicas": {
-          "description": "The number of ready replicas for this replication controller.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "replicas": {
-          "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.ResourceFieldSelector": {
       "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
-      "type": "object",
-      "required": [
-        "resource"
-      ],
       "properties": {
         "containerName": {
           "description": "Container name: required for volumes, optional for env vars",
           "type": "string"
         },
         "divisor": {
-          "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Specifies the output format of the exposed resources, defaults to \"1\""
         },
         "resource": {
           "description": "Required: resource to select",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.api.core.v1.ResourceQuota": {
-      "description": "ResourceQuota sets aggregate quota restrictions enforced per namespace",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaSpec"
-        },
-        "status": {
-          "description": "Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaStatus"
-        }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ResourceQuota",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ResourceQuotaList": {
-      "description": "ResourceQuotaList is a list of ResourceQuota items.",
-      "type": "object",
       "required": [
-        "items"
+        "resource"
       ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.ResourceHealth": {
+      "description": "ResourceHealth represents the health of a resource. It has the latest device health information. This is a part of KEP https://kep.k8s.io/4680.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "health": {
+          "description": "Health of the resource. can be one of:\n - Healthy: operates as normal\n - Unhealthy: reported unhealthy. We consider this a temporary health issue\n              since we do not have a mechanism today to distinguish\n              temporary and permanent issues.\n - Unknown: The status cannot be determined.\n            For example, Device Plugin got unregistered and hasn't been re-registered since.\n\nIn future we may want to introduce the PermanentlyUnhealthy Status.",
           "type": "string"
         },
-        "items": {
-          "description": "Items is a list of ResourceQuota objects. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuota"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "resourceID": {
+          "description": "ResourceID is the unique identifier of the resource. See the ResourceID type for more information.",
           "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ResourceQuotaList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ResourceQuotaSpec": {
-      "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
-      "type": "object",
-      "properties": {
-        "hard": {
-          "description": "Hard is the set of desired hard limits for each named resource. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "scopes": {
-          "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ResourceQuotaStatus": {
-      "description": "ResourceQuotaStatus defines the enforced hard limits and observed use.",
-      "type": "object",
-      "properties": {
-        "hard": {
-          "description": "Hard is the set of enforced hard limits for each named resource. More info: https://git.k8s.io/community/contributors/design-proposals/admission_control_resource_quota.md",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        },
-        "used": {
-          "description": "Used is the current observed total usage of the resource in the namespace.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
-        }
-      }
+      "required": [
+        "resourceID"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.ResourceRequirements": {
       "description": "ResourceRequirements describes the compute resource requirements.",
-      "type": "object",
       "properties": {
+        "claims": {
+          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis field depends on the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceClaim"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
         "limits": {
-          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
-          "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
+          },
+          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
         },
         "requests": {
-          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
-          "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
-          }
+          },
+          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ResourceStatus": {
+      "description": "ResourceStatus represents the status of a single resource allocated to a Pod.",
+      "properties": {
+        "name": {
+          "description": "Name of the resource. Must be unique within the pod and in case of non-DRA resource, match one of the resources from the pod spec. For DRA resources, the value must be \"claim:<claim_name>/<request>\". When this status is reported about a container, the \"claim_name\" and \"request\" must match one of the claims of this container.",
+          "type": "string"
+        },
+        "resources": {
+          "description": "List of unique resources health. Each element in the list contains an unique resource ID and its health. At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node. If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share. See ResourceID type definition for a specific format it has in various use cases.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceHealth"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "resourceID"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.SELinuxOptions": {
       "description": "SELinuxOptions are the labels to be applied to the container",
-      "type": "object",
       "properties": {
         "level": {
           "description": "Level is SELinux level label that applies to the container.",
@@ -4744,639 +3495,325 @@
           "description": "User is a SELinux user label that applies to the container.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.ScaleIOVolumeSource": {
       "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
-      "type": "object",
+      "properties": {
+        "fsType": {
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+          "type": "string"
+        },
+        "gateway": {
+          "description": "gateway is the host address of the ScaleIO API Gateway.",
+          "type": "string"
+        },
+        "protectionDomain": {
+          "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+        },
+        "sslEnabled": {
+          "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+          "type": "boolean"
+        },
+        "storageMode": {
+          "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+          "type": "string"
+        },
+        "storagePool": {
+          "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+          "type": "string"
+        },
+        "system": {
+          "description": "system is the name of the storage system as configured in ScaleIO.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+          "type": "string"
+        }
+      },
       "required": [
         "gateway",
         "system",
         "secretRef"
       ],
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "gateway": {
-          "description": "The host address of the ScaleIO API Gateway.",
-          "type": "string"
-        },
-        "protectionDomain": {
-          "description": "The name of the Protection Domain for the configured storage (defaults to \"default\").",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "sslEnabled": {
-          "description": "Flag to enable/disable SSL communication with Gateway, default false",
-          "type": "boolean"
-        },
-        "storageMode": {
-          "description": "Indicates whether the storage for a volume should be thick or thin (defaults to \"thin\").",
-          "type": "string"
-        },
-        "storagePool": {
-          "description": "The Storage Pool associated with the protection domain (defaults to \"default\").",
-          "type": "string"
-        },
-        "system": {
-          "description": "The name of the storage system as configured in ScaleIO.",
-          "type": "string"
-        },
-        "volumeName": {
-          "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
-    "io.k8s.api.core.v1.Secret": {
-      "description": "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
-      "type": "object",
+    "io.k8s.api.core.v1.SeccompProfile": {
+      "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "localhostProfile": {
+          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
           "type": "string"
-        },
-        "data": {
-          "description": "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "format": "byte"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "stringData": {
-          "description": "stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
         },
         "type": {
-          "description": "Used to facilitate programmatic handling of secret data.",
+          "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
           "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "x-kubernetes-unions": [
         {
-          "group": "",
-          "kind": "Secret",
-          "version": "v1"
+          "discriminator": "type",
+          "fields-to-discriminateBy": {
+            "localhostProfile": "LocalhostProfile"
+          }
         }
       ]
     },
     "io.k8s.api.core.v1.SecretEnvSource": {
       "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
-      "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "optional": {
           "description": "Specify whether the Secret must be defined",
           "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.SecretKeySelector": {
       "description": "SecretKeySelector selects a key of a Secret.",
-      "type": "object",
-      "required": [
-        "key"
-      ],
       "properties": {
         "key": {
           "description": "The key of the secret to select from.  Must be a valid secret key.",
           "type": "string"
         },
         "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-          "type": "string"
-        },
-        "optional": {
-          "description": "Specify whether the Secret or it's key must be defined",
-          "type": "boolean"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SecretList": {
-      "description": "SecretList is a list of Secret.",
-      "type": "object",
-      "required": [
-        "items"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "SecretList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.SecretProjection": {
-      "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
-      "type": "object",
-      "properties": {
-        "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
-        },
-        "name": {
-          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "optional": {
           "description": "Specify whether the Secret or its key must be defined",
           "type": "boolean"
         }
-      }
-    },
-    "io.k8s.api.core.v1.SecretReference": {
-      "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
+      },
+      "required": [
+        "key"
+      ],
       "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.SecretProjection": {
+      "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
       "properties": {
+        "items": {
+          "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
         "name": {
-          "description": "Name is unique within a namespace to reference a secret resource.",
+          "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
-        "namespace": {
-          "description": "Namespace defines the space within which the secret name must be unique.",
-          "type": "string"
+        "optional": {
+          "description": "optional field specify whether the Secret or its key must be defined",
+          "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.SecretVolumeSource": {
       "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
-      "type": "object",
       "properties": {
         "defaultMode": {
-          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
-          "type": "integer",
-          "format": "int32"
+          "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "format": "int32",
+          "type": "integer"
         },
         "items": {
-          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
-          "type": "array",
+          "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "optional": {
-          "description": "Specify whether the Secret or it's keys must be defined",
+          "description": "optional field specify whether the Secret or its keys must be defined",
           "type": "boolean"
         },
         "secretName": {
-          "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+          "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.SecurityContext": {
       "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
-      "type": "object",
       "properties": {
         "allowPrivilegeEscalation": {
-          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than it's parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
           "type": "boolean"
+        },
+        "appArmorProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
+          "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows."
         },
         "capabilities": {
-          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities"
+          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
+          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows."
         },
         "privileged": {
-          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
           "type": "boolean"
         },
+        "procMount": {
+          "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "string"
+        },
         "readOnlyRootFilesystem": {
-          "description": "Whether this container has a read-only root filesystem. Default is false.",
+          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
           "type": "boolean"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
         },
         "runAsNonRoot": {
           "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
           "type": "boolean"
         },
         "runAsUser": {
-          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-          "type": "integer",
-          "format": "int64"
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+          "format": "int64",
+          "type": "integer"
         },
         "seLinuxOptions": {
-          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.Service": {
-      "description": "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows."
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
+        "seccompProfile": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
+          "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows."
         },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "spec": {
-          "description": "Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceSpec"
-        },
-        "status": {
-          "description": "Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceStatus"
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux."
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Service",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.api.core.v1.ServiceAccount": {
-      "description": "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets",
-      "type": "object",
+    "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
+      "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "audience": {
+          "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
           "type": "string"
         },
-        "automountServiceAccountToken": {
-          "description": "AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.",
-          "type": "boolean"
+        "expirationSeconds": {
+          "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+          "format": "int64",
+          "type": "integer"
         },
-        "imagePullSecrets": {
-          "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "path": {
+          "description": "path is the path relative to the mount point of the file to project the token into.",
           "type": "string"
-        },
-        "metadata": {
-          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
-        },
-        "secrets": {
-          "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ServiceAccount",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServiceAccountList": {
-      "description": "ServiceAccountList is a list of ServiceAccount objects",
-      "type": "object",
       "required": [
-        "items"
+        "path"
       ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SleepAction": {
+      "description": "SleepAction describes a \"sleep\" action.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccount"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        "seconds": {
+          "description": "Seconds is the number of seconds to sleep.",
+          "format": "int64",
+          "type": "integer"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ServiceAccountList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServiceList": {
-      "description": "ServiceList holds a list of services.",
-      "type": "object",
       "required": [
-        "items"
+        "seconds"
       ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of services",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.Service"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "ServiceList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.api.core.v1.ServicePort": {
-      "description": "ServicePort contains information on service's port.",
-      "type": "object",
-      "required": [
-        "port"
-      ],
-      "properties": {
-        "name": {
-          "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. This maps to the 'Name' field in EndpointPort objects. Optional if only one ServicePort is defined on this service.",
-          "type": "string"
-        },
-        "nodePort": {
-          "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
-          "type": "integer",
-          "format": "int32"
-        },
-        "port": {
-          "description": "The port that will be exposed by this service.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "protocol": {
-          "description": "The IP protocol for this port. Supports \"TCP\" and \"UDP\". Default is TCP.",
-          "type": "string"
-        },
-        "targetPort": {
-          "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ServiceSpec": {
-      "description": "ServiceSpec describes the attributes that a user creates on a service.",
-      "type": "object",
-      "properties": {
-        "clusterIP": {
-          "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "string"
-        },
-        "externalIPs": {
-          "description": "externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "externalName": {
-          "description": "externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires Type to be ExternalName.",
-          "type": "string"
-        },
-        "externalTrafficPolicy": {
-          "description": "externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. \"Local\" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. \"Cluster\" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.",
-          "type": "string"
-        },
-        "healthCheckNodePort": {
-          "description": "healthCheckNodePort specifies the healthcheck nodePort for the service. If not specified, HealthCheckNodePort is created by the service api backend with the allocated nodePort. Will use user-specified nodePort value if specified by the client. Only effects when Type is set to LoadBalancer and ExternalTrafficPolicy is set to Local.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "loadBalancerIP": {
-          "description": "Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.",
-          "type": "string"
-        },
-        "loadBalancerSourceRanges": {
-          "description": "If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.\" More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "ports": {
-          "description": "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.core.v1.ServicePort"
-          },
-          "x-kubernetes-patch-merge-key": "port",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "publishNotReadyAddresses": {
-          "description": "publishNotReadyAddresses, when set to true, indicates that DNS implementations must publish the notReadyAddresses of subsets for the Endpoints associated with the Service. The default value is false. The primary use case for setting this field is to use a StatefulSet's Headless Service to propagate SRV records for its Pods without respect to their readiness for purpose of peer discovery. This field will replace the service.alpha.kubernetes.io/tolerate-unready-endpoints when that annotation is deprecated and all clients have been converted to use this field.",
-          "type": "boolean"
-        },
-        "selector": {
-          "description": "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "sessionAffinity": {
-          "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
-          "type": "string"
-        },
-        "sessionAffinityConfig": {
-          "description": "sessionAffinityConfig contains the configurations of session affinity.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SessionAffinityConfig"
-        },
-        "type": {
-          "description": "type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. \"ExternalName\" maps to the specified externalName. \"ClusterIP\" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object. If clusterIP is \"None\", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a stable IP. \"NodePort\" builds on ClusterIP and allocates a port on every node which routes to the clusterIP. \"LoadBalancer\" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.ServiceStatus": {
-      "description": "ServiceStatus represents the current status of a service.",
-      "type": "object",
-      "properties": {
-        "loadBalancer": {
-          "description": "LoadBalancer contains the current status of the load-balancer, if one is present.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.SessionAffinityConfig": {
-      "description": "SessionAffinityConfig represents the configurations of session affinity.",
-      "type": "object",
-      "properties": {
-        "clientIP": {
-          "description": "clientIP contains the configurations of Client IP based session affinity.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ClientIPConfig"
-        }
-      }
-    },
-    "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
-      "description": "Represents a StorageOS persistent volume resource.",
-      "type": "object",
-      "properties": {
-        "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-          "type": "string"
-        },
-        "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
-          "type": "boolean"
-        },
-        "secretRef": {
-          "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
-        },
-        "volumeName": {
-          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
-          "type": "string"
-        },
-        "volumeNamespace": {
-          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.StorageOSVolumeSource": {
       "description": "Represents a StorageOS persistent volume resource.",
-      "type": "object",
       "properties": {
         "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
           "type": "string"
         },
         "readOnly": {
-          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
           "type": "boolean"
         },
         "secretRef": {
-          "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+          "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
         },
         "volumeName": {
-          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+          "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
           "type": "string"
         },
         "volumeNamespace": {
-          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+          "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Sysctl": {
+      "description": "Sysctl defines a kernel parameter to be set",
+      "properties": {
+        "name": {
+          "description": "Name of a property to set",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of a property to set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.TCPSocketAction": {
       "description": "TCPSocketAction describes an action based on opening a socket",
-      "type": "object",
-      "required": [
-        "port"
-      ],
       "properties": {
         "host": {
           "description": "Optional: Host name to connect to, defaults to the pod IP.",
           "type": "string"
         },
         "port": {
-          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
         }
-      }
-    },
-    "io.k8s.api.core.v1.Taint": {
-      "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
-      "type": "object",
+      },
       "required": [
-        "key",
-        "effect"
+        "port"
       ],
-      "properties": {
-        "effect": {
-          "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
-          "type": "string"
-        },
-        "key": {
-          "description": "Required. The taint key to be applied to a node.",
-          "type": "string"
-        },
-        "timeAdded": {
-          "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "value": {
-          "description": "Required. The taint value corresponding to the taint key.",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "io.k8s.api.core.v1.Toleration": {
-      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
-      "type": "object",
+      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
       "properties": {
         "effect": {
           "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
@@ -5387,150 +3824,279 @@
           "type": "string"
         },
         "operator": {
-          "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+          "description": "Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
           "type": "string"
         },
         "tolerationSeconds": {
           "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-          "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "type": "integer"
         },
         "value": {
           "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TopologySpreadConstraint": {
+      "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+      "properties": {
+        "labelSelector": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain."
+        },
+        "matchLabelKeys": {
+          "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "maxSkew": {
+          "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "minDomains": {
+          "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "nodeAffinityPolicy": {
+          "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+          "type": "string"
+        },
+        "nodeTaintsPolicy": {
+          "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+          "type": "string"
+        },
+        "topologyKey": {
+          "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+          "type": "string"
+        },
+        "whenUnsatisfiable": {
+          "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "maxSkew",
+        "topologyKey",
+        "whenUnsatisfiable"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.TypedLocalObjectReference": {
+      "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.TypedObjectReference": {
+      "description": "TypedObjectReference contains enough information to let you locate the typed referenced object",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is the type of resource being referenced",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.Volume": {
       "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
-      "type": "object",
-      "required": [
-        "name"
-      ],
       "properties": {
         "awsElasticBlockStore": {
-          "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+          "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
         },
         "azureDisk": {
-          "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
+          "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod. Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type are redirected to the disk.csi.azure.com CSI driver."
         },
         "azureFile": {
-          "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource",
+          "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod. Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type are redirected to the file.csi.azure.com CSI driver."
         },
         "cephfs": {
-          "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource",
+          "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime. Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported."
         },
         "cinder": {
-          "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource",
+          "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. Deprecated: Cinder is deprecated. All operations for the in-tree cinder type are redirected to the cinder.csi.openstack.org CSI driver. More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
         },
         "configMap": {
-          "description": "ConfigMap represents a configMap that should populate this volume",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource",
+          "description": "configMap represents a configMap that should populate this volume"
+        },
+        "csi": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.CSIVolumeSource",
+          "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers."
         },
         "downwardAPI": {
-          "description": "DownwardAPI represents downward API about the pod that should populate this volume",
-          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource",
+          "description": "downwardAPI represents downward API about the pod that should populate this volume"
         },
         "emptyDir": {
-          "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-          "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
+          "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
+        },
+        "ephemeral": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralVolumeSource",
+          "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.\n\nUse this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.\n\nA pod can use both types of ephemeral volumes and persistent volumes at the same time."
         },
         "fc": {
-          "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
+          "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
         },
         "flexVolume": {
-          "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource",
+          "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead."
         },
         "flocker": {
-          "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
-          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
+          "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running. Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported."
         },
         "gcePersistentDisk": {
-          "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+          "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
         },
         "gitRepo": {
-          "description": "GitRepo represents a git repository at a particular revision.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource",
+          "description": "gitRepo represents a git repository at a particular revision. Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container."
         },
         "glusterfs": {
-          "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource",
+          "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported."
         },
         "hostPath": {
-          "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
+          "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+        },
+        "image": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ImageVolumeSource",
+          "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33. The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type."
         },
         "iscsi": {
-          "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource",
+          "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi"
         },
         "name": {
-          "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
         },
         "nfs": {
-          "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
+          "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
         },
         "persistentVolumeClaim": {
-          "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource",
+          "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
         },
         "photonPersistentDisk": {
-          "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+          "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine. Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported."
         },
         "portworxVolume": {
-          "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
+          "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine. Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate is on."
         },
         "projected": {
-          "description": "Items for all in one resources secrets, configmaps, and downward API",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource",
+          "description": "projected items for all in one resources secrets, configmaps, and downward API"
         },
         "quobyte": {
-          "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
-          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
+          "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime. Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported."
         },
         "rbd": {
-          "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md",
-          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource",
+          "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported."
         },
         "scaleIO": {
-          "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource",
+          "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes. Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported."
         },
         "secret": {
-          "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource",
+          "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
         },
         "storageos": {
-          "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource",
+          "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported."
         },
         "vsphereVolume": {
-          "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
-          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
+          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+          "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine. Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type are redirected to the csi.vsphere.vmware.com CSI driver."
         }
-      }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeDevice": {
+      "description": "volumeDevice describes a mapping of a raw block device within a container.",
+      "properties": {
+        "devicePath": {
+          "description": "devicePath is the path inside of the container that the device will be mapped to.",
+          "type": "string"
+        },
+        "name": {
+          "description": "name must match the name of a persistentVolumeClaim in the pod",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "devicePath"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.VolumeMount": {
       "description": "VolumeMount describes a mounting of a Volume within a container.",
-      "required": [
-        "name",
-        "mountPath"
-      ],
       "properties": {
         "mountPath": {
           "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+          "type": "string"
+        },
+        "mountPropagation": {
+          "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).",
           "type": "string"
         },
         "name": {
@@ -5541,666 +4107,1112 @@
           "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
           "type": "boolean"
         },
+        "recursiveReadOnly": {
+          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled recursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+          "type": "string"
+        },
         "subPath": {
           "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
           "type": "string"
+        },
+        "subPathExpr": {
+          "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "name",
+        "mountPath"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeMountStatus": {
+      "description": "VolumeMountStatus shows status of volume mounts.",
+      "properties": {
+        "mountPath": {
+          "description": "MountPath corresponds to the original VolumeMount.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name corresponds to the name of the original VolumeMount.",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly corresponds to the original VolumeMount.",
+          "type": "boolean"
+        },
+        "recursiveReadOnly": {
+          "description": "RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts). An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled, depending on the mount result.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "mountPath"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.VolumeProjection": {
-      "description": "Projection that may be projected along with other supported volume types",
-      "type": "object",
+      "description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
       "properties": {
+        "clusterTrustBundle": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ClusterTrustBundleProjection",
+          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time."
+        },
         "configMap": {
-          "description": "information about the configMap data to project",
-          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection"
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection",
+          "description": "configMap information about the configMap data to project"
         },
         "downwardAPI": {
-          "description": "information about the downwardAPI data to project",
-          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection"
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection",
+          "description": "downwardAPI information about the downwardAPI data to project"
+        },
+        "podCertificate": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodCertificateProjection",
+          "description": "Projects an auto-rotating credential bundle (private key and certificate chain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a PodCertificateRequest to the named signer.  Once the signer approves the request and issues a certificate chain, Kubelet writes the key and certificate chain to the pod filesystem.  The pod does not start until certificates have been issued for each podCertificate projected volume source in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated by the signer using the PodCertificateRequest.Status.BeginRefreshAt timestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath field, or separate files, indicated by the keyPath and certificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM entry is the private key (in PKCS#8 format), and the remaining PEM entries are the certificate chain issued by the signer (typically, signers will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code can read it atomically.  If you use keyPath and certificateChainPath, your application must make two separate file reads. If these coincide with a certificate rotation, it is possible that the private key and leaf certificate you read may not correspond to each other.  Your application will need to check for this condition, and re-read until they are consistent.\n\nThe named signer controls chooses the format of the certificate it issues; consult the signer implementation's documentation to learn how to use the certificates it issues."
         },
         "secret": {
-          "description": "information about the secret data to project",
-          "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection"
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection",
+          "description": "secret information about the secret data to project"
+        },
+        "serviceAccountToken": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccountTokenProjection",
+          "description": "serviceAccountToken is information about the serviceAccountToken data to project"
         }
-      }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeResourceRequirements": {
+      "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+      "properties": {
+        "limits": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
+        },
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+          "type": "object"
+        }
+      },
+      "type": "object"
     },
     "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
       "description": "Represents a vSphere volume resource.",
-      "type": "object",
-      "required": [
-        "volumePath"
-      ],
       "properties": {
         "fsType": {
-          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
           "type": "string"
         },
         "storagePolicyID": {
-          "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+          "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
           "type": "string"
         },
         "storagePolicyName": {
-          "description": "Storage Policy Based Management (SPBM) profile name.",
+          "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
           "type": "string"
         },
         "volumePath": {
-          "description": "Path that identifies vSphere volume vmdk",
+          "description": "volumePath is the path that identifies vSphere volume vmdk",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "volumePath"
+      ],
+      "type": "object"
     },
     "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
       "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-      "type": "object",
+      "properties": {
+        "podAffinityTerm": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm",
+          "description": "Required. A pod affinity term, associated with the corresponding weight."
+        },
+        "weight": {
+          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
       "required": [
         "weight",
         "podAffinityTerm"
       ],
-      "properties": {
-        "podAffinityTerm": {
-          "description": "Required. A pod affinity term, associated with the corresponding weight.",
-          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
-        },
-        "weight": {
-          "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-          "type": "integer",
-          "format": "int32"
-        }
-      }
+      "type": "object"
     },
-    "io.k8s.apimachinery.pkg.api.resource.Quantity": {
-      "type": "string"
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
-      "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
-      "type": "object",
-      "required": [
-        "name",
-        "versions",
-        "serverAddressByClientCIDRs"
-      ],
+    "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
+      "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "gmsaCredentialSpec": {
+          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
           "type": "string"
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "gmsaCredentialSpecName": {
+          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+          "type": "string"
+        },
+        "hostProcess": {
+          "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+          "type": "boolean"
+        },
+        "runAsUserName": {
+          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WorkloadReference": {
+      "description": "WorkloadReference identifies the Workload object and PodGroup membership that a Pod belongs to. The scheduler uses this information to apply workload-aware scheduling semantics.",
+      "properties": {
+        "name": {
+          "description": "Name defines the name of the Workload object this Pod belongs to. Workload must be in the same namespace as the Pod. If it doesn't match any existing Workload, the Pod will remain unschedulable until a Workload object is created and observed by the kube-scheduler. It must be a DNS subdomain.",
+          "type": "string"
+        },
+        "podGroup": {
+          "description": "PodGroup is the name of the PodGroup within the Workload that this Pod belongs to. If it doesn't match any existing PodGroup within the Workload, the Pod will remain unschedulable until the Workload object is recreated and observed by the kube-scheduler. It must be a DNS label.",
+          "type": "string"
+        },
+        "podGroupReplicaKey": {
+          "description": "PodGroupReplicaKey specifies the replica key of the PodGroup to which this Pod belongs. It is used to distinguish pods belonging to different replicas of the same pod group. The pod group policy is applied separately to each replica. When set, it must be a DNS label.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "podGroup"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition": {
+      "description": "CustomResourceColumnDefinition specifies a column for server side printing.",
+      "properties": {
+        "description": {
+          "description": "description is a human readable description of this column.",
+          "type": "string"
+        },
+        "format": {
+          "description": "format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.",
+          "type": "string"
+        },
+        "jsonPath": {
+          "description": "jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.",
           "type": "string"
         },
         "name": {
-          "description": "name is the name of the group.",
+          "description": "name is a human readable name for the column.",
           "type": "string"
         },
-        "preferredVersion": {
-          "description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+        "priority": {
+          "description": "priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.",
+          "format": "int32",
+          "type": "integer"
         },
-        "serverAddressByClientCIDRs": {
-          "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
-          }
-        },
-        "versions": {
-          "description": "versions are the versions supported in this group.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIGroup",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
-      "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
-      "type": "object",
-      "required": [
-        "groups"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "groups": {
-          "description": "groups is a list of APIGroup.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
-          }
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+        "type": {
+          "description": "type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.",
           "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIGroupList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
-      "description": "APIResource specifies the name of a resource and whether it is namespaced.",
-      "type": "object",
       "required": [
         "name",
-        "singularName",
-        "namespaced",
-        "kind",
-        "verbs"
+        "type",
+        "jsonPath"
       ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion": {
+      "description": "CustomResourceConversion describes how to convert different versions of a CR.",
+      "properties": {
+        "strategy": {
+          "description": "strategy specifies how custom resources are converted between versions. Allowed values are: - `\"None\"`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `\"Webhook\"`: API Server will call to an external webhook to do the conversion. Additional information\n  is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.",
+          "type": "string"
+        },
+        "webhook": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion",
+          "description": "webhook describes how to call the conversion webhook. Required when `strategy` is set to `\"Webhook\"`."
+        }
+      },
+      "required": [
+        "strategy"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition": {
+      "description": "CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec",
+          "description": "spec describes how the user wants the resources to appear"
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus",
+          "description": "status indicates the actual state of the CustomResourceDefinition"
+        }
+      },
+      "required": [
+        "spec"
+      ],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "apiextensions.k8s.io",
+          "kind": "CustomResourceDefinition",
+          "version": "v1"
+        }
+      ]
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition": {
+      "description": "CustomResourceDefinitionCondition contains details for the current condition of this pod.",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "lastTransitionTime last time the condition transitioned from one status to another."
+        },
+        "message": {
+          "description": "message is a human-readable message indicating details about last transition.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "reason": {
+          "description": "reason is a unique, one-word, CamelCase reason for the condition's last transition.",
+          "type": "string"
+        },
+        "status": {
+          "description": "status is the status of the condition. Can be True, False, Unknown.",
+          "type": "string"
+        },
+        "type": {
+          "description": "type is the type of the condition. Types include Established, NamesAccepted and Terminating.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "status"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames": {
+      "description": "CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition",
       "properties": {
         "categories": {
-          "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
-          "type": "array",
+          "description": "categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "kind": {
-          "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+          "description": "kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.",
           "type": "string"
         },
-        "name": {
-          "description": "name is the plural name of the resource.",
+        "listKind": {
+          "description": "listKind is the serialized kind of the list for this resource. Defaults to \"`kind`List\".",
           "type": "string"
         },
-        "namespaced": {
-          "description": "namespaced indicates if a resource is namespaced or not.",
-          "type": "boolean"
+        "plural": {
+          "description": "plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.",
+          "type": "string"
         },
         "shortNames": {
-          "description": "shortNames is a list of suggested short names of the resource.",
-          "type": "array",
+          "description": "shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.",
           "items": {
             "type": "string"
-          }
-        },
-        "singularName": {
-          "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
-          "type": "string"
-        },
-        "verbs": {
-          "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+          },
           "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
-      "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
-      "type": "object",
-      "required": [
-        "groupVersion",
-        "resources"
-      ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
+          "x-kubernetes-list-type": "atomic"
         },
-        "groupVersion": {
-          "description": "groupVersion is the group and version this APIResourceList is for.",
+        "singular": {
+          "description": "singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.",
           "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "resources": {
-          "description": "resources contains the name of the resources and if they are namespaced.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
-          }
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIResourceList",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions": {
-      "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
-      "type": "object",
       "required": [
-        "versions",
-        "serverAddressByClientCIDRs"
+        "plural",
+        "kind"
       ],
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "serverAddressByClientCIDRs": {
-          "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
-          }
-        },
-        "versions": {
-          "description": "versions are the api versions that are available.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "APIVersions",
-          "version": "v1"
-        }
-      ]
+      "type": "object"
     },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
-      "description": "DeleteOptions may be provided when deleting an API object.",
-      "type": "object",
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec": {
+      "description": "CustomResourceDefinitionSpec describes how a user wants their resource to appear",
       "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+        "conversion": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion",
+          "description": "conversion defines conversion settings for the CRD."
+        },
+        "group": {
+          "description": "group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).",
           "type": "string"
         },
-        "gracePeriodSeconds": {
-          "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
-          "type": "integer",
-          "format": "int64"
+        "names": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames",
+          "description": "names specify the resource and kind names for the custom resource."
         },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "orphanDependents": {
-          "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+        "preserveUnknownFields": {
+          "description": "preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.",
           "type": "boolean"
         },
-        "preconditions": {
-          "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+        "scope": {
+          "description": "scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.",
+          "type": "string"
         },
-        "propagationPolicy": {
-          "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.",
+        "versions": {
+          "description": "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "group",
+        "names",
+        "scope",
+        "versions"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus": {
+      "description": "CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition",
+      "properties": {
+        "acceptedNames": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames",
+          "description": "acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec."
+        },
+        "conditions": {
+          "description": "conditions indicate state for particular aspects of a CustomResourceDefinition",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the CRD controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "storedVersions": {
+          "description": "storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion": {
+      "description": "CustomResourceDefinitionVersion describes a version for CRD.",
+      "properties": {
+        "additionalPrinterColumns": {
+          "description": "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "deprecated": {
+          "description": "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.",
+          "type": "boolean"
+        },
+        "deprecationWarning": {
+          "description": "deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.",
+          "type": "string"
+        },
+        "name": {
+          "description": "name is the version name, e.g. \u201cv1\u201d, \u201cv2beta1\u201d, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.",
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
+          "description": "schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource."
+        },
+        "selectableFields": {
+          "description": "selectableFields specifies paths to fields that may be used as field selectors. A maximum of 8 selectable fields are allowed. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "served": {
+          "description": "served is a flag enabling/disabling this version from being served via REST APIs",
+          "type": "boolean"
+        },
+        "storage": {
+          "description": "storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.",
+          "type": "boolean"
+        },
+        "subresources": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources",
+          "description": "subresources specify what subresources this version of the defined custom resource have."
+        }
+      },
+      "required": [
+        "name",
+        "served",
+        "storage"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale": {
+      "description": "CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.",
+      "properties": {
+        "labelSelectorPath": {
+          "description": "labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.",
+          "type": "string"
+        },
+        "specReplicasPath": {
+          "description": "specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.",
+          "type": "string"
+        },
+        "statusReplicasPath": {
+          "description": "statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.",
           "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "admission.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "apps",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "apps",
-          "kind": "DeleteOptions",
-          "version": "v1beta2"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "DeleteOptions",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "batch",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "batch",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "batch",
-          "kind": "DeleteOptions",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "certificates.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "extensions",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "federation",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "imagepolicy.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "networking.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "policy",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        },
-        {
-          "group": "scheduling.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "settings.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "DeleteOptions",
-          "version": "v1beta1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
-      "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
-      "type": "object",
       "required": [
-        "groupVersion",
-        "version"
+        "specReplicasPath",
+        "statusReplicasPath"
       ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus": {
+      "description": "CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza",
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources": {
+      "description": "CustomResourceSubresources defines the status and scale subresources for CustomResources.",
       "properties": {
-        "groupVersion": {
-          "description": "groupVersion specifies the API group and version in the form \"group/version\"",
+        "scale": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale",
+          "description": "scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus",
+          "description": "status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation": {
+      "description": "CustomResourceValidation is a list of validation methods for CustomResources.",
+      "properties": {
+        "openAPIV3Schema": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps",
+          "description": "openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation": {
+      "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+      "properties": {
+        "description": {
           "type": "string"
         },
-        "version": {
-          "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+        "url": {
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializer": {
-      "description": "Initializer is information about an initializer that has not yet completed.",
-      "type": "object",
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON": {
+      "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps": {
+      "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+      "properties": {
+        "$ref": {
+          "type": "string"
+        },
+        "$schema": {
+          "type": "string"
+        },
+        "additionalItems": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
+        },
+        "additionalProperties": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
+        },
+        "allOf": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "anyOf": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "default": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON",
+          "description": "default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false."
+        },
+        "definitions": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "type": "object"
+        },
+        "dependencies": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray"
+          },
+          "type": "object"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "example": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+        },
+        "exclusiveMaximum": {
+          "type": "boolean"
+        },
+        "exclusiveMinimum": {
+          "type": "boolean"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation"
+        },
+        "format": {
+          "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:\n\n- bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray"
+        },
+        "maxItems": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "maxLength": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "maxProperties": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "maximum": {
+          "format": "double",
+          "type": "number"
+        },
+        "minItems": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "minLength": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "minProperties": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "minimum": {
+          "format": "double",
+          "type": "number"
+        },
+        "multipleOf": {
+          "format": "double",
+          "type": "number"
+        },
+        "not": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "oneOf": {
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "patternProperties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "type": "object"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          },
+          "type": "object"
+        },
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "uniqueItems": {
+          "type": "boolean"
+        },
+        "x-kubernetes-embedded-resource": {
+          "description": "x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).",
+          "type": "boolean"
+        },
+        "x-kubernetes-int-or-string": {
+          "description": "x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:\n\n1) anyOf:\n   - type: integer\n   - type: string\n2) allOf:\n   - anyOf:\n     - type: integer\n     - type: string\n   - ... zero or more",
+          "type": "boolean"
+        },
+        "x-kubernetes-list-map-keys": {
+          "description": "x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.\n\nThis tag MUST only be used on lists that have the \"x-kubernetes-list-type\" extension set to \"map\". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).\n\nThe properties specified must either be required or have a default value, to ensure those properties are present for all list items.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "x-kubernetes-list-type": {
+          "description": "x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:\n\n1) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic lists will be entirely replaced when updated. This extension\n     may be used on any type of list (struct, scalar, ...).\n2) `set`:\n     Sets are lists that must not have multiple items with the same value. Each\n     value must be a scalar, an object with x-kubernetes-map-type `atomic` or an\n     array with x-kubernetes-list-type `atomic`.\n3) `map`:\n     These lists are like maps in that their elements have a non-index key\n     used to identify them. Order is preserved upon merge. The map tag\n     must only be used on a list with elements of type object.\nDefaults to atomic for arrays.",
+          "type": "string"
+        },
+        "x-kubernetes-map-type": {
+          "description": "x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:\n\n1) `granular`:\n     These maps are actual maps (key-value pairs) and each fields are independent\n     from each other (they can each be manipulated by separate actors). This is\n     the default behaviour for all maps.\n2) `atomic`: the list is treated as a single entity, like a scalar.\n     Atomic maps will be entirely replaced when updated.",
+          "type": "string"
+        },
+        "x-kubernetes-preserve-unknown-fields": {
+          "description": "x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
+          "type": "boolean"
+        },
+        "x-kubernetes-validations": {
+          "description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "rule"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "rule",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray": {
+      "description": "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool": {
+      "description": "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray": {
+      "description": "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array."
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField": {
+      "description": "SelectableField specifies the JSON path of a field that may be used with field selectors.",
+      "properties": {
+        "jsonPath": {
+          "description": "jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metdata fields. Required.",
+          "type": "string"
+        }
+      },
       "required": [
-        "name"
+        "jsonPath"
       ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference": {
+      "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
       "properties": {
         "name": {
-          "description": "name of the process that is responsible for initializing this object.",
+          "description": "name is the name of the service. Required",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "namespace is the namespace of the service. Required",
+          "type": "string"
+        },
+        "path": {
+          "description": "path is an optional URL path at which the webhook will be contacted.",
+          "type": "string"
+        },
+        "port": {
+          "description": "port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "namespace",
+        "name"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule": {
+      "description": "ValidationRule describes a validation rule written in the CEL expression language.",
+      "properties": {
+        "fieldPath": {
+          "description": "fieldPath represents the field path returned when the validation fails. It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field. e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo` If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList` It does not support list numeric index. It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info. Numeric index of array is not supported. For field name which contains special characters, use `['specialName']` to refer the field name. e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\"",
+          "type": "string"
+        },
+        "messageExpression": {
+          "description": "MessageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a rule, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the rule; the only difference is the return type. Example: \"x must be less than max (\"+string(self.max)+\")\"",
+          "type": "string"
+        },
+        "optionalOldSelf": {
+          "description": "optionalOldSelf is used to opt a transition rule into evaluation even when the object is first created, or if the old object is missing the value.\n\nWhen enabled `oldSelf` will be a CEL optional whose value will be `None` if there is no old value, or when the object is initially created.\n\nYou may check for presence of oldSelf using `oldSelf.hasValue()` and unwrap it after checking using `oldSelf.value()`. Check the CEL documentation for Optional types for more information: https://pkg.go.dev/github.com/google/cel-go/cel#OptionalTypes\n\nMay not be set unless `oldSelf` is used in `rule`.",
+          "type": "boolean"
+        },
+        "reason": {
+          "description": "reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule. The HTTP status code returned to the caller will match the reason of the reason of the first failed validation rule. The currently supported reasons are: \"FieldValueInvalid\", \"FieldValueForbidden\", \"FieldValueRequired\", \"FieldValueDuplicate\". If not set, default to use \"FieldValueInvalid\". All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.",
+          "type": "string"
+        },
+        "rule": {
+          "description": "Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {\"rule\": \"self.status.actual <= self.spec.maxDesired\"}\n\nIf the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {\"rule\": \"self.components['Widget'].priority < 10\"} - Rule scoped to a list of integers: {\"rule\": \"self.values.all(value, value >= 0 && value < 100)\"} - Rule scoped to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.\n\nUnknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an \"unknown type\". An \"unknown type\" is recursively defined as:\n  - A schema with no type and x-kubernetes-preserve-unknown-fields set to true\n  - An array where the items schema is of an \"unknown type\"\n  - An object where the additionalProperties schema is of an \"unknown type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Rule accessing a property named \"namespace\": {\"rule\": \"self.__namespace__ > 0\"}\n  - Rule accessing a property named \"x-prop\": {\"rule\": \"self.x__dash__prop > 0\"}\n  - Rule accessing a property named \"redact__d\": {\"rule\": \"self.redact__underscores__d > 0\"}\n\nEquality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\n\nIf `rule` makes use of the `oldSelf` variable it is implicitly a `transition rule`.\n\nBy default, the `oldSelf` variable is the same type as `self`. When `optionalOldSelf` is true, the `oldSelf` variable is a CEL optional\n variable whose value() is the same type as `self`.\nSee the documentation for the `optionalOldSelf` field for details.\n\nTransition rules by default are applied only on UPDATE requests and are skipped if an old value could not be found. You can opt a transition rule into unconditional evaluation by setting `optionalOldSelf` to true.",
           "type": "string"
         }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializers": {
-      "description": "Initializers tracks the progress of initialization.",
-      "type": "object",
+      },
       "required": [
-        "pending"
+        "rule"
       ],
-      "properties": {
-        "pending": {
-          "description": "Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializer"
-          },
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "result": {
-          "description": "If result is set with the Failure field, the object will be persisted to storage and then deleted, ensuring that other clients can observe the deletion.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
-        }
-      }
+      "type": "object"
     },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
-      "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
-      "type": "object",
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig": {
+      "description": "WebhookClientConfig contains the information to make a TLS connection with the webhook.",
       "properties": {
-        "matchExpressions": {
-          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
-          }
+        "caBundle": {
+          "description": "caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.",
+          "format": "byte",
+          "type": "string"
         },
-        "matchLabels": {
-          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-          "type": "object",
-          "additionalProperties": {
+        "service": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference",
+          "description": "service is a reference to the service for this webhook. Either service or url must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`."
+        },
+        "url": {
+          "description": "url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.\n\nThe `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.\n\nPlease note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.\n\nThe scheme must be \"https\"; the URL must begin with \"https://\".\n\nA path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.\n\nAttempting to use a user or basic auth e.g. \"user:password@\" is not allowed. Fragments (\"#...\") and query parameters (\"?...\") are not allowed, either.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion": {
+      "description": "WebhookConversion describes how to call a conversion webhook",
+      "properties": {
+        "clientConfig": {
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig",
+          "description": "clientConfig is the instructions for how to call the webhook if strategy is `Webhook`."
+        },
+        "conversionReviewVersions": {
+          "description": "conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail.",
+          "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         }
-      }
+      },
+      "required": [
+        "conversionReviewVersions"
+      ],
+      "type": "object"
     },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
-      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-      "type": "object",
+    "io.k8s.apimachinery.pkg.api.resource.Quantity": {
+      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+      "type": "string"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement": {
+      "description": "FieldSelectorRequirement is a selector that contains values, a key, and an operator that relates the key and values.",
+      "properties": {
+        "key": {
+          "description": "key is the field selector key that the requirement applies to.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. The list of operators may grow in the future.",
+          "type": "string"
+        },
+        "values": {
+          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
       "required": [
         "key",
         "operator"
       ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+      "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+      "properties": {
+        "matchExpressions": {
+          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "matchLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
       "properties": {
         "key": {
           "description": "key is the label key that the selector applies to.",
-          "type": "string",
-          "x-kubernetes-patch-merge-key": "key",
-          "x-kubernetes-patch-strategy": "merge"
+          "type": "string"
         },
         "operator": {
-          "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
+          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
           "type": "string"
         },
         "values": {
           "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
-      "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
-      "type": "object",
-      "properties": {
-        "resourceVersion": {
-          "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
-          "type": "string"
-        },
-        "selfLink": {
-          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
-      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
-      "type": "object",
-      "properties": {
-        "annotations": {
-          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "clusterName": {
-          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
-          "type": "string"
-        },
-        "creationTimestamp": {
-          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "deletionGracePeriodSeconds": {
-          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "deletionTimestamp": {
-          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
-        },
-        "finalizers": {
-          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
-          "type": "array",
           "items": {
             "type": "string"
           },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "key",
+        "operator"
+      ],
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+      "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+      "properties": {
+        "continue": {
+          "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+          "type": "string"
+        },
+        "remainingItemCount": {
+          "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "resourceVersion": {
+          "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+      "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+          "type": "string"
+        },
+        "fieldsType": {
+          "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+          "type": "string"
+        },
+        "fieldsV1": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1",
+          "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type."
+        },
+        "manager": {
+          "description": "Manager is an identifier of the workflow managing these fields.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+          "type": "string"
+        },
+        "subresource": {
+          "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+          "type": "string"
+        },
+        "time": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+          "type": "object"
+        },
+        "creationTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "deletionTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set",
           "x-kubernetes-patch-strategy": "merge"
         },
         "generateName": {
-          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency",
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
           "type": "string"
         },
         "generation": {
           "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
-          "type": "integer",
-          "format": "int64"
-        },
-        "initializers": {
-          "description": "An initializer is a controller which enforces some system invariant at object creation time. This field is a list of initializers that have not yet acted on this object. If nil or empty, this object has been completely initialized. Otherwise, the object is considered uninitialized and is hidden (in list/watch and get calls) from clients that haven't explicitly asked to observe uninitialized objects.\n\nWhen an object is created, the system will populate this list with the current set of initializers. Only privileged users may set or modify this list. Once it is empty, it may not be modified further by any user.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Initializers"
+          "format": "int64",
+          "type": "integer"
         },
         "labels": {
-          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+          "type": "object"
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "name": {
-          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
           "type": "string"
         },
         "namespace": {
-          "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
           "type": "string"
         },
         "ownerReferences": {
           "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
           },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "uid"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "uid",
           "x-kubernetes-patch-strategy": "merge"
         },
         "resourceVersion": {
-          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency",
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
           "type": "string"
         },
         "selfLink": {
-          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
           "type": "string"
         },
         "uid": {
-          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
-      "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
-      "type": "object",
-      "required": [
-        "apiVersion",
-        "kind",
-        "name",
-        "uid"
-      ],
+      "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
       "properties": {
         "apiVersion": {
           "description": "API version of the referent.",
           "type": "string"
         },
         "blockOwnerDeletion": {
-          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
           "type": "boolean"
         },
         "controller": {
@@ -6208,367 +5220,40 @@
           "type": "boolean"
         },
         "kind": {
-          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
         },
         "name": {
-          "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
           "type": "string"
         },
         "uid": {
-          "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
-      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
-      "type": "object"
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
-      "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
-      "type": "object",
-      "properties": {
-        "uid": {
-          "description": "Specifies the target UID.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
-      "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
-      "type": "object",
-      "required": [
-        "clientCIDR",
-        "serverAddress"
-      ],
-      "properties": {
-        "clientCIDR": {
-          "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
-          "type": "string"
-        },
-        "serverAddress": {
-          "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
-      "description": "Status is a return value for calls that don't return other objects.",
-      "type": "object",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
-          "type": "string"
-        },
-        "code": {
-          "description": "Suggested HTTP return code for this status, 0 if not set.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "details": {
-          "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "message": {
-          "description": "A human-readable description of the status of this operation.",
-          "type": "string"
-        },
-        "metadata": {
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
-        },
-        "reason": {
-          "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
-          "type": "string"
-        },
-        "status": {
-          "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
           "type": "string"
         }
       },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "Status",
-          "version": "v1"
-        }
-      ]
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
-      "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ],
       "type": "object",
-      "properties": {
-        "field": {
-          "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
-          "type": "string"
-        },
-        "message": {
-          "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
-          "type": "string"
-        }
-      }
-    },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
-      "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
-      "type": "object",
-      "properties": {
-        "causes": {
-          "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
-          }
-        },
-        "group": {
-          "description": "The group attribute of the resource associated with the status StatusReason.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
-          "type": "string"
-        },
-        "name": {
-          "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
-          "type": "string"
-        },
-        "retryAfterSeconds": {
-          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "uid": {
-          "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-          "type": "string"
-        }
-      }
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
-      "type": "string",
-      "format": "date-time"
+      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+      "format": "date-time",
+      "type": "string"
     },
-    "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
-      "description": "Event represents a single event to a watched resource.",
-      "type": "object",
-      "required": [
-        "type",
-        "object"
-      ],
-      "properties": {
-        "object": {
-          "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
-          "type": "object"
-        },
-        "type": {
-          "type": "string"
-        }
-      },
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "admission.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "apps",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "apps",
-          "kind": "WatchEvent",
-          "version": "v1beta2"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "authentication.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "autoscaling",
-          "kind": "WatchEvent",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "batch",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "batch",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "batch",
-          "kind": "WatchEvent",
-          "version": "v2alpha1"
-        },
-        {
-          "group": "certificates.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "extensions",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "federation",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "imagepolicy.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "networking.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "policy",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "rbac.authorization.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        },
-        {
-          "group": "scheduling.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "settings.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1alpha1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1"
-        },
-        {
-          "group": "storage.k8s.io",
-          "kind": "WatchEvent",
-          "version": "v1beta1"
-        }
-      ]
+    "io.k8s.apimachinery.pkg.runtime.RawExtension": {
+      "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.Object `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// External package:\n\n\ttype MyAPIObject struct {\n\t\truntime.TypeMeta `json:\",inline\"`\n\t\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n\t}\n\n\ttype PluginA struct {\n\t\tAOption string `json:\"aOption\"`\n\t}\n\n// On the wire, the JSON will look something like this:\n\n\t{\n\t\t\"kind\":\"MyAPIObject\",\n\t\t\"apiVersion\":\"v1\",\n\t\t\"myPlugin\": {\n\t\t\t\"kind\":\"PluginA\",\n\t\t\t\"aOption\":\"foo\",\n\t\t},\n\t}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
-      "type": "string",
-      "format": "int-or-string"
-    },
-    "io.k8s.apimachinery.pkg.version.Info": {
-      "description": "Info contains versioning information. how we'll want to distribute that information.",
-      "type": "object",
-      "required": [
-        "major",
-        "minor",
-        "gitVersion",
-        "gitCommit",
-        "gitTreeState",
-        "buildDate",
-        "goVersion",
-        "compiler",
-        "platform"
-      ],
-      "properties": {
-        "buildDate": {
-          "type": "string"
-        },
-        "compiler": {
-          "type": "string"
-        },
-        "gitCommit": {
-          "type": "string"
-        },
-        "gitTreeState": {
-          "type": "string"
-        },
-        "gitVersion": {
-          "type": "string"
-        },
-        "goVersion": {
-          "type": "string"
-        },
-        "major": {
-          "type": "string"
-        },
-        "minor": {
-          "type": "string"
-        },
-        "platform": {
-          "type": "string"
-        }
-      }
+      "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+      "format": "int-or-string",
+      "type": "string"
     }
-  },
-  "securityDefinitions": {
-    "BearerToken": {
-      "description": "Bearer Token authentication",
-      "type": "apiKey",
-      "name": "authorization",
-      "in": "header"
-    }
-  },
-  "security": [
-    {
-      "BearerToken": []
-    }
-  ]
+  }
 }

--- a/pkg/util/proto/validation/validation_test.go
+++ b/pkg/util/proto/validation/validation_test.go
@@ -66,8 +66,8 @@ func loadModels(t *testing.T) proto.Models {
 func TestResourceValidation(t *testing.T) {
 	t.Run("finds Deployment in Schema and validates it", func(t *testing.T) {
 		models := loadModels(t)
-		err := Validate(models, "io.k8s.api.apps.v1beta1.Deployment", `
-apiVersion: extensions/v1beta1
+		err := Validate(models, "io.k8s.api.apps.v1.Deployment", `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -75,6 +75,9 @@ metadata:
   name: name
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: redis
   template:
     metadata:
       labels:
@@ -310,13 +313,6 @@ spec:
 					Field: "name",
 				},
 			},
-			validation.ValidationError{
-				Path: "io.k8s.api.core.v1.Pod.spec.containers[0]",
-				Err: validation.MissingRequiredFieldError{
-					Path:  "io.k8s.api.core.v1.Container",
-					Field: "image",
-				},
-			},
 		}
 		if !reflect.DeepEqual(err, want) {
 			t.Errorf("err = %v, want %v", err, want)
@@ -334,7 +330,7 @@ metadata:
   name: name
 spec:
   containers:
-  - image:
+  - image: image
     name:
 `)
 		want := []error{
@@ -343,13 +339,6 @@ spec:
 				Err: validation.MissingRequiredFieldError{
 					Path:  "io.k8s.api.core.v1.Container",
 					Field: "name",
-				},
-			},
-			validation.ValidationError{
-				Path: "io.k8s.api.core.v1.Pod.spec.containers[0]",
-				Err: validation.MissingRequiredFieldError{
-					Path:  "io.k8s.api.core.v1.Container",
-					Field: "image",
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

- Replace swagger v2 test fixtures (`swagger.json`, `swagger_next.json`) with trimmed extracts from the Kubernetes v1.35.2 OpenAPI spec
- Update all test references from deprecated `apps/v1beta1` to GA `apps/v1`
- Fix `Container` required-field assertions (`image` is no longer required)
- Add `selector` to Deployment validation test (required in `apps/v1`)
- Update `DeploymentStatus.conditions` extension assertions to include `x-kubernetes-list-map-keys` and `x-kubernetes-list-type`

OpenAPI v3 test data (v1.24) is left unchanged pending a fix for the proto v3 parser's lack of `allOf`-wrapped `$ref` support (see #477 #583 and #584).

Resolves feedback from https://github.com/kubernetes/kube-openapi/pull/579#discussion_r2948598747