### PR TITLE
set fail-fast to false in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
         go-version: ['1.24', '1.25', '1.26']
     runs-on: ubuntu-latest


### PR DESCRIPTION
If tests fail on one go version, they shouldn't fail tests for other versions because it's possible a failure is isolated to only one version.