### PR TITLE
Use AllowMultiple as signal for array query parameters

### DIFF
--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -448,32 +448,34 @@ func (o *openAPI) buildParameter(restParam common.Parameter, bodySample interfac
 		return ret, fmt.Errorf("unknown restful operation kind : %v", restParam.Kind())
 	}
 	dataType := restParam.DataType()
-	var openAPIType, openAPIFormat string
-	openAPIType, openAPIFormat = common.OpenAPITypeFormat(dataType)
-	if openAPIType == "" && strings.HasPrefix(dataType, "[]") {
-		// Array type: element type is encoded as "[]string" or "[]integer"
-		itemsType := dataType[2:]
-		itemsAPIType, itemsAPIFormat := common.OpenAPITypeFormat(itemsType)
-		if itemsAPIType == "" {
-			return ret, fmt.Errorf("non-body Restful parameter array element type should be a simple type, but got: %v", itemsType)
-		}
-		openAPIType = "array"
-		openAPIFormat = ""
+
+	// AllowMultiple indicates an array parameter. The element type is
+	// derived by stripping the "[]" prefix from DataType.
+	elementType := dataType
+	if restParam.AllowMultiple() {
+		elementType = strings.TrimPrefix(dataType, "[]")
+	}
+
+	openAPIType, openAPIFormat := common.OpenAPITypeFormat(elementType)
+	if openAPIType == "" {
+		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got: %v", dataType)
+	}
+
+	if restParam.AllowMultiple() {
+		ret.Type = "array"
+		ret.Format = ""
+		ret.CollectionFormat = "multi"
 		ret.Items = &spec.Items{
 			SimpleSchema: spec.SimpleSchema{
-				Type:   itemsAPIType,
-				Format: itemsAPIFormat,
+				Type:   openAPIType,
+				Format: openAPIFormat,
 			},
 		}
-	} else if openAPIType == "" {
-		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
+	} else {
+		ret.Type = openAPIType
+		ret.Format = openAPIFormat
 	}
-	ret.Type = openAPIType
-	ret.Format = openAPIFormat
 	ret.UniqueItems = !restParam.AllowMultiple()
-	if openAPIType == "array" && restParam.AllowMultiple() {
-		ret.CollectionFormat = "multi"
-	}
 	return ret, nil
 }
 

--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -447,9 +447,28 @@ func (o *openAPI) buildParameter(restParam common.Parameter, bodySample interfac
 	default:
 		return ret, fmt.Errorf("unknown restful operation kind : %v", restParam.Kind())
 	}
-	openAPIType, openAPIFormat := common.OpenAPITypeFormat(restParam.DataType())
-	if openAPIType == "" {
-		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", restParam.DataType())
+	dataType := restParam.DataType()
+	var openAPIType, openAPIFormat, itemsType string
+	if strings.HasPrefix(dataType, "[]") {
+		// Array type: element type is encoded as "[]string" or "[]integer"
+		itemsType = dataType[2:]
+		itemsAPIType, itemsAPIFormat := common.OpenAPITypeFormat(itemsType)
+		if itemsAPIType == "" {
+			return ret, fmt.Errorf("non-body Restful parameter array element type should be a simple type, but got: %v", itemsType)
+		}
+		openAPIType = "array"
+		openAPIFormat = ""
+		ret.Items = &spec.Items{
+			SimpleSchema: spec.SimpleSchema{
+				Type:   itemsAPIType,
+				Format: itemsAPIFormat,
+			},
+		}
+	} else {
+		openAPIType, openAPIFormat = common.OpenAPITypeFormat(dataType)
+		if openAPIType == "" {
+			return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
+		}
 	}
 	ret.Type = openAPIType
 	ret.Format = openAPIFormat

--- a/pkg/builder/openapi.go
+++ b/pkg/builder/openapi.go
@@ -448,10 +448,11 @@ func (o *openAPI) buildParameter(restParam common.Parameter, bodySample interfac
 		return ret, fmt.Errorf("unknown restful operation kind : %v", restParam.Kind())
 	}
 	dataType := restParam.DataType()
-	var openAPIType, openAPIFormat, itemsType string
-	if strings.HasPrefix(dataType, "[]") {
+	var openAPIType, openAPIFormat string
+	openAPIType, openAPIFormat = common.OpenAPITypeFormat(dataType)
+	if openAPIType == "" && strings.HasPrefix(dataType, "[]") {
 		// Array type: element type is encoded as "[]string" or "[]integer"
-		itemsType = dataType[2:]
+		itemsType := dataType[2:]
 		itemsAPIType, itemsAPIFormat := common.OpenAPITypeFormat(itemsType)
 		if itemsAPIType == "" {
 			return ret, fmt.Errorf("non-body Restful parameter array element type should be a simple type, but got: %v", itemsType)
@@ -464,15 +465,15 @@ func (o *openAPI) buildParameter(restParam common.Parameter, bodySample interfac
 				Format: itemsAPIFormat,
 			},
 		}
-	} else {
-		openAPIType, openAPIFormat = common.OpenAPITypeFormat(dataType)
-		if openAPIType == "" {
-			return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
-		}
+	} else if openAPIType == "" {
+		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
 	}
 	ret.Type = openAPIType
 	ret.Format = openAPIFormat
 	ret.UniqueItems = !restParam.AllowMultiple()
+	if openAPIType == "array" && restParam.AllowMultiple() {
+		ret.CollectionFormat = "multi"
+	}
 	return ret, nil
 }
 

--- a/pkg/builder/openapi_test.go
+++ b/pkg/builder/openapi_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	openapi "k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/common/restfuladapter"
 	"k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 )
@@ -650,6 +651,76 @@ func TestEscapeJsonPointerInDefinitionName(t *testing.T) {
 				_, exists = definitions.Definitions[tc.shouldNotExist]
 				assert.False(exists, "Definition should not exist with unescaped name: %s", tc.shouldNotExist)
 			}
+		})
+	}
+}
+
+func TestBuildParameter(t *testing.T) {
+	o := &openAPI{}
+
+	// buildParameter receives *restfuladapter.ParamAdapter at runtime.
+	newParam := func(dt string, allowMultiple bool) openapi.Parameter {
+		return &restfuladapter.ParamAdapter{
+			Param: restful.QueryParameter("p", "").DataType(dt).AllowMultiple(allowMultiple),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		param       openapi.Parameter
+		wantType    string
+		wantFormat  string
+		wantItems   bool
+		wantErr     bool
+	}{
+		{
+			name:     "scalar string",
+			param:    newParam("string", false),
+			wantType: "string",
+		},
+		{
+			name:       "scalar []byte stays scalar",
+			param:      newParam("[]byte", false),
+			wantType:   "string",
+			wantFormat: "byte",
+		},
+		{
+			name:      "AllowMultiple=true emits array",
+			param:     newParam("[]string", true),
+			wantType:  "array",
+			wantItems: true,
+		},
+		{
+			name:      "AllowMultiple=true with plain DataType emits array",
+			param:     newParam("string", true),
+			wantType:  "array",
+			wantItems: true,
+		},
+		{
+			name:    "[]string without AllowMultiple is a misconfiguration — errors intentionally",
+			param:   newParam("[]string", false),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := o.buildParameter(tt.param, nil)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantType, got.Type)
+			assert.Equal(t, tt.wantFormat, got.Format)
+			if tt.wantItems {
+				assert.NotNil(t, got.Items)
+				assert.Equal(t, "multi", got.CollectionFormat)
+			} else {
+				assert.Nil(t, got.Items)
+				assert.Empty(t, got.CollectionFormat)
+			}
+			assert.True(t, got.UniqueItems != tt.param.AllowMultiple())
 		})
 	}
 }

--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -419,16 +419,41 @@ func (o *openAPI) buildParameter(restParam common.Parameter) (ret *spec3.Paramet
 	default:
 		return ret, fmt.Errorf("unsupported restful parameter kind : %v", restParam.Kind())
 	}
-	openAPIType, openAPIFormat := common.OpenAPITypeFormat(restParam.DataType())
-	if openAPIType == "" {
-		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", restParam.DataType())
+	dataType := restParam.DataType()
+	var schemaType string
+	var schemaFormat string
+	var itemsSchema *spec.SchemaOrArray
+
+	if strings.HasPrefix(dataType, "[]") {
+		// Array type: element type is encoded as "[]string" or "[]integer"
+		itemsType := dataType[2:]
+		itemsAPIType, itemsAPIFormat := common.OpenAPITypeFormat(itemsType)
+		if itemsAPIType == "" {
+			return ret, fmt.Errorf("non-body Restful parameter array element type should be a simple type, but got: %v", itemsType)
+		}
+		schemaType = "array"
+		schemaFormat = ""
+		itemsSchema = &spec.SchemaOrArray{
+			Schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type:   []string{itemsAPIType},
+					Format: itemsAPIFormat,
+				},
+			},
+		}
+	} else {
+		schemaType, schemaFormat = common.OpenAPITypeFormat(dataType)
+		if schemaType == "" {
+			return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
+		}
 	}
 
 	ret.Schema = &spec.Schema{
 		SchemaProps: spec.SchemaProps{
-			Type:        []string{openAPIType},
-			Format:      openAPIFormat,
+			Type:        []string{schemaType},
+			Format:      schemaFormat,
 			UniqueItems: !restParam.AllowMultiple(),
+			Items:       itemsSchema,
 		},
 	}
 	return ret, nil

--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -424,7 +424,8 @@ func (o *openAPI) buildParameter(restParam common.Parameter) (ret *spec3.Paramet
 	var schemaFormat string
 	var itemsSchema *spec.SchemaOrArray
 
-	if strings.HasPrefix(dataType, "[]") {
+	schemaType, schemaFormat = common.OpenAPITypeFormat(dataType)
+	if schemaType == "" && strings.HasPrefix(dataType, "[]") {
 		// Array type: element type is encoded as "[]string" or "[]integer"
 		itemsType := dataType[2:]
 		itemsAPIType, itemsAPIFormat := common.OpenAPITypeFormat(itemsType)
@@ -441,11 +442,8 @@ func (o *openAPI) buildParameter(restParam common.Parameter) (ret *spec3.Paramet
 				},
 			},
 		}
-	} else {
-		schemaType, schemaFormat = common.OpenAPITypeFormat(dataType)
-		if schemaType == "" {
-			return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
-		}
+	} else if schemaType == "" {
+		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
 	}
 
 	ret.Schema = &spec.Schema{
@@ -455,6 +453,10 @@ func (o *openAPI) buildParameter(restParam common.Parameter) (ret *spec3.Paramet
 			UniqueItems: !restParam.AllowMultiple(),
 			Items:       itemsSchema,
 		},
+	}
+	if schemaType == "array" && restParam.AllowMultiple() {
+		ret.Style = "form"
+		ret.Explode = true
 	}
 	return ret, nil
 }

--- a/pkg/builder3/openapi.go
+++ b/pkg/builder3/openapi.go
@@ -420,43 +420,44 @@ func (o *openAPI) buildParameter(restParam common.Parameter) (ret *spec3.Paramet
 		return ret, fmt.Errorf("unsupported restful parameter kind : %v", restParam.Kind())
 	}
 	dataType := restParam.DataType()
-	var schemaType string
-	var schemaFormat string
-	var itemsSchema *spec.SchemaOrArray
 
-	schemaType, schemaFormat = common.OpenAPITypeFormat(dataType)
-	if schemaType == "" && strings.HasPrefix(dataType, "[]") {
-		// Array type: element type is encoded as "[]string" or "[]integer"
-		itemsType := dataType[2:]
-		itemsAPIType, itemsAPIFormat := common.OpenAPITypeFormat(itemsType)
-		if itemsAPIType == "" {
-			return ret, fmt.Errorf("non-body Restful parameter array element type should be a simple type, but got: %v", itemsType)
-		}
-		schemaType = "array"
-		schemaFormat = ""
-		itemsSchema = &spec.SchemaOrArray{
-			Schema: &spec.Schema{
-				SchemaProps: spec.SchemaProps{
-					Type:   []string{itemsAPIType},
-					Format: itemsAPIFormat,
+	// AllowMultiple indicates an array parameter. The element type is
+	// derived by stripping the "[]" prefix from DataType.
+	elementType := dataType
+	if restParam.AllowMultiple() {
+		elementType = strings.TrimPrefix(dataType, "[]")
+	}
+
+	elementAPIType, elementAPIFormat := common.OpenAPITypeFormat(elementType)
+	if elementAPIType == "" {
+		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got: %v", dataType)
+	}
+
+	if restParam.AllowMultiple() {
+		ret.Style = "form"
+		ret.Explode = true
+		ret.Schema = &spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:        []string{"array"},
+				UniqueItems: false,
+				Items: &spec.SchemaOrArray{
+					Schema: &spec.Schema{
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{elementAPIType},
+							Format: elementAPIFormat,
+						},
+					},
 				},
 			},
 		}
-	} else if schemaType == "" {
-		return ret, fmt.Errorf("non-body Restful parameter type should be a simple type, but got : %v", dataType)
-	}
-
-	ret.Schema = &spec.Schema{
-		SchemaProps: spec.SchemaProps{
-			Type:        []string{schemaType},
-			Format:      schemaFormat,
-			UniqueItems: !restParam.AllowMultiple(),
-			Items:       itemsSchema,
-		},
-	}
-	if schemaType == "array" && restParam.AllowMultiple() {
-		ret.Style = "form"
-		ret.Explode = true
+	} else {
+		ret.Schema = &spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:        []string{elementAPIType},
+				Format:      elementAPIFormat,
+				UniqueItems: true,
+			},
+		}
 	}
 	return ret, nil
 }

--- a/pkg/builder3/openapi_test.go
+++ b/pkg/builder3/openapi_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	openapi "k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/common/restfuladapter"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/util/jsontesting"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -577,6 +578,87 @@ func TestEscapeJsonPointerInSchemaName(t *testing.T) {
 			if tc.shouldNotExist != "" {
 				_, exists = schemas[tc.shouldNotExist]
 				assert.False(exists, "Schema should not exist with unescaped name: %s", tc.shouldNotExist)
+			}
+		})
+	}
+}
+
+func TestBuildParameter(t *testing.T) {
+	o := &openAPI{}
+
+	// buildParameter receives *restfuladapter.ParamAdapter at runtime.
+	newParam := func(dt string, allowMultiple bool) openapi.Parameter {
+		return &restfuladapter.ParamAdapter{
+			Param: restful.QueryParameter("p", "").DataType(dt).AllowMultiple(allowMultiple),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		param       openapi.Parameter
+		wantType    string
+		wantFormat  string
+		wantItems   bool
+		wantStyle   string
+		wantExplode bool
+		wantErr     bool
+	}{
+		{
+			name:     "scalar string",
+			param:    newParam("string", false),
+			wantType: "string",
+		},
+		{
+			name:       "scalar []byte stays scalar",
+			param:      newParam("[]byte", false),
+			wantType:   "string",
+			wantFormat: "byte",
+		},
+		{
+			name:        "AllowMultiple=true emits array",
+			param:       newParam("[]string", true),
+			wantType:    "array",
+			wantItems:   true,
+			wantStyle:   "form",
+			wantExplode: true,
+		},
+		{
+			name:        "AllowMultiple=true with plain DataType emits array",
+			param:       newParam("string", true),
+			wantType:    "array",
+			wantItems:   true,
+			wantStyle:   "form",
+			wantExplode: true,
+		},
+		{
+			name:    "[]string without AllowMultiple is a misconfiguration — errors intentionally",
+			param:   newParam("[]string", false),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := o.buildParameter(tt.param)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, got.Schema, "schema should not be nil")
+			assert.Equal(t, spec.StringOrArray{tt.wantType}, got.Schema.Type)
+			assert.Equal(t, tt.wantFormat, got.Schema.Format)
+			assert.True(t, got.Schema.UniqueItems != tt.param.AllowMultiple())
+			if tt.wantItems {
+				assert.NotNil(t, got.Schema.Items, "items should not be nil")
+				assert.NotNil(t, got.Schema.Items.Schema, "items schema should not be nil")
+				assert.Equal(t, spec.StringOrArray{"string"}, got.Schema.Items.Schema.Type)
+				assert.Equal(t, tt.wantStyle, got.Style)
+				assert.Equal(t, tt.wantExplode, got.Explode)
+			} else {
+				assert.Nil(t, got.Schema.Items)
+				assert.Empty(t, got.Style)
+				assert.False(t, got.Explode)
 			}
 		})
 	}


### PR DESCRIPTION
Use `AllowMultiple()` as the signal for emitting `type: array` in OpenAPI schemas instead of detecting a `[]` prefix on DataType. When `AllowMultiple()` is true, the `[]` prefix is only stripped to derive the element type.

Changes:
- `pkg/builder/openapi.go` (v2): array detection via `AllowMultiple()`, `CollectionFormat: "multi"` always set for array params
- `pkg/builder3/openapi.go` (v3): same, with `Style: "form"` + `Explode: true` for array params
- `[]byte` stays scalar naturally through `OpenAPITypeFormat`: no special guard needed
- `[]string` without `AllowMultiple` intentionally errors as a misconfiguration
- Tests: table-driven, uses `restfuladapter.ParamAdapter` (same adapter as runtime)

### Relationship to kubernetes/kubernetes#140050

This PR is a **necessary precondition** for fixing that issue, but does not close it alone. The Kubernetes apiserver's `typeToJSON` function (`staging/src/k8s.io/apiserver/pkg/endpoints/installer.go`) explicitly strips `[]string` → `"string"` and `[]int32` → `"integer"` with a TODO referencing the go-restful limitation this PR addresses. A companion PR to remove those cases from `typeToJSON` is needed to fully resolve the issue.

Refs: kubernetes/kubernetes#140050