### PR TITLE
Do not emit defaults for slice items or map value schemas

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -1148,9 +1148,6 @@ func (g openAPITypeWriter) generateMapProperty(t *types.Type) error {
 
 	g.Do("Type: []string{\"object\"},\n", nil)
 	g.Do("AdditionalProperties: &spec.SchemaOrBool{\nAllows: true,\nSchema: &spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
-	if err := g.generateDefault(t.Elem.CommentLines, t.Elem, false, t.Elem); err != nil {
-		return err
-	}
 	typeString, format := openapi.OpenAPITypeFormat(elemType.String())
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)
@@ -1185,9 +1182,6 @@ func (g openAPITypeWriter) generateSliceProperty(t *types.Type) error {
 	elemType := resolveAliasAndPtrType(t.Elem)
 	g.Do("Type: []string{\"array\"},\n", nil)
 	g.Do("Items: &spec.SchemaOrArray{\nSchema: &spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
-	if err := g.generateDefault(t.Elem.CommentLines, t.Elem, false, t.Elem); err != nil {
-		return err
-	}
 	typeString, format := openapi.OpenAPITypeFormat(elemType.String())
 	if typeString != "" {
 		g.generateSimpleProperty(typeString, format)

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -342,7 +342,6 @@ Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -364,7 +363,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -918,7 +916,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -987,7 +984,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: 0,
 Type: []string{"integer"},
 Format: "int32",
 },
@@ -1056,7 +1052,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: false,
 Type: []string{"boolean"},
 Format: "",
 },
@@ -1158,30 +1153,6 @@ func TestFailingDefaultEnforced(t *testing.T) {
 				}
 			}`,
 		expectedError: `failed to generate default in example.com/base/foo.Blah: Struct: invalid default value (map[string]interface {}{"foo":5}) for non-pointer/non-omitempty. If specified, must be: {}`,
-	}, {
-		definition: `
-			package foo
-
-			type Blah struct {
-				List []Item
-
-			}
-
-			// +default="foo"
-			type Item string`,
-		expectedError: `failed to generate slice property in example.com/base/foo.Blah: List: invalid default value ("foo") for non-pointer/non-omitempty. If specified, must be: ""`,
-	}, {
-		definition: `
-			package foo
-
-			type Blah struct {
-				Map map[string]Item
-
-			}
-
-			// +default="foo"
-			type Item string`,
-		expectedError: `failed to generate map property in example.com/base/foo.Blah: Map: invalid default value ("foo") for non-pointer/non-omitempty. If specified, must be: ""`,
 	}}
 
 	for i, test := range tests {
@@ -1589,7 +1560,6 @@ Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -1605,7 +1575,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -1672,7 +1641,6 @@ Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: 0,
 Type: []string{"integer"},
 Format: "int64",
 },
@@ -1750,7 +1718,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -1839,7 +1806,6 @@ Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -1862,7 +1828,6 @@ Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 },
@@ -2141,7 +2106,6 @@ Type: []string{"array"},
 Items: &spec.SchemaOrArray{
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 Enum: []interface{}{"a", "b"},
@@ -2157,7 +2121,6 @@ AdditionalProperties: &spec.SchemaOrBool{
 Allows: true,
 Schema: &spec.Schema{
 SchemaProps: spec.SchemaProps{
-Default: "",
 Type: []string{"string"},
 Format: "",
 Enum: []interface{}{"a", "b"},
@@ -2525,7 +2488,6 @@ func TestMarkerComments(t *testing.T) {
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{
 										SchemaProps: spec.SchemaProps{
-											Default: "",
 											Type:    []string{"string"},
 											Format:  "",
 										},
@@ -3104,7 +3066,6 @@ func TestNestedMarkers(t *testing.T) {
                                                                 Items: &spec.SchemaOrArray{
                                                                         Schema: &spec.Schema{
                                                                                 SchemaProps: spec.SchemaProps{
-                                                                                        Default: "",
                                                                                         Type:    []string{"string"},
                                                                                         Format:  "",
                                                                                 },
@@ -3137,7 +3098,6 @@ func TestNestedMarkers(t *testing.T) {
                                                                                         Items: &spec.SchemaOrArray{
                                                                                                 Schema: &spec.Schema{
                                                                                                  SchemaProps: spec.SchemaProps{
-                                                                                                 Default: "",
                                                                                                  Type:    []string{"string"},
                                                                                                  Format:  "",
                                                                                                  },

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -1176,6 +1176,59 @@ func TestFailingDefaultEnforced(t *testing.T) {
 	}
 }
 
+// TestSliceMapElementDefaultIgnored verifies that a +default annotation on a
+// type used as a slice item or map value is silently ignored: the generator
+// succeeds and produces a schema with no default on the items/value schema.
+func TestSliceMapElementDefaultIgnored(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition string
+	}{{
+		name: "slice element default ignored",
+		definition: `
+			package foo
+
+			// +k8s:openapi-gen=true
+			type Blah struct {
+				List []Item
+			}
+
+			// +default="foo"
+			type Item string`,
+	}, {
+		name: "map element default ignored",
+		definition: `
+			package foo
+
+			// +k8s:openapi-gen=true
+			type Blah struct {
+				Map map[string]Item
+			}
+
+			// +default="foo"
+			type Item string`,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			packagestest.TestAll(t, func(t *testing.T, x packagestest.Exporter) {
+				e := packagestest.Export(t, x, []packagestest.Module{{
+					Name: "example.com/base/foo",
+					Files: map[string]interface{}{
+						"foo.go": test.definition,
+					},
+				}})
+				defer e.Cleanup()
+
+				_, funcErr, _, _, _ := testOpenAPITypeWriter(t, e.Config)
+				if funcErr != nil {
+					t.Fatalf("Unexpected error: %v", funcErr)
+				}
+			})
+		})
+	}
+}
+
 func TestCustomDef(t *testing.T) {
 	inputFile := `
 		package foo

--- a/test/integration/pkg/generated/openapi_generated.go
+++ b/test/integration/pkg/generated/openapi_generated.go
@@ -128,9 +128,8 @@ func schema_test_integration_testdata_defaults_Defaulted(ref common.ReferenceCal
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -156,9 +155,8 @@ func schema_test_integration_testdata_defaults_Defaulted(ref common.ReferenceCal
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -417,9 +415,8 @@ func schema_test_integration_testdata_listtype_AtomicList(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -499,8 +496,7 @@ func schema_test_integration_testdata_listtype_MapList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/kube-openapi/test/integration/testdata/listtype.Item"),
+										Ref: ref("k8s.io/kube-openapi/test/integration/testdata/listtype.Item"),
 									},
 								},
 							},
@@ -532,9 +528,8 @@ func schema_test_integration_testdata_listtype_SetList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -559,9 +554,8 @@ func schema_test_integration_testdata_listtype_UntypedList(ref common.ReferenceC
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -592,9 +586,8 @@ func schema_test_integration_testdata_maptype_AtomicMap(ref common.ReferenceCall
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -625,9 +618,8 @@ func schema_test_integration_testdata_maptype_GranularMap(ref common.ReferenceCa
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -1048,9 +1040,8 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -1065,9 +1056,8 @@ func schema_test_integration_testdata_valuevalidation_Foo(ref common.ReferenceCa
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},

--- a/test/integration/testdata/golden.v2.json
+++ b/test/integration/testdata/golden.v2.json
@@ -773,8 +773,7 @@
        "bar"
       ],
       "items": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       }
      },
      "Map": {
@@ -783,8 +782,7 @@
        "foo": "bar"
       },
       "additionalProperties": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       }
      },
      "OtherField": {
@@ -939,8 +937,7 @@
      "Field": {
       "type": "array",
       "items": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       },
       "x-kubernetes-list-type": "atomic"
      }
@@ -987,7 +984,6 @@
      "Field": {
       "type": "array",
       "items": {
-       "default": {},
        "$ref": "#/definitions/listtype.Item"
       },
       "x-kubernetes-list-map-keys": [
@@ -1006,8 +1002,7 @@
      "Field": {
       "type": "array",
       "items": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       },
       "x-kubernetes-list-type": "set"
      }
@@ -1022,8 +1017,7 @@
      "KeyValue": {
       "type": "object",
       "additionalProperties": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       },
       "x-kubernetes-map-type": "atomic"
      }
@@ -1038,8 +1032,7 @@
      "KeyValue": {
       "type": "object",
       "additionalProperties": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       },
       "x-kubernetes-map-type": "granular"
      }
@@ -1234,8 +1227,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       }
      },
      "MapValue": {
@@ -1243,8 +1235,7 @@
       "maxProperties": 5,
       "minProperties": 1,
       "additionalProperties": {
-       "type": "string",
-       "default": ""
+       "type": "string"
       }
      },
      "NumberValue": {

--- a/test/integration/testdata/golden.v3.json
+++ b/test/integration/testdata/golden.v3.json
@@ -711,8 +711,7 @@
         "bar"
        ],
        "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        }
       },
       "Map": {
@@ -721,8 +720,7 @@
         "foo": "bar"
        },
        "additionalProperties": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        }
       },
       "OtherField": {
@@ -885,8 +883,7 @@
       "Field": {
        "type": "array",
        "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        },
        "x-kubernetes-list-type": "atomic"
       }
@@ -933,12 +930,7 @@
       "Field": {
        "type": "array",
        "items": {
-        "default": {},
-        "allOf": [
-         {
-          "$ref": "#/components/schemas/listtype.Item"
-         }
-        ]
+        "$ref": "#/components/schemas/listtype.Item"
        },
        "x-kubernetes-list-map-keys": [
         "port"
@@ -956,8 +948,7 @@
       "Field": {
        "type": "array",
        "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        },
        "x-kubernetes-list-type": "set"
       }
@@ -972,8 +963,7 @@
       "KeyValue": {
        "type": "object",
        "additionalProperties": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        },
        "x-kubernetes-map-type": "atomic"
       }
@@ -988,8 +978,7 @@
       "KeyValue": {
        "type": "object",
        "additionalProperties": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        },
        "x-kubernetes-map-type": "granular"
       }
@@ -1196,8 +1185,7 @@
        "minItems": 1,
        "uniqueItems": true,
        "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        }
       },
       "MapValue": {
@@ -1205,8 +1193,7 @@
        "maxProperties": 5,
        "minProperties": 1,
        "additionalProperties": {
-        "type": "string",
-        "default": ""
+        "type": "string"
        }
       },
       "NumberValue": {


### PR DESCRIPTION
Per JSON Schema, the `default` keyword means `"the value to assume if this property is absent."` Array items and map values are never absent in that sense, they are either explicitly provided or the entry does not exist.

Emitting `default` on these schemas is semantically meaningless and adds noise to the generated spec.

Started this at https://github.com/kubernetes/kube-openapi/pull/600#discussion_r3209661718

This PR removes the `generateDefault` calls from `generateSliceProperty` and `generateMapProperty` so defaults are only emitted at the object property level where they are meaningful.

This also significantly reduces the diff footprint when bumping kin-openapi in k/k, since the majority of generated changes were item-level defaults going from `{}` to populated zero values.