### PR TITLE
Rename project from Kube OpenAPI to Kube CloseAPI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kube OpenAPI
+# Kube CloseAPI
 
 This repo is the home for Kubernetes OpenAPI discovery spec generation. The goal 
 is to support a subset of OpenAPI features to satisfy kubernetes use-cases but 


### PR DESCRIPTION
Renamed project from Kube OpenAPI to Kube CloseAPI.