### PR TITLE
Fix default annotation to match JSON property names

### DIFF
--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -138,7 +138,7 @@ func schema_test_integration_testdata_defaults_Defaulted(ref common.ReferenceCal
 					},
 					"Sub": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{"i": 5, "s": "foo"},
+							Default: map[string]interface{}{"I": 5, "S": "foo"},
 							Ref:     ref("k8s.io/kube-openapi/test/integration/testdata/defaults.SubStruct"),
 						},
 					},

--- a/test/integration/testdata/defaults/default.go
+++ b/test/integration/testdata/defaults/default.go
@@ -8,7 +8,7 @@ type Defaulted struct {
 	OtherField int
 	// +default=["foo", "bar"]
 	List []Item
-	// +default={"s": "foo", "i": 5}
+	// +default={"S": "foo", "I": 5}
 	Sub *SubStruct
 
 	OtherSub SubStruct

--- a/test/integration/testdata/golden.v2.json
+++ b/test/integration/testdata/golden.v2.json
@@ -798,8 +798,8 @@
      },
      "Sub": {
       "default": {
-       "i": 5,
-       "s": "foo"
+       "I": 5,
+       "S": "foo"
       },
       "$ref": "#/definitions/defaults.SubStruct"
      },

--- a/test/integration/testdata/golden.v3.json
+++ b/test/integration/testdata/golden.v3.json
@@ -740,8 +740,8 @@
       },
       "Sub": {
        "default": {
-        "i": 5,
-        "s": "foo"
+        "I": 5,
+        "S": "foo"
        },
        "allOf": [
         {


### PR DESCRIPTION
The `SubStruct` fields serialize as `"S"` and `"I"` in JSON (field name `S` has no json tag, field `I` has `json:"I,omitempty"`), but the `+default` annotation used lowercase `"s"` and `"i"`.

https://github.com/kubernetes/kube-openapi/blob/33341827b39275d2a7a7ad235525aa85430520c9/test/integration/testdata/defaults/default.go#L39
```
// +k8s:openapi-gen=true
type SubStruct struct {
	S string
	// +default=1
	I int `json:"I,omitempty"`
}
```

This caused the generated OpenAPI spec to advertise a default value with keys that don't correspond to the actual schema property names, producing an invalid default.

This PR updates the `+default` annotation to `{"S": "foo", "I": 5}` and regenerates the affected golden files.