### PR TITLE
validation: anchor duration regex to reject invalid tokens

### DIFF
--- a/pkg/validation/strfmt/duration.go
+++ b/pkg/validation/strfmt/duration.go
@@ -52,7 +52,8 @@ var (
 		"w":  7 * 24 * time.Hour,
 	}
 
-	durationMatcher = regexp.MustCompile(`((\d+)\s*([A-Za-zµ]+))`)
+	durationValidator = regexp.MustCompile(`^\s*(?:\d+\s*[A-Za-zµ]+\s*)+$`)
+	durationMatcher   = regexp.MustCompile(`((\d+)\s*([A-Za-zµ]+))`)
 )
 
 // IsDuration returns true if the provided string is a valid duration
@@ -88,6 +89,10 @@ func (d *Duration) UnmarshalText(data []byte) error { // validation is performed
 func ParseDuration(cand string) (time.Duration, error) {
 	if dur, err := time.ParseDuration(cand); err == nil {
 		return dur, nil
+	}
+
+	if !durationValidator.MatchString(cand) {
+		return 0, fmt.Errorf("unable to parse %s as duration", cand)
 	}
 
 	var dur time.Duration

--- a/pkg/validation/strfmt/duration_test.go
+++ b/pkg/validation/strfmt/duration_test.go
@@ -80,6 +80,24 @@ func TestIsDuration_Failed(t *testing.T) {
 	assert.False(t, e)
 }
 
+func TestDurationInvalidToken(t *testing.T) {
+	badDurations := []string{
+		"1s invalid",
+		"invalid 1s",
+		"1s   invalid",
+		"invalid   1s",
+		"1s 2m invalid",
+		"1s invalid 2m",
+	}
+	for _, d := range badDurations {
+		t.Run(d, func(t *testing.T) {
+			assert.False(t, IsDuration(d), "Expected IsDuration(%q) to be false", d)
+			_, err := ParseDuration(d)
+			assert.Error(t, err, "Expected ParseDuration(%q) to return an error", d)
+		})
+	}
+}
+
 func TestDurationParser(t *testing.T) {
 	testcases := map[string]time.Duration{
 
@@ -138,6 +156,14 @@ func TestDurationParser(t *testing.T) {
 		"1  hour":         1 * time.Hour,
 		"1  day":          24 * time.Hour,
 		"1  week":         7 * 24 * time.Hour,
+
+		// parse composite durations, without spaces
+		"1w2s":     7*24*time.Hour + 2*time.Second,
+		"1d2h3m5s": 24*time.Hour + 2*time.Hour + 3*time.Minute + 5*time.Second,
+
+		// parse composite durations, with spaces
+		"1s 2m":       2*time.Minute + 1*time.Second,
+		"1w 2d 3h 4m": 7*24*time.Hour + 2*24*time.Hour + 3*time.Hour + 4*time.Minute,
 	}
 
 	for str, dur := range testcases {


### PR DESCRIPTION
I anchored the duration validation regex to ensure the entire string is validated.

Previously, the durationMatcher regex was unanchored. This allowed ParseDuration to match valid duration substrings embedded within invalid strings, ignoring the invalid text. For example, "1s invalid" would successfully validate and return a duration of 1s.

To fix this, I introduced a two-step validation:

1. Check the candidate string against durationValidator, an anchored regex that ensures the input consists only of valid duration components.
2. Sum the components using durationMatcher.

This allows composite durations like "1w2s" or "1w 2d 3h 4m" to be parsed while rejecting inputs with invalid tokens. I added positive and negative test cases to cover expected behavior.