### PR TITLE
fix(generators): detect inline fields structurally instead of matching ",inline" tag

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -223,8 +223,8 @@ func getReferableName(m *types.Member) string {
 }
 
 func shouldInlineMembers(m *types.Member) bool {
-	jsonTags := getJsonTags(m)
-	return len(jsonTags) > 1 && jsonTags[1] == "inline"
+	jsonTag, jsonTagExists := reflect.StructTag(m.Tags).Lookup("json")
+	return m.Embedded && jsonTagExists && (jsonTag == "" || strings.HasPrefix(jsonTag, ","))
 }
 
 type openAPITypeWriter struct {

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -810,6 +810,65 @@ Required: []string{"String"},
 	})
 }
 
+func TestEmbeddedInlineStructWithEmptyJSONTag(t *testing.T) {
+	inputFile := `
+	package foo
+
+		// Nested is used as embedded inline struct field
+		type Nested struct {
+		  // A simple string
+		  String string
+		}
+
+		// Blah demonstrate a struct with embedded inline struct field using empty json tag.
+		type Blah struct {
+		  // An embedded inline struct field with empty json tag
+		  Nested ` + "`" + `json:""` + "`" + `
+		}`
+
+	packagestest.TestAll(t, func(t *testing.T, x packagestest.Exporter) {
+		e := packagestest.Export(t, x, []packagestest.Module{{
+			Name: "example.com/base/foo",
+			Files: map[string]interface{}{
+				"foo.go": inputFile,
+			},
+		}})
+		defer e.Cleanup()
+
+		callErr, funcErr, callBuffer, funcBuffer, _ := testOpenAPITypeWriter(t, e.Config)
+		if callErr != nil {
+			t.Fatal(callErr)
+		}
+		if funcErr != nil {
+			t.Fatal(funcErr)
+		}
+		assertEqual(t, callBuffer.String(),
+			`"example.com/base/foo.Blah": schema_examplecom_base_foo_Blah(ref),`)
+		assertEqual(t, funcBuffer.String(),
+			`func schema_examplecom_base_foo_Blah(ref common.ReferenceCallback) common.OpenAPIDefinition {
+return common.OpenAPIDefinition{
+Schema: spec.Schema{
+SchemaProps: spec.SchemaProps{
+Description: "Blah demonstrate a struct with embedded inline struct field using empty json tag.",
+Type: []string{"object"},
+Properties: map[string]spec.Schema{
+"String": {
+SchemaProps: spec.SchemaProps{
+Description: "A simple string",
+Default: "",
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+Required: []string{"String"},
+},
+},
+}
+}`)
+	})
+}
+
 func TestNestedMapString(t *testing.T) {
 	inputFile := `
 		package foo
@@ -3101,4 +3160,56 @@ func TestNestedMarkers(t *testing.T) {
 		}
 	})
 
+}
+
+func TestShouldInlineMembers(t *testing.T) {
+	tests := []struct {
+		name     string
+		member   types.Member
+		expected bool
+	}{
+		{
+			name:     "embedded with ,inline tag",
+			member:   types.Member{Name: "TypeMeta", Embedded: true, Tags: `json:",inline"`},
+			expected: true,
+		},
+		{
+			name:     "embedded with empty json tag",
+			member:   types.Member{Name: "TypeMeta", Embedded: true, Tags: `json:""`},
+			expected: true,
+		},
+		{
+			name:     "embedded with ,inline,omitempty tag",
+			member:   types.Member{Name: "ObjectMeta", Embedded: true, Tags: `json:",inline,omitempty"`},
+			expected: true,
+		},
+		{
+			name:     "embedded with no json tag",
+			member:   types.Member{Name: "TypeMeta", Embedded: true, Tags: ``},
+			expected: false,
+		},
+		{
+			name:     "embedded with explicit name",
+			member:   types.Member{Name: "TypeMeta", Embedded: true, Tags: `json:"typemeta"`},
+			expected: false,
+		},
+		{
+			name:     "non-embedded with ,inline tag",
+			member:   types.Member{Name: "TypeMeta", Embedded: false, Tags: `json:",inline"`},
+			expected: false,
+		},
+		{
+			name:     "non-embedded with empty json tag",
+			member:   types.Member{Name: "TypeMeta", Embedded: false, Tags: `json:""`},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldInlineMembers(&tc.member); got != tc.expected {
+				t.Errorf("shouldInlineMembers(%+v) = %v, want %v", tc.member, got, tc.expected)
+			}
+		})
+	}
 }

--- a/pkg/generators/rules/list_type_streaming_tags.go
+++ b/pkg/generators/rules/list_type_streaming_tags.go
@@ -62,7 +62,14 @@ func (l *StreamingListTypeJSONTags) Validate(t *types.Type) ([]string, error) {
 	for _, m := range t.Members {
 		switch m.Name {
 		case "TypeMeta":
-			if reflect.StructTag(m.Tags).Get("json") != ",inline" {
+			if !m.Embedded {
+				// field must be embedded to inline
+				fields = append(fields, "TypeMeta")
+			} else if jsonTag, jsonTagExists := reflect.StructTag(m.Tags).Lookup("json"); !jsonTagExists {
+				// field should declare a json tag to indicate it is serialized
+				fields = append(fields, "TypeMeta")
+			} else if jsonTag != "" && jsonTag != ",inline" {
+				// expect a completely empty json tag (preferred) or an empty name segment and only an ,inline directive (previously used)
 				fields = append(fields, "TypeMeta")
 			}
 		case "ListMeta":

--- a/pkg/generators/rules/list_type_streaming_tags_test.go
+++ b/pkg/generators/rules/list_type_streaming_tags_test.go
@@ -119,13 +119,35 @@ func TestStreamingListTypeJSONTags(t *testing.T) {
 		expectedFields []string
 	}{
 		{
-			name: "simple list",
+			name: "simple list with inline tag",
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline"`,
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline"`,
+					},
+					{
+						Name: "ListMeta",
+						Tags: `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`,
+					},
+					{
+						Name: "Items",
+						Tags: `json:"items" protobuf:"bytes,2,rep,name=items"`,
+					},
+				},
+			},
+		},
+		{
+			name: "simple list with empty json tag",
+			t: &types.Type{
+				Kind: types.Struct,
+				Members: []types.Member{
+					{
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:""`,
 					},
 					{
 						Name: "ListMeta",
@@ -175,8 +197,9 @@ func TestStreamingListTypeJSONTags(t *testing.T) {
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:"typemeta"`, // subfield typemeta instead of inline
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:"typemeta"`, // subfield typemeta instead of inline
 					},
 					{
 						Name: "ListMeta",
@@ -196,8 +219,9 @@ func TestStreamingListTypeJSONTags(t *testing.T) {
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline"`,
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline"`,
 					},
 					{
 						Name: "ListMeta",
@@ -212,13 +236,14 @@ func TestStreamingListTypeJSONTags(t *testing.T) {
 			expectedFields: []string{"ListMeta"},
 		},
 		{
-			name: "bad listmeta json tag",
+			name: "bad items json tag",
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline"`,
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline"`,
 					},
 					{
 						Name: "ListMeta",
@@ -258,8 +283,9 @@ func TestStreamingListTypeProtoTags(t *testing.T) {
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline"`,
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline"`,
 					},
 					{
 						Name: "ListMeta",
@@ -309,8 +335,9 @@ func TestStreamingListTypeProtoTags(t *testing.T) {
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline" protobuf:"bytes,3,opt,name=typemeta"`, // Added protobuf tag
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline" protobuf:"bytes,3,opt,name=typemeta"`, // Added protobuf tag
 					},
 					{
 						Name: "ListMeta",
@@ -325,13 +352,14 @@ func TestStreamingListTypeProtoTags(t *testing.T) {
 			expectedFields: []string{"TypeMeta"},
 		},
 		{
-			name: "bad listmeta json tag",
+			name: "bad listmeta proto tag",
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline"`,
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline"`,
 					},
 					{
 						Name: "ListMeta",
@@ -346,13 +374,14 @@ func TestStreamingListTypeProtoTags(t *testing.T) {
 			expectedFields: []string{"ListMeta"},
 		},
 		{
-			name: "bad listmeta json tag",
+			name: "bad items proto tag",
 			t: &types.Type{
 				Kind: types.Struct,
 				Members: []types.Member{
 					{
-						Name: "TypeMeta",
-						Tags: `json:",inline"`,
+						Name:     "TypeMeta",
+						Embedded: true,
+						Tags:     `json:",inline"`,
 					},
 					{
 						Name: "ListMeta",


### PR DESCRIPTION
Determine whether a field should be inlined based on whether it is embedded and has an empty json tag name, rather than checking for the literal ",inline" json tag option which is not a real encoding/json directive.

This allows types to use `json:""` instead of `json:",inline"` on embedded fields like TypeMeta, ObjectMeta, and ListMeta.

xref: https://github.com/kubernetes/kubernetes/pull/138260