### PR TITLE
Fix false-positive omitempty detection in JSON struct tags

### DIFF
--- a/pkg/generators/openapi.go
+++ b/pkg/generators/openapi.go
@@ -100,7 +100,7 @@ func isOptional(m *types.Member) (bool, error) {
 
 	// If neither +optional nor +required is present in the comments,
 	// infer optional from the json tags.
-	return strings.Contains(reflect.StructTag(m.Tags).Get("json"), "omitempty"), nil
+	return hasOmitemptyTag(m), nil
 }
 
 func apiTypeFilterFunc(c *generator.Context, t *types.Type) bool {
@@ -220,6 +220,11 @@ func getReferableName(m *types.Member) string {
 	} else {
 		return m.Name
 	}
+}
+
+func hasOmitemptyTag(m *types.Member) bool {
+	jsonTag, _ := reflect.StructTag(m.Tags).Lookup("json")
+	return strings.HasSuffix(jsonTag, ",omitempty") || strings.Contains(jsonTag, ",omitempty,")
 }
 
 func shouldInlineMembers(m *types.Member) bool {
@@ -1032,7 +1037,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type)
 		g.Do("},\n},\n", nil)
 		return nil
 	}
-	omitEmpty := strings.Contains(reflect.StructTag(m.Tags).Get("json"), "omitempty")
+	omitEmpty := hasOmitemptyTag(m)
 	if err := g.generateDefault(m.CommentLines, m.Type, omitEmpty, parent); err != nil {
 		return fmt.Errorf("failed to generate default in %v: %v: %v", parent, m.Name, err)
 	}

--- a/pkg/generators/openapi_test.go
+++ b/pkg/generators/openapi_test.go
@@ -3226,3 +3226,60 @@ func TestShouldInlineMembers(t *testing.T) {
 		})
 	}
 }
+
+func TestHasOmitemptyTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		member   types.Member
+		expected bool
+	}{
+		{
+			name:     "standard omitempty",
+			member:   types.Member{Tags: `json:"foo,omitempty"`},
+			expected: true,
+		},
+		{
+			name:     "omitempty with no name",
+			member:   types.Member{Tags: `json:",omitempty"`},
+			expected: true,
+		},
+		{
+			name:     "omitempty in the middle of options",
+			member:   types.Member{Tags: `json:"foo,omitempty,string"`},
+			expected: true,
+		},
+		{
+			name:     "no omitempty",
+			member:   types.Member{Tags: `json:"foo"`},
+			expected: false,
+		},
+		{
+			name:     "no json tag",
+			member:   types.Member{Tags: ``},
+			expected: false,
+		},
+		{
+			name:     "field name contains omitempty - should not match",
+			member:   types.Member{Tags: `json:"omitemptyTest"`},
+			expected: false,
+		},
+		{
+			name:     "field name ends with omitempty - should not match",
+			member:   types.Member{Tags: `json:"fooOmitempty"`},
+			expected: false,
+		},
+		{
+			name:     "field name is omitempty with no options - should not match",
+			member:   types.Member{Tags: `json:"omitempty"`},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasOmitemptyTag(&tc.member); got != tc.expected {
+				t.Errorf("hasOmitemptyTag(%+v) = %v, want %v", tc.member, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The existing `strings.Contains(tag, "omitempty")` checks match the substring anywhere in the JSON tag value, causing false positives for field names like `json:"omitemptyTest"` or `json:"fooOmitempty"`.

This PR introduces a `hasOmitemptyTag` helper that correctly identifies `omitempty` as a comma-delimited option.