### PR TITLE
third_party/go-json-experiment: skip aliases absent from target package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,28 @@ jobs:
     - name: Run verify scripts
       run: |
         ./hack/verify-go-directive.sh 1.24.0
+  ci-go-tip:
+    # Informational lane that exercises the vendored encoding/json/v2 shim
+    # against Go tip so upstream changes (e.g. graduating JSONv2 to baseline)
+    # surface here rather than in kubernetes/kubernetes CI.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+    - name: Set up Go stable
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
+      with:
+        go-version: 'stable'
+    - name: Install gotip
+      run: |
+        go install golang.org/dl/gotip@latest
+        gotip download
+    - name: Build with gotip (default GOEXPERIMENT)
+      run: |
+        gotip build ./cmd/... ./pkg/...
+    - name: Test with gotip (default GOEXPERIMENT)
+      run: |
+        gotip test -race ./cmd/... ./pkg/...
   required:
     # The name of the ci jobs above change based on the golang version.
     # Use this as a stable required job that depends on the above jobs.

--- a/pkg/internal/third_party/go-json-experiment/json/alias.go
+++ b/pkg/internal/third_party/go-json-experiment/json/alias.go
@@ -608,15 +608,6 @@ func UnmarshalDecode(in *jsontext.Decoder, out any, opts ...Options) (err error)
 	return json.UnmarshalDecode(in, out, opts...)
 }
 
-// SkipFunc may be returned by [MarshalToFunc] and [UnmarshalFromFunc] functions.
-//
-// Any function that returns SkipFunc must not cause observable side effects
-// on the provided [jsontext.Encoder] or [jsontext.Decoder].
-// For example, it is permissible to call [jsontext.Decoder.PeekKind],
-// but not permissible to call [jsontext.Decoder.ReadToken] or
-// [jsontext.Encoder.WriteToken] since such methods mutate the state.
-var SkipFunc = json.SkipFunc
-
 // Marshalers is a list of functions that may override the marshal behavior
 // of specific types. Populate [WithMarshalers] to use it with
 // [Marshal], [MarshalWrite], or [MarshalEncode].
@@ -946,15 +937,6 @@ func OmitZeroStructFields(v bool) Options {
 // if it matches one of the declared fields in the Go struct.
 func MatchCaseInsensitiveNames(v bool) Options {
 	return json.MatchCaseInsensitiveNames(v)
-}
-
-// DiscardUnknownMembers specifies that marshaling should ignore any
-// JSON object members stored in Go struct fields dedicated to storing
-// unknown JSON object members.
-//
-// This only affects marshaling and is ignored when unmarshaling.
-func DiscardUnknownMembers(v bool) Options {
-	return json.DiscardUnknownMembers(v)
 }
 
 // RejectUnknownMembers specifies that unknown members should be rejected


### PR DESCRIPTION
The alias generator forwarded every exported declaration from the vendored go-json-experiment shim to the target stdlib package (encoding/json/v2). When stdlib v2 dropped symbols that still exist in the pinned upstream snapshot - SkipFunc and DiscardUnknownMembers after JSONv2 graduated to baseline in golang/go@e62d3e6e - the generated alias.go referenced undefined symbols and broke every consumer transitively importing kube-openapi.

- https://github.com/go-json-experiment/json/pull/201
- https://github.com/go-json-experiment/json/pull/203 

Teach alias_gen.go to load the target package's exported top-level declarations via go/build and go/parser, and emit aliases only for names present there. The check is applied to const, var, type, and non-method function declarations.

Regenerate alias.go for encoding/json/v2; SkipFunc and DiscardUnknownMembers are dropped. Builds clean under both GOEXPERIMENT=jsonv2 and GOEXPERIMENT=nojsonv2.