### PR TITLE
test/integration: make valuevalidation fields with incompatible const…

### DIFF
--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -1021,7 +1021,6 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"StringValue": {
 						SchemaProps: spec.SchemaProps{
-							Default:   "",
 							MinLength: ptr.To[int64](1),
 							MaxLength: ptr.To[int64](5),
 							Pattern:   "^a.*b$",
@@ -1031,7 +1030,6 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 					},
 					"NumberValue": {
 						SchemaProps: spec.SchemaProps{
-							Default:          0,
 							Minimum:          ptr.To[float64](1),
 							Maximum:          ptr.To[float64](5),
 							ExclusiveMinimum: true,
@@ -1088,7 +1086,7 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"StringValue", "NumberValue", "ArrayValue", "MapValue"},
+				Required: []string{"ArrayValue", "MapValue"},
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{

--- a/test/integration/testdata/golden.v2.json
+++ b/test/integration/testdata/golden.v2.json
@@ -1224,8 +1224,6 @@
     "maxProperties": 5,
     "minProperties": 1,
     "required": [
-     "StringValue",
-     "NumberValue",
      "ArrayValue",
      "MapValue"
     ],
@@ -1252,7 +1250,6 @@
      "NumberValue": {
       "type": "number",
       "format": "double",
-      "default": 0,
       "maximum": 5,
       "exclusiveMaximum": true,
       "minimum": 1,
@@ -1261,7 +1258,6 @@
      },
      "StringValue": {
       "type": "string",
-      "default": "",
       "maxLength": 5,
       "minLength": 1,
       "pattern": "^a.*b$"

--- a/test/integration/testdata/golden.v3.json
+++ b/test/integration/testdata/golden.v3.json
@@ -1186,8 +1186,6 @@
      "maxProperties": 5,
      "minProperties": 1,
      "required": [
-      "StringValue",
-      "NumberValue",
       "ArrayValue",
       "MapValue"
      ],
@@ -1214,7 +1212,6 @@
       "NumberValue": {
        "type": "number",
        "format": "double",
-       "default": 0,
        "maximum": 5,
        "exclusiveMaximum": true,
        "minimum": 1,
@@ -1223,7 +1220,6 @@
       },
       "StringValue": {
        "type": "string",
-       "default": "",
        "maxLength": 5,
        "minLength": 1,
        "pattern": "^a.*b$"

--- a/test/integration/testdata/valuevalidation/alpha.go
+++ b/test/integration/testdata/valuevalidation/alpha.go
@@ -18,14 +18,16 @@ type Foo struct {
 	// +k8s:validation:maxLength=5
 	// +k8s:validation:minLength=1
 	// +k8s:validation:pattern="^a.*b$"
-	StringValue string
+	// +optional
+	StringValue string `json:"StringValue,omitempty"`
 
 	// +k8s:validation:maximum=5.0
 	// +k8s:validation:minimum=1.0
 	// +k8s:validation:exclusiveMinimum=true
 	// +k8s:validation:exclusiveMaximum=true
 	// +k8s:validation:multipleOf=2.0
-	NumberValue float64
+	// +optional
+	NumberValue float64 `json:"NumberValue,omitempty"`
 
 	// +k8s:validation:maxItems=5
 	// +k8s:validation:minItems=1


### PR DESCRIPTION
`StringValue` and `NumberValue` in the valuevalidation test fixture have validation constraints (`minLength=1`, `exclusiveMinimum=true`) that their Go zero values (`""` and `0`) cannot satisfy. When these fields are required, the generated schema enforces defaults that immediately violate the constraints.

This PR marks them `// +optional` with `omitempty` JSON tags so the zero value is omitted rather than serialized into an invalid default.