### PR TITLE
Add apiversion.yaml support

### DIFF
--- a/pkg/generators/apidefinitions/loader.go
+++ b/pkg/generators/apidefinitions/loader.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apidefinitions
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+const (
+	schemeGroupVersion = "apidefinitions.k8s.io/v1alpha1"
+	kindAPIVersion     = "APIVersion"
+
+	fileName = "apiversion.yaml"
+)
+
+// LoadAPIVersion reads apiversion.yaml from a Go package dir, returning
+// nil if no such file exists.
+func LoadAPIVersion(dir string) (*APIVersion, error) {
+	data, err := os.ReadFile(filepath.Join(dir, fileName))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	av := &APIVersion{}
+	if err := yaml.Unmarshal(data, av); err != nil {
+		return nil, fmt.Errorf("%s: decoding %s: %w", filepath.Join(dir, fileName), kindAPIVersion, err)
+	}
+	if av.APIVersion != schemeGroupVersion {
+		return nil, fmt.Errorf("%s: expected apiVersion %s but got %s", filepath.Join(dir, fileName), schemeGroupVersion, av.APIVersion)
+	}
+	if av.Kind != kindAPIVersion {
+		return nil, fmt.Errorf("%s: expected kind %s but got %s", filepath.Join(dir, fileName), kindAPIVersion, av.Kind)
+	}
+	if av.Metadata.Name == "" {
+		return nil, fmt.Errorf("%s: metadata.name is required", filepath.Join(dir, fileName))
+	}
+	if av.Spec.ModelPackage == "" {
+		return nil, fmt.Errorf("%s: spec.modelPackage is required", filepath.Join(dir, fileName))
+	}
+	return av, nil
+}
+
+// Group returns the API group declared by an APIVersion. metadata.name is
+// parsed as "<group>/<version>" or "<version>" (core group, empty group).
+func (av *APIVersion) Group() string {
+	if i := strings.LastIndex(av.Metadata.Name, "/"); i >= 0 {
+		return av.Metadata.Name[:i]
+	}
+	return ""
+}
+
+// Version returns the API version declared by an APIVersion.
+func (av *APIVersion) Version() string {
+	if i := strings.LastIndex(av.Metadata.Name, "/"); i >= 0 {
+		return av.Metadata.Name[i+1:]
+	}
+	return av.Metadata.Name
+}

--- a/pkg/generators/apidefinitions/types.go
+++ b/pkg/generators/apidefinitions/types.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apidefinitions
+
+// Metadata is a thin subset of K8s ObjectMeta used by codegen manifests.
+type Metadata struct {
+	Name string `yaml:"name"`
+}
+
+// APIVersion declares an external versioned API package.
+type APIVersion struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   Metadata       `yaml:"metadata"`
+	Spec       APIVersionSpec `yaml:"spec"`
+}
+
+// APIVersionSpec carries codegen-relevant fields for an APIVersion.
+type APIVersionSpec struct {
+	// ModelPackage is the OpenAPI model package name for the schema
+	// types defined in this group/version.
+	ModelPackage string `yaml:"modelPackage"`
+
+	// InternalVersions lists the InternalVersion metadata.name values
+	// this APIVersion converts to/from. Used by extensions/v1beta1's
+	// historical fan-out. openapi-gen does not consume this field but
+	// keeps it in the schema for round-trip safety.
+	InternalVersions []string `yaml:"internalVersions,omitempty"`
+}

--- a/pkg/generators/config.go
+++ b/pkg/generators/config.go
@@ -105,9 +105,9 @@ func GetModelNameTargets(context *generator.Context, args *args.Args, boilerplat
 			continue
 		}
 
-		openAPISchemaNamePackage, err := extractOpenAPISchemaNamePackage(pkg.Comments)
+		openAPISchemaNamePackage, err := resolvePackageModelPackage(pkg)
 		if err != nil {
-			klog.Fatalf("Package %v: invalid %s:%v", i, tagModelPackage, err)
+			klog.Fatalf("Package %v: %v", i, err)
 		}
 		hasPackageTag := len(openAPISchemaNamePackage) > 0
 

--- a/pkg/generators/model_names.go
+++ b/pkg/generators/model_names.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
 	"k8s.io/klog/v2"
+	"k8s.io/kube-openapi/pkg/generators/apidefinitions"
 )
 
 const (
@@ -38,6 +39,21 @@ func extractOpenAPISchemaNamePackage(comments []string) (string, error) {
 		return "", err
 	}
 	return v.Value, nil
+}
+
+// resolvePackageModelPackage returns the OpenAPI model package for pkg.
+// When apiversion.yaml is present, spec.modelPackage is authoritative.
+// The +k8s:openapi-model-package tag is used only when the yaml file
+// is absent.
+func resolvePackageModelPackage(pkg *types.Package) (string, error) {
+	av, err := apidefinitions.LoadAPIVersion(pkg.Dir)
+	if err != nil {
+		return "", err
+	}
+	if av != nil {
+		return av.Spec.ModelPackage, nil
+	}
+	return extractOpenAPISchemaNamePackage(pkg.Comments)
 }
 
 func singularTag(tagName string, comments []string) (*gengo.Tag, error) {

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
 	openapi "k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/generators/apidefinitions"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	"k8s.io/klog/v2"
@@ -109,13 +110,31 @@ func apiTypeFilterFunc(c *generator.Context, t *types.Type) bool {
 		return false
 	}
 	pkg := c.Universe.Package(t.Name.Package)
-	if hasOpenAPITagValue(pkg.Comments, tagValueTrue) {
+	if isOpenAPIEnabledForPackage(pkg) {
 		return !hasOpenAPITagValue(t.CommentLines, tagValueFalse)
 	}
 	if hasOpenAPITagValue(t.CommentLines, tagValueTrue) {
 		return true
 	}
 	return false
+}
+
+// isOpenAPIEnabledForPackage reports whether openapi generation is
+// requested for pkg. apiversion.yaml is authoritative when present;
+// the legacy +k8s:openapi-gen=true tag is consulted only when the yaml
+// is absent.
+func isOpenAPIEnabledForPackage(pkg *types.Package) bool {
+	if pkg == nil {
+		return false
+	}
+	av, err := apidefinitions.LoadAPIVersion(pkg.Dir)
+	if err != nil {
+		klog.Fatalf("Package %v: %v", pkg.Path, err)
+	}
+	if av != nil {
+		return true
+	}
+	return hasOpenAPITagValue(pkg.Comments, tagValueTrue)
 }
 
 const (
@@ -321,8 +340,13 @@ func (g openAPITypeWriter) shouldUseOpenAPIModelName(t *types.Type) bool {
 	if value != "" {
 		return true
 	}
+	// Private types never get a generated OpenAPIModelName method
+	// (model_names-gen skips them), so we can't reference one here.
+	if namer.IsPrivateGoName(t.Name.Name) {
+		return false
+	}
 	pkg := g.context.Universe.Package(t.Name.Package)
-	value, err = extractOpenAPISchemaNamePackage(pkg.Comments)
+	value, err = resolvePackageModelPackage(pkg)
 	if err != nil {
 		klog.Fatalf("Package %v: invalid %s:%v", pkg, tagModelPackage, err)
 	}


### PR DESCRIPTION
This implements a declaration file for simplifying codegen management as described in https://github.com/kubernetes/enhancements/issues/5975

This improves openapi-gen to support groupversion.yaml files but still respect +k8s:openapi-gen if not yaml file is present.