### PR TITLE
Add x-kubernetes-preserve-unknown-fields to runtime.RawExtension schema

### DIFF
--- a/pkg/generators/known_types.go
+++ b/pkg/generators/known_types.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"k8s.io/gengo/v2/types"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// PackageOverride patches the schema of types in a single Go package while
+// openapi-gen is constructing it.
+type PackageOverride func(t *types.Type, schema *spec.Schema)
+
+// KnownPackages overrides types in some packages that have semantics the
+// generator cannot infer from their Go shape (e.g. runtime.RawExtension should
+// carry x-kubernetes-preserve-unknown-fields: true).
+//
+// Author-provided values for the same key (e.g. via comment markers) are not overwritten.
+var KnownPackages = map[string]PackageOverride{
+	"k8s.io/apimachinery/pkg/runtime": func(t *types.Type, s *spec.Schema) {
+		switch t.Name.Name {
+		case "RawExtension":
+			if _, ok := s.Extensions["x-kubernetes-preserve-unknown-fields"]; !ok {
+				s.AddExtension("x-kubernetes-preserve-unknown-fields", true)
+			}
+		}
+	},
+}
+
+// applyKnownPackages runs any registered override for t against schema.
+func applyKnownPackages(t *types.Type, schema *spec.Schema) {
+	if override, ok := KnownPackages[t.Name.Package]; ok {
+		override(t, schema)
+	}
+}

--- a/pkg/generators/known_types_test.go
+++ b/pkg/generators/known_types_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages/packagestest"
+
+	"k8s.io/gengo/v2/types"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func TestKnownPackagesRawExtension(t *testing.T) {
+	rawExt := &types.Type{
+		Name: types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "RawExtension"},
+		Kind: types.Struct,
+	}
+
+	var s spec.Schema
+	applyKnownPackages(rawExt, &s)
+	if got := s.Extensions["x-kubernetes-preserve-unknown-fields"]; got != true {
+		t.Errorf("override did not set x-kubernetes-preserve-unknown-fields: got %#v, want true", got)
+	}
+
+	explicit := spec.Schema{VendorExtensible: spec.VendorExtensible{Extensions: spec.Extensions{
+		"x-kubernetes-preserve-unknown-fields": false,
+	}}}
+	applyKnownPackages(rawExt, &explicit)
+	if got := explicit.Extensions["x-kubernetes-preserve-unknown-fields"]; got != false {
+		t.Errorf("explicit value was overwritten: got %#v, want false", got)
+	}
+}
+
+func TestKnownPackagesGenerate(t *testing.T) {
+	const fixturePkg = "example.com/base/foo"
+	orig, hadOrig := KnownPackages[fixturePkg]
+	KnownPackages[fixturePkg] = func(typ *types.Type, s *spec.Schema) {
+		if typ.Name.Name == "Blah" {
+			s.AddExtension("x-kubernetes-preserve-unknown-fields", true)
+		}
+	}
+	defer func() {
+		if hadOrig {
+			KnownPackages[fixturePkg] = orig
+		} else {
+			delete(KnownPackages, fixturePkg)
+		}
+	}()
+
+	inputFile := `
+		package foo
+
+		type Blah struct {
+		}`
+
+	packagestest.TestAll(t, func(t *testing.T, x packagestest.Exporter) {
+		e := packagestest.Export(t, x, []packagestest.Module{{
+			Name: "example.com/base/foo",
+			Files: map[string]interface{}{
+				"foo.go": inputFile,
+			},
+		}})
+		defer e.Cleanup()
+
+		callErr, funcErr, _, funcBuffer, _ := testOpenAPITypeWriter(t, e.Config)
+		if callErr != nil {
+			t.Fatal(callErr)
+		}
+		if funcErr != nil {
+			t.Fatal(funcErr)
+		}
+		want := `"x-kubernetes-preserve-unknown-fields": true,`
+		if !strings.Contains(funcBuffer.String(), want) {
+			t.Errorf("missing %q in generated source:\n%s", want, funcBuffer.String())
+		}
+	})
+}

--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -604,6 +604,8 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			return nil
 		}
 
+		applyKnownPackages(t, validationSchema)
+
 		args := argsFromType(t)
 		g.Do("func "+nameTmpl+"(ref $.ReferenceCallback|raw$) $.OpenAPIDefinition|raw$ {\n", args)
 		switch {


### PR DESCRIPTION
The openapi-gen generator emits an empty `type: object` schema for any field typed as `runtime.RawExtension`. Some projects do static validation of resources (e.g. [KRO](https://kro.run)) and treat such fields as a closed empty object with no `properties` and no `additionalProperties`, so any nested keys are pruned/rejected.

This change adds a `KnownPackages` registry of schema overrides similar to what has been done in `controller-tools` for CRDs (`sigs.k8s.io/controller-tools/pkg/crd`) and registers an override for `runtime.RawExtension` that emits `x-kubernetes-preserve-unknown-fields: true` on the generated schema. Author-provided values for the same key win over any defined overrides.

This PR matches the behaviour of generated CRDs kubernetes-sigs/controller-tools#683 for aggregated API servers.

Generated openapi schema now would have `RawExtension` with the following structure:
```go
func schema_k8sio_apimachinery_pkg_runtime_RawExtension(ref common.ReferenceCallback) common.OpenAPIDefinition {
	return common.OpenAPIDefinition{
		Schema: spec.Schema{
			SchemaProps: spec.SchemaProps{
				Description: "RawExtension is used to hold extensions in external versions...",
				Type:        []string{"object"},
			},
			VendorExtensible: spec.VendorExtensible{
				Extensions: spec.Extensions{
					"x-kubernetes-preserve-unknown-fields": true,
				},
			},
		},
	}
}
```