### PR TITLE
Fix namedmodels --output-pkg path in integration test README

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -28,7 +28,7 @@ $ go run ../../cmd/openapi-gen/openapi-gen.go \
 
 $ go run ../../cmd/openapi-gen/openapi-gen.go \
   --output-dir pkg/generated/namedmodels \
-  --output-pkg generated \
+  --output-pkg generated/namedmodels \
   --output-file openapi_generated.go \
   --output-model-name-file zz_generated_model_name.go \
   --go-header-file ../../boilerplate/boilerplate.go.txt \


### PR DESCRIPTION
The `openapi-gen` command documented in the README used `--output-pkg generated` but the output directory is `pkg/generated/namedmodels`. This mismatch causes the generated package declaration to not match what the golden file expects.

This PR adds the `/namedmodels` suffix so the command reads `--output-pkg generated/namedmodels`, aligning the generated package name with the actual output location.