### PR TITLE
aggregator: guard nil Extensions map when merging GVKs

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -323,7 +323,11 @@ PARAMETERLOOP:
 		} else if merged, changed, err := mergedGVKs(&existing, &v); err != nil {
 			return err
 		} else if changed {
+			if existing.Extensions == nil {
+				existing.Extensions = make(spec.Extensions)
+			}
 			existing.Extensions[gvkKey] = merged
+			dest.Definitions[k] = existing
 		}
 	}
 

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -2507,3 +2507,118 @@ func TestDeepEqualDefinitionsModuloGVKs(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeSpecsGVKIntoNilExtensions(t *testing.T) {
+	// The destination definition has no vendor extensions, so its Extensions
+	// map is nil. The source carries the same definition plus a
+	// x-kubernetes-group-version-kind extension, so mergedGVKs reports a
+	// change and the merge writes the gvk into the destination. This must not
+	// panic on the nil map.
+	var destSpec, sourceSpec, expected *spec.Swagger
+	if err := yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /foo:
+    post:
+      operationId: "fooTest"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Foo"
+      responses:
+        200:
+          description: "OK"
+definitions:
+  Foo:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+`), &destSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /bar:
+    post:
+      operationId: "barTest"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Foo"
+      responses:
+        200:
+          description: "OK"
+definitions:
+  Foo:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+    x-kubernetes-group-version-kind:
+    - group: group1
+      version: v1
+      kind: Foo
+`), &sourceSpec); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := yaml.Unmarshal([]byte(`
+swagger: "2.0"
+paths:
+  /foo:
+    post:
+      operationId: "fooTest"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Foo"
+      responses:
+        200:
+          description: "OK"
+  /bar:
+    post:
+      operationId: "barTest"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Foo"
+      responses:
+        200:
+          description: "OK"
+definitions:
+  Foo:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+    x-kubernetes-group-version-kind:
+    - group: group1
+      version: v1
+      kind: Foo
+`), &expected); err != nil {
+		t.Fatal(err)
+	}
+
+	ast := assert.New(t)
+	if destSpec.Definitions["Foo"].Extensions != nil {
+		t.Fatalf("test setup: expected nil Extensions on destination definition")
+	}
+	if !ast.NoError(MergeSpecs(destSpec, sourceSpec)) {
+		return
+	}
+	ast.Equal(DebugSpec{expected}, DebugSpec{destSpec})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`MergeSpecs` panics with `assignment to entry in nil map` when it merges group-version-kind extensions into a destination definition that has no vendor extensions.

In the definition copy loop in `pkg/aggregator/aggregator.go`, when a definition already exists in the destination, `mergedGVKs` can report `changed == true` if the source carries a `x-kubernetes-group-version-kind` extension that the destination lacks. The code then does `existing.Extensions[gvkKey] = merged`. If the destination definition has no extensions at all, its `Extensions` map is nil and that write panics.

The sibling branch a few lines up (the one that copies a brand new definition) already guards its destination map before writing, `if dest.Definitions == nil { dest.Definitions = make(...) }`. This change applies the same pattern to the GVK merge branch: initialize `Extensions` when it is nil, then store the updated definition back into `dest.Definitions` since `existing` is a copy.

This is a defensive nil-map guard, not a security fix. The realistic trigger is an aggregated apiserver whose OpenAPI spec lacks GVK extensions on a shared definition, which the control plane already treats as trusted, so there is no security impact here.

#### Verification

Added `TestMergeSpecsGVKIntoNilExtensions`, which merges a definition that has a nil `Extensions` map against a source definition carrying a gvk extension.

Before the fix (guard reverted), the new test panics:

```
--- FAIL: TestMergeSpecsGVKIntoNilExtensions (0.00s)
panic: assignment to entry in nil map [recovered, repanicked]
	pkg/aggregator/aggregator.go:326
```

After the fix:

```
--- PASS: TestMergeSpecsGVKIntoNilExtensions (0.00s)
ok  	k8s.io/kube-openapi/pkg/aggregator
```

`go build ./...` and `go test ./pkg/aggregator/...` both pass.

#### Which issue(s) this PR fixes

None filed. Found while reading the aggregation merge path.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a panic in the OpenAPI aggregator when merging group-version-kind extensions into a definition that has no vendor extensions.
```
